### PR TITLE
Add MC68881 plan, VHDL ALU/top scaffolding, and testbenches for add/sub/mul/div

### DIFF
--- a/docs/mc68881_plan_checklist.txt
+++ b/docs/mc68881_plan_checklist.txt
@@ -1,0 +1,80 @@
+MC68881 VHDL-2008 Implementation Plan (Checklist)
+=================================================
+
+Scope: Full 80-bit extended-precision MC68881-compatible FPU for M68000 bus.
+Target: Xilinx Artix-7 (100T/200T), DSP-pipelined datapath, cycle counts per datasheet.
+
+Sources (Codex Export Bundle):
+- Table 11 (Signal Summary): table11_signal_summary.csv
+- Table 10 (DSACK assertions): table10_dsack_assertions.csv
+- AC Timing Read/Write: ac_timing_read_write_cycles.csv + ac_timing_notes.json
+- Instruction cycle counts: table4_arithmetic.csv + table4_notes.json
+- Effective address cycles: table3_effective_address.csv
+- FMOVE/FMOVEM timing: table5_fmove_fmovem.csv + table5_notes.json
+- Conditional timing: table6_conditional.csv + table6_notes.json
+- FSAVE/FRESTORE timing: table7_fsave_frestore.csv + table7_notes.json
+
+Legend:
+[ ] Not started
+[~] In progress
+[x] Done
+
+A) External Interface (Signals + Bus Timing)
+-------------------------------------------
+[~] A1. Implement MC68881 external signal set:
+    - A0-A4, D0-D31, SIZE, AS, CS, R/W, DS, DSACK0/DSACK1, RESET, CLK, SENSE.
+    - Direction/active state per Table 11.
+
+[~] A2. Implement DSACK behavior per Table 10:
+    - 32-bit A4=1 => DSACK1=0, DSACK0=0 (D31-D0)
+    - 32-bit A4=0 => DSACK1=0, DSACK0=1 (D31-D16)
+    - 16-bit => DSACK1=0, DSACK0=1
+    - 8-bit => DSACK1=1, DSACK0=0
+    - Wait states => DSACK1=1, DSACK0=1
+
+[ ] A3. Apply AC timing constraints for read/write cycles:
+    - Address to AS/DS, CS to DS, DS width, data valid, DSACK timing.
+    - Implement synchronous read cycles only for save/response CIR reads.
+    - START = CS + AS + (R/W · DS).
+
+B) Instruction Cycle Accounting
+-------------------------------
+[~] B1. Base arithmetic cycles (Table 4):
+    - FADD/FSUB: 51 (FPM reg), 72-80 (mem single/integer), 76-78 (mem ext/dbl), 888 (packed)
+    - FMUL: 71 (FPM reg), 92-100 (mem single/int), 96-98 (mem ext/dbl), 908 (packed)
+    - FDIV: 103 (FPM reg), 124-132 (mem single/int), 128-130 (mem ext/dbl), 940 (packed)
+
+[ ] B2. Add EA cycles per Table 3:
+    - Example: (An) +0..2, (An)+ +3..6, (d16,An) +0..3, (xxx).L +1..5, etc.
+
+[ ] B3. Apply Table 4 notes:
+    - Add EA time.
+    - Adjust for MC68020 data register source/dest.
+    - Packed decimal K-factor +14 when dynamic.
+
+C) Core Microarchitecture
+-------------------------
+[~] C1. Top-level entity (mc68881_top) with bus and internal core.
+[~] C2. Bus interface: decode access class (CIR/operand/FPCR/FPSR/etc), manage DSACK.
+[ ] C3. Microsequencer: enforce total cycle count = base op + EA (+ adjustments).
+[ ] C4. State frames: FSAVE/FRESTORE behavior and timing.
+
+D) Arithmetic Datapath (Start: ADD/SUB/MUL/DIV)
+-----------------------------------------------
+[~] D1. 80-bit internal operand format + pack/unpack scaffolding.
+[~] D2. ADD/SUB pipeline (alignment, add/sub, normalize, round) using DSP slices.
+[~] D3. MUL pipeline using DSP cascade partial products.
+[~] D4. DIV pipeline (restoring/SRT) with cycle-count gating.
+[ ] D5. IEEE exception flags and FPSR update.
+
+E) Verification / Testbench Coverage
+------------------------------------
+[~] E1. Unit tests for add/sub/mul/div datapath (behavioral reference vs DUT).
+[ ] E2. Bus interface tests: DSACK sequencing, wait-states, START logic.
+[ ] E3. Cycle-count checks for FADD/FSUB/FMUL/FDIV + EA additions.
+[ ] E4. AC timing conformance assertions where simulatable.
+
+Notes:
+- This plan intentionally prioritizes cycle-accurate external behavior with DSP-optimized
+  internal pipelines, using DSACK wait-states to match datasheet cycle counts.
+- Additional opcodes (FSQRT, transcendental, FMOVE/FMOVEM, FSAVE/FRESTORE) are next phases.

--- a/src/mc68881_alu.vhd
+++ b/src/mc68881_alu.vhd
@@ -1,0 +1,53 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+use work.mc68881_pkg.all;
+
+entity mc68881_alu is
+  port (
+    op_sel  : in  fpu_op_t;
+    a_in    : in  fp80_t;
+    b_in    : in  fp80_t;
+    result  : out fp80_t;
+    valid   : out std_logic
+  );
+end entity mc68881_alu;
+
+architecture rtl of mc68881_alu is
+  signal a_u : unsigned(FP_WIDTH-1 downto 0);
+  signal b_u : unsigned(FP_WIDTH-1 downto 0);
+  signal r_u : unsigned(FP_WIDTH-1 downto 0);
+  signal r_ext : unsigned((FP_WIDTH*2)-1 downto 0);
+begin
+  a_u <= unsigned(a_in);
+  b_u <= unsigned(b_in);
+
+  process(op_sel, a_u, b_u)
+  begin
+    r_u   <= (others => '0');
+    r_ext <= (others => '0');
+    valid <= '1';
+
+    case op_sel is
+      when FPU_OP_ADD =>
+        r_u <= a_u + b_u;
+      when FPU_OP_SUB =>
+        r_u <= a_u - b_u;
+      when FPU_OP_MUL =>
+        r_ext <= a_u * b_u;
+        r_u   <= r_ext(FP_WIDTH-1 downto 0);
+      when FPU_OP_DIV =>
+        if b_u = 0 then
+          r_u <= (others => '0');
+        else
+          r_u <= a_u / b_u;
+        end if;
+      when others =>
+        valid <= '0';
+        r_u   <= (others => '0');
+    end case;
+  end process;
+
+  result <= std_logic_vector(r_u);
+end architecture rtl;

--- a/src/mc68881_alu.vhd
+++ b/src/mc68881_alu.vhd
@@ -18,16 +18,16 @@ architecture rtl of mc68881_alu is
   signal a_u : unsigned(FP_WIDTH-1 downto 0);
   signal b_u : unsigned(FP_WIDTH-1 downto 0);
   signal r_u : unsigned(FP_WIDTH-1 downto 0);
-  signal r_ext : unsigned((FP_WIDTH*2)-1 downto 0);
 begin
   a_u <= unsigned(a_in);
   b_u <= unsigned(b_in);
 
   process(op_sel, a_u, b_u)
+    variable product : unsigned((FP_WIDTH*2)-1 downto 0);
   begin
     r_u   <= (others => '0');
-    r_ext <= (others => '0');
     valid <= '1';
+    product := (others => '0');
 
     case op_sel is
       when FPU_OP_ADD =>
@@ -35,8 +35,8 @@ begin
       when FPU_OP_SUB =>
         r_u <= a_u - b_u;
       when FPU_OP_MUL =>
-        r_ext <= a_u * b_u;
-        r_u   <= r_ext(FP_WIDTH-1 downto 0);
+        product := a_u * b_u;
+        r_u     <= product(FP_WIDTH-1 downto 0);
       when FPU_OP_DIV =>
         if b_u = 0 then
           r_u <= (others => '0');

--- a/src/mc68881_pkg.vhd
+++ b/src/mc68881_pkg.vhd
@@ -1,0 +1,36 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+package mc68881_pkg is
+  constant FP_WIDTH : natural := 80;
+
+  subtype fp80_t is std_logic_vector(FP_WIDTH-1 downto 0);
+
+  type fpu_op_t is (
+    FPU_OP_NOP,
+    FPU_OP_ADD,
+    FPU_OP_SUB,
+    FPU_OP_MUL,
+    FPU_OP_DIV
+  );
+
+  function to_fp80(value : unsigned) return fp80_t;
+end package mc68881_pkg;
+
+package body mc68881_pkg is
+  function to_fp80(value : unsigned) return fp80_t is
+    variable result : fp80_t := (others => '0');
+    variable width  : natural := value'length;
+    variable copy_w : natural := 0;
+  begin
+    if width >= FP_WIDTH then
+      copy_w := FP_WIDTH;
+      result := std_logic_vector(value(copy_w-1 downto 0));
+    else
+      copy_w := width;
+      result(copy_w-1 downto 0) := std_logic_vector(value);
+    end if;
+    return result;
+  end function;
+end package body mc68881_pkg;

--- a/src/mc68881_top.vhd
+++ b/src/mc68881_top.vhd
@@ -1,0 +1,144 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+use work.mc68881_pkg.all;
+
+entity mc68881_top is
+  port (
+    -- Bus interface
+    a_in    : in  std_logic_vector(4 downto 0);
+    d_in    : in  std_logic_vector(31 downto 0);
+    d_out   : out std_logic_vector(31 downto 0);
+    size_n  : in  std_logic; -- active low
+    as_n    : in  std_logic; -- active low
+    cs_n    : in  std_logic; -- active low
+    rw      : in  std_logic; -- high=read, low=write
+    ds_n    : in  std_logic; -- active low
+    dsack0_n: out std_logic;
+    dsack1_n: out std_logic;
+    reset_n : in  std_logic;
+    clk     : in  std_logic;
+    sense_n : inout std_logic
+  );
+end entity mc68881_top;
+
+architecture rtl of mc68881_top is
+  type reg_array_t is array (0 to 1) of fp80_t;
+
+  signal op_sel    : fpu_op_t := FPU_OP_NOP;
+  signal operand   : reg_array_t := (others => (others => '0'));
+  signal result    : fp80_t := (others => '0');
+  signal result_lo : std_logic_vector(31 downto 0) := (others => '0');
+  signal result_hi : std_logic_vector(31 downto 0) := (others => '0');
+  signal result_ex : std_logic_vector(15 downto 0) := (others => '0');
+  signal valid     : std_logic := '0';
+
+  signal dsack0_i  : std_logic := '1';
+  signal dsack1_i  : std_logic := '1';
+
+  signal bus_write : std_logic;
+  signal bus_read  : std_logic;
+  signal addr      : unsigned(4 downto 0);
+
+  constant ADDR_OPSEL  : unsigned(4 downto 0) := to_unsigned(0, 5);
+  constant ADDR_OPA_L  : unsigned(4 downto 0) := to_unsigned(1, 5);
+  constant ADDR_OPA_H  : unsigned(4 downto 0) := to_unsigned(2, 5);
+  constant ADDR_OPA_E  : unsigned(4 downto 0) := to_unsigned(3, 5);
+  constant ADDR_OPB_L  : unsigned(4 downto 0) := to_unsigned(4, 5);
+  constant ADDR_OPB_H  : unsigned(4 downto 0) := to_unsigned(5, 5);
+  constant ADDR_OPB_E  : unsigned(4 downto 0) := to_unsigned(6, 5);
+  constant ADDR_RES_L  : unsigned(4 downto 0) := to_unsigned(7, 5);
+  constant ADDR_RES_H  : unsigned(4 downto 0) := to_unsigned(8, 5);
+  constant ADDR_RES_E  : unsigned(4 downto 0) := to_unsigned(9, 5);
+
+begin
+  addr      <= unsigned(a_in);
+  bus_write <= (cs_n = '0' and as_n = '0' and ds_n = '0' and rw = '0');
+  bus_read  <= (cs_n = '0' and as_n = '0' and ds_n = '0' and rw = '1');
+
+  alu_inst : entity work.mc68881_alu
+    port map (
+      op_sel => op_sel,
+      a_in   => operand(0),
+      b_in   => operand(1),
+      result => result,
+      valid  => valid
+    );
+
+  process(clk, reset_n)
+  begin
+    if reset_n = '0' then
+      op_sel      <= FPU_OP_NOP;
+      operand     <= (others => (others => '0'));
+      result_lo   <= (others => '0');
+      result_hi   <= (others => '0');
+      result_ex   <= (others => '0');
+    elsif rising_edge(clk) then
+      if bus_write = '1' then
+        case addr is
+          when ADDR_OPSEL =>
+            case d_in(2 downto 0) is
+              when "001" => op_sel <= FPU_OP_ADD;
+              when "010" => op_sel <= FPU_OP_SUB;
+              when "011" => op_sel <= FPU_OP_MUL;
+              when "100" => op_sel <= FPU_OP_DIV;
+              when others => op_sel <= FPU_OP_NOP;
+            end case;
+          when ADDR_OPA_L => operand(0)(31 downto 0)  <= d_in;
+          when ADDR_OPA_H => operand(0)(63 downto 32) <= d_in;
+          when ADDR_OPA_E => operand(0)(79 downto 64) <= d_in(15 downto 0);
+          when ADDR_OPB_L => operand(1)(31 downto 0)  <= d_in;
+          when ADDR_OPB_H => operand(1)(63 downto 32) <= d_in;
+          when ADDR_OPB_E => operand(1)(79 downto 64) <= d_in(15 downto 0);
+          when others => null;
+        end case;
+      end if;
+
+      if valid = '1' then
+        result_lo <= result(31 downto 0);
+        result_hi <= result(63 downto 32);
+        result_ex <= result(79 downto 64);
+      end if;
+    end if;
+  end process;
+
+  process(addr, bus_read, result_lo, result_hi, result_ex)
+  begin
+    d_out <= (others => '0');
+    if bus_read = '1' then
+      case addr is
+        when ADDR_RES_L => d_out <= result_lo;
+        when ADDR_RES_H => d_out <= result_hi;
+        when ADDR_RES_E => d_out(15 downto 0) <= result_ex;
+        when others => d_out <= (others => '0');
+      end case;
+    end if;
+  end process;
+
+  -- DSACK generation placeholder: immediate response based on size and A4.
+  process(cs_n, as_n, ds_n, size_n, a_in)
+  begin
+    dsack0_i <= '1';
+    dsack1_i <= '1';
+
+    if (cs_n = '0' and as_n = '0' and ds_n = '0') then
+      if size_n = '0' then
+        dsack1_i <= '0';
+        dsack0_i <= '1';
+      else
+        if a_in(4) = '1' then
+          dsack1_i <= '0';
+          dsack0_i <= '0';
+        else
+          dsack1_i <= '0';
+          dsack0_i <= '1';
+        end if;
+      end if;
+    end if;
+  end process;
+
+  dsack0_n <= dsack0_i;
+  dsack1_n <= dsack1_i;
+  sense_n  <= 'Z';
+end architecture rtl;

--- a/tb/tb_mc68881_alu.vhd
+++ b/tb/tb_mc68881_alu.vhd
@@ -1,0 +1,76 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+use work.mc68881_pkg.all;
+
+entity tb_mc68881_alu is
+end entity tb_mc68881_alu;
+
+architecture sim of tb_mc68881_alu is
+  signal op_sel : fpu_op_t := FPU_OP_NOP;
+  signal a_in   : fp80_t := (others => '0');
+  signal b_in   : fp80_t := (others => '0');
+  signal result : fp80_t;
+  signal valid  : std_logic;
+
+  procedure check_result(
+    constant expected : fp80_t;
+    constant label    : string
+  ) is
+  begin
+    assert result = expected
+      report "Mismatch: " & label
+      severity failure;
+  end procedure;
+
+  function fp80_of(value : natural) return fp80_t is
+    variable tmp : fp80_t := (others => '0');
+  begin
+    tmp(31 downto 0) := std_logic_vector(to_unsigned(value, 32));
+    return tmp;
+  end function;
+
+begin
+  dut : entity work.mc68881_alu
+    port map (
+      op_sel => op_sel,
+      a_in   => a_in,
+      b_in   => b_in,
+      result => result,
+      valid  => valid
+    );
+
+  process
+  begin
+    -- ADD
+    op_sel <= FPU_OP_ADD;
+    a_in   <= fp80_of(10);
+    b_in   <= fp80_of(5);
+    wait for 10 ns;
+    check_result(fp80_of(15), "ADD 10+5");
+
+    -- SUB
+    op_sel <= FPU_OP_SUB;
+    a_in   <= fp80_of(10);
+    b_in   <= fp80_of(3);
+    wait for 10 ns;
+    check_result(fp80_of(7), "SUB 10-3");
+
+    -- MUL
+    op_sel <= FPU_OP_MUL;
+    a_in   <= fp80_of(7);
+    b_in   <= fp80_of(9);
+    wait for 10 ns;
+    check_result(fp80_of(63), "MUL 7*9");
+
+    -- DIV
+    op_sel <= FPU_OP_DIV;
+    a_in   <= fp80_of(40);
+    b_in   <= fp80_of(5);
+    wait for 10 ns;
+    check_result(fp80_of(8), "DIV 40/5");
+
+    wait;
+  end process;
+end architecture sim;

--- a/tb/tb_mc68881_top.vhd
+++ b/tb/tb_mc68881_top.vhd
@@ -1,0 +1,110 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+use work.mc68881_pkg.all;
+
+entity tb_mc68881_top is
+end entity tb_mc68881_top;
+
+architecture sim of tb_mc68881_top is
+  signal a_in     : std_logic_vector(4 downto 0) := (others => '0');
+  signal d_in     : std_logic_vector(31 downto 0) := (others => '0');
+  signal d_out    : std_logic_vector(31 downto 0);
+  signal size_n   : std_logic := '1';
+  signal as_n     : std_logic := '1';
+  signal cs_n     : std_logic := '1';
+  signal rw       : std_logic := '1';
+  signal ds_n     : std_logic := '1';
+  signal dsack0_n : std_logic;
+  signal dsack1_n : std_logic;
+  signal reset_n  : std_logic := '0';
+  signal clk      : std_logic := '0';
+  signal sense_n  : std_logic;
+
+  constant CLK_PERIOD : time := 10 ns;
+
+  procedure bus_write(
+    constant addr : unsigned(4 downto 0);
+    constant data : std_logic_vector(31 downto 0)
+  ) is
+  begin
+    a_in <= std_logic_vector(addr);
+    d_in <= data;
+    rw   <= '0';
+    cs_n <= '0';
+    as_n <= '0';
+    ds_n <= '0';
+    wait for CLK_PERIOD;
+    cs_n <= '1';
+    as_n <= '1';
+    ds_n <= '1';
+    rw   <= '1';
+    wait for CLK_PERIOD;
+  end procedure;
+
+  procedure bus_read(
+    constant addr : unsigned(4 downto 0)
+  ) is
+  begin
+    a_in <= std_logic_vector(addr);
+    rw   <= '1';
+    cs_n <= '0';
+    as_n <= '0';
+    ds_n <= '0';
+    wait for CLK_PERIOD;
+    cs_n <= '1';
+    as_n <= '1';
+    ds_n <= '1';
+    wait for CLK_PERIOD;
+  end procedure;
+
+begin
+  clk <= not clk after CLK_PERIOD/2;
+
+  dut : entity work.mc68881_top
+    port map (
+      a_in     => a_in,
+      d_in     => d_in,
+      d_out    => d_out,
+      size_n   => size_n,
+      as_n     => as_n,
+      cs_n     => cs_n,
+      rw       => rw,
+      ds_n     => ds_n,
+      dsack0_n => dsack0_n,
+      dsack1_n => dsack1_n,
+      reset_n  => reset_n,
+      clk      => clk,
+      sense_n  => sense_n
+    );
+
+  process
+  begin
+    reset_n <= '0';
+    wait for 2 * CLK_PERIOD;
+    reset_n <= '1';
+    wait for 2 * CLK_PERIOD;
+
+    -- Write operands and op select (ADD)
+    bus_write(to_unsigned(0, 5), x"00000001");
+    bus_write(to_unsigned(1, 5), x"0000000A");
+    bus_write(to_unsigned(2, 5), x"00000000");
+    bus_write(to_unsigned(3, 5), x"00000000");
+    bus_write(to_unsigned(4, 5), x"00000005");
+    bus_write(to_unsigned(5, 5), x"00000000");
+    bus_write(to_unsigned(6, 5), x"00000000");
+
+    bus_read(to_unsigned(7, 5));
+    assert d_out = x"0000000F"
+      report "ADD result lower word mismatch"
+      severity failure;
+
+    -- DSACK should not be both high during active cycle
+    assert not (dsack0_n = '1' and dsack1_n = '1')
+      report "DSACK should acknowledge immediate response in stub"
+      severity note;
+
+    wait;
+  end process;
+end architecture sim;


### PR DESCRIPTION
### Motivation
- Provide a clear implementation checklist for an MC68881-compatible 80-bit FPU to guide development and verification. 
- Start the arithmetic and bus-interface implementation by scaffolding the first datapath operations (ADD/SUB/MUL/DIV) and a minimal top-level bus stub so integration and simulation can begin.
- Ensure basic testbench coverage for the initial operations and a simple bus access flow to catch early integration issues.

### Description
- Add a project plan file `docs/mc68881_plan_checklist.txt` with scope, sources, phased tasks, and verification goals. 
- Introduce `src/mc68881_pkg.vhd` providing `FP_WIDTH`, the `fp80_t` subtype, the `fpu_op_t` enum and a `to_fp80` helper function. 
- Add `src/mc68881_alu.vhd`, a behavioral ALU scaffold that implements `FPU_OP_ADD`, `FPU_OP_SUB`, `FPU_OP_MUL`, and `FPU_OP_DIV` over the `fp80_t` vectors. 
- Add `src/mc68881_top.vhd`, a top-level bus interface stub with a small register map, operand/result packing, and a placeholder `DSACK` generation policy that follows the datasheet-stated cases in simplified form. 
- Provide testbenches `tb/tb_mc68881_alu.vhd` and `tb/tb_mc68881_top.vhd` that exercise the four arithmetic ops and a basic bus write/read flow with assertions for expected results and DSACK behavior.

### Testing
- Added unit testbenches `tb/tb_mc68881_alu.vhd` (checks `ADD`, `SUB`, `MUL`, `DIV` via assertions) and `tb/tb_mc68881_top.vhd` (exercises bus write/read for an `ADD` and asserts result and DSACK behavior). 
- The testbenches include `assert` checks for result mismatches and a DSACK note assert, providing immediate simulation failure points. 
- No automated simulations were executed as part of this change, so testbenches were not run in CI in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986e2b52c308321b03b72f9c42e49ac)