### PR TITLE
Implement fp80 add/sub datapath and wire into ALU

### DIFF
--- a/src/mc68881_alu.vhd
+++ b/src/mc68881_alu.vhd
@@ -31,9 +31,9 @@ begin
 
     case op_sel is
       when FPU_OP_ADD =>
-        r_u <= a_u + b_u;
+        r_u <= unsigned(add_sub_fp80(a_in, b_in, false));
       when FPU_OP_SUB =>
-        r_u <= a_u - b_u;
+        r_u <= unsigned(add_sub_fp80(a_in, b_in, true));
       when FPU_OP_MUL =>
         product := a_u * b_u;
         r_u     <= product(FP_WIDTH-1 downto 0);

--- a/src/mc68881_pkg.vhd
+++ b/src/mc68881_pkg.vhd
@@ -4,6 +4,10 @@ use ieee.numeric_std.all;
 
 package mc68881_pkg is
   constant FP_WIDTH : natural := 80;
+  constant FP_EXP_WIDTH : natural := 15;
+  constant FP_FRAC_WIDTH : natural := 63;
+  constant FP_MANT_WIDTH : natural := 1 + FP_FRAC_WIDTH;
+  constant FP_EXP_BIAS : natural := 16383;
 
   subtype fp80_t is std_logic_vector(FP_WIDTH-1 downto 0);
 
@@ -16,9 +20,90 @@ package mc68881_pkg is
   );
 
   function to_fp80(value : unsigned) return fp80_t;
+  function fp80_from_int(value : integer) return fp80_t;
+  function add_sub_fp80(
+    a        : fp80_t;
+    b        : fp80_t;
+    subtract : boolean
+  ) return fp80_t;
 end package mc68881_pkg;
 
 package body mc68881_pkg is
+  constant FP_GRS_BITS : natural := 3;
+  constant FP_MANT_EXT_WIDTH : natural := FP_MANT_WIDTH + FP_GRS_BITS;
+
+  type fp_unpacked_t is record
+    sign : std_logic;
+    exp  : unsigned(FP_EXP_WIDTH-1 downto 0);
+    mant : unsigned(FP_MANT_WIDTH-1 downto 0);
+  end record;
+
+  function unpack_fp80(value : fp80_t) return fp_unpacked_t is
+    variable result : fp_unpacked_t;
+  begin
+    result.sign := value(FP_WIDTH-1);
+    result.exp  := unsigned(value(FP_WIDTH-2 downto FP_WIDTH-1-FP_EXP_WIDTH));
+    result.mant := unsigned(value(FP_MANT_WIDTH-1 downto 0));
+    return result;
+  end function;
+
+  function pack_fp80(value : fp_unpacked_t) return fp80_t is
+    variable result : fp80_t := (others => '0');
+  begin
+    result(FP_WIDTH-1) := value.sign;
+    result(FP_WIDTH-2 downto FP_WIDTH-1-FP_EXP_WIDTH) := std_logic_vector(value.exp);
+    result(FP_MANT_WIDTH-1 downto 0) := std_logic_vector(value.mant);
+    return result;
+  end function;
+
+  function shift_right_with_sticky(
+    value : unsigned;
+    shift : natural
+  ) return unsigned is
+    variable result : unsigned(value'length-1 downto 0) := (others => '0');
+    variable sticky : std_logic := '0';
+  begin
+    if shift = 0 then
+      return value;
+    end if;
+
+    if shift >= value'length then
+      if value /= 0 then
+        sticky := '1';
+      end if;
+      result(0) := sticky;
+      return result;
+    end if;
+
+    if value(shift-1 downto 0) /= 0 then
+      sticky := '1';
+    end if;
+
+    if shift = 1 then
+      result := value(value'length-1 downto 1) & sticky;
+    else
+      result := value(value'length-1 downto shift) & (shift-1 downto 1 => '0') & sticky;
+    end if;
+    return result;
+  end function;
+
+  procedure normalize_left(
+    value   : in  unsigned;
+    exp_in  : in  unsigned;
+    value_o : out unsigned;
+    exp_o   : out unsigned
+  ) is
+    variable result : unsigned(value'range) := value;
+    variable exp_var : unsigned(exp_in'range) := exp_in;
+  begin
+    while result(result'left) = '0' and exp_var /= 0 and result /= 0 loop
+      result := result(result'left-1 downto 0) & '0';
+      exp_var := exp_var - 1;
+    end loop;
+    value_o := result;
+    exp_o := exp_var;
+  end procedure;
+
   function to_fp80(value : unsigned) return fp80_t is
     variable result : fp80_t := (others => '0');
     variable width  : natural := value'length;
@@ -32,5 +117,160 @@ package body mc68881_pkg is
       result(copy_w-1 downto 0) := std_logic_vector(value);
     end if;
     return result;
+  end function;
+
+  function fp80_from_int(value : integer) return fp80_t is
+    variable result : fp80_t := (others => '0');
+    variable abs_val : natural := 0;
+    variable sign    : std_logic := '0';
+    variable exp     : unsigned(FP_EXP_WIDTH-1 downto 0) := (others => '0');
+    variable mant    : unsigned(FP_MANT_WIDTH-1 downto 0) := (others => '0');
+    variable msb_pos : integer := 0;
+    variable tmp     : natural := 0;
+  begin
+    if value = 0 then
+      return result;
+    end if;
+
+    if value < 0 then
+      sign := '1';
+      abs_val := natural(-value);
+    else
+      abs_val := natural(value);
+    end if;
+
+    tmp := abs_val;
+    msb_pos := 0;
+    while tmp > 1 loop
+      tmp := tmp / 2;
+      msb_pos := msb_pos + 1;
+    end loop;
+
+    exp := to_unsigned(FP_EXP_BIAS + msb_pos, FP_EXP_WIDTH);
+    mant := resize(to_unsigned(abs_val, FP_MANT_WIDTH), FP_MANT_WIDTH) sll (FP_MANT_WIDTH-1-msb_pos);
+
+    result(FP_WIDTH-1) := sign;
+    result(FP_WIDTH-2 downto FP_WIDTH-1-FP_EXP_WIDTH) := std_logic_vector(exp);
+    result(FP_MANT_WIDTH-1 downto 0) := std_logic_vector(mant);
+    return result;
+  end function;
+
+  function add_sub_fp80(
+    a        : fp80_t;
+    b        : fp80_t;
+    subtract : boolean
+  ) return fp80_t is
+    variable a_u : fp_unpacked_t := unpack_fp80(a);
+    variable b_u : fp_unpacked_t := unpack_fp80(b);
+    variable res_u : fp_unpacked_t;
+    variable mant_a_ext : unsigned(FP_MANT_EXT_WIDTH-1 downto 0) := (others => '0');
+    variable mant_b_ext : unsigned(FP_MANT_EXT_WIDTH-1 downto 0) := (others => '0');
+    variable mant_sum   : unsigned(FP_MANT_EXT_WIDTH downto 0) := (others => '0');
+    variable mant_main  : unsigned(FP_MANT_WIDTH-1 downto 0) := (others => '0');
+    variable exp_diff   : natural := 0;
+    variable exp_res    : unsigned(FP_EXP_WIDTH-1 downto 0) := (others => '0');
+    variable sign_b     : std_logic := '0';
+    variable guard      : std_logic := '0';
+    variable round_bit  : std_logic := '0';
+    variable sticky     : std_logic := '0';
+    variable increment  : std_logic := '0';
+    variable mant_round : unsigned(FP_MANT_WIDTH downto 0) := (others => '0');
+  begin
+    res_u.sign := '0';
+    res_u.exp  := (others => '0');
+    res_u.mant := (others => '0');
+
+    if a_u.exp = 0 and a_u.mant = 0 then
+      if subtract then
+        b_u.sign := not b_u.sign;
+      end if;
+      return pack_fp80(b_u);
+    end if;
+
+    if b_u.exp = 0 and b_u.mant = 0 then
+      return pack_fp80(a_u);
+    end if;
+
+    sign_b := b_u.sign;
+    if subtract then
+      sign_b := not sign_b;
+    end if;
+
+    mant_a_ext := a_u.mant & (FP_GRS_BITS-1 downto 0 => '0');
+    mant_b_ext := b_u.mant & (FP_GRS_BITS-1 downto 0 => '0');
+
+    if a_u.exp > b_u.exp then
+      exp_diff := to_integer(a_u.exp - b_u.exp);
+      mant_b_ext := shift_right_with_sticky(mant_b_ext, exp_diff);
+      exp_res := a_u.exp;
+    elsif b_u.exp > a_u.exp then
+      exp_diff := to_integer(b_u.exp - a_u.exp);
+      mant_a_ext := shift_right_with_sticky(mant_a_ext, exp_diff);
+      exp_res := b_u.exp;
+    else
+      exp_res := a_u.exp;
+    end if;
+
+    if a_u.sign = sign_b then
+      mant_sum := ('0' & mant_a_ext) + ('0' & mant_b_ext);
+      res_u.sign := a_u.sign;
+
+      if mant_sum(mant_sum'left) = '1' then
+        mant_sum(mant_sum'left-1 downto 0) := shift_right_with_sticky(mant_sum(mant_sum'left-1 downto 0), 1);
+        mant_sum(mant_sum'left) := '0';
+        exp_res := exp_res + 1;
+      end if;
+    else
+      if mant_a_ext >= mant_b_ext then
+        mant_sum := ('0' & mant_a_ext) - ('0' & mant_b_ext);
+        res_u.sign := a_u.sign;
+      else
+        mant_sum := ('0' & mant_b_ext) - ('0' & mant_a_ext);
+        res_u.sign := sign_b;
+      end if;
+
+      normalize_left(
+        mant_sum(mant_sum'left-1 downto 0),
+        exp_res,
+        mant_sum(mant_sum'left-1 downto 0),
+        exp_res
+      );
+    end if;
+
+    guard := mant_sum(2);
+    round_bit := mant_sum(1);
+    sticky := mant_sum(0);
+    mant_main := mant_sum(mant_sum'left-1 downto FP_GRS_BITS);
+
+    if guard = '1' and (round_bit = '1' or sticky = '1' or mant_main(0) = '1') then
+      increment := '1';
+    end if;
+
+    if increment = '1' then
+      mant_round := ('0' & mant_main) + 1;
+      if mant_round(mant_round'left) = '1' then
+        mant_main := shift_right_with_sticky(mant_round(mant_round'left-1 downto 0), 1);
+        exp_res := exp_res + 1;
+      else
+        mant_main := mant_round(mant_round'left-1 downto 0);
+      end if;
+    end if;
+
+    if mant_main = 0 then
+      res_u.sign := '0';
+      res_u.exp := (others => '0');
+      res_u.mant := (others => '0');
+      return pack_fp80(res_u);
+    end if;
+
+    if exp_res = (others => '1') then
+      res_u.exp := exp_res;
+      res_u.mant := (others => '0');
+      return pack_fp80(res_u);
+    end if;
+
+    res_u.exp := exp_res;
+    res_u.mant := mant_main;
+    return pack_fp80(res_u);
   end function;
 end package body mc68881_pkg;

--- a/src/mc68881_pkg.vhd
+++ b/src/mc68881_pkg.vhd
@@ -218,7 +218,9 @@ package body mc68881_pkg is
       if mant_sum(mant_sum'left) = '1' then
         mant_sum(mant_sum'left-1 downto 0) := shift_right_with_sticky(mant_sum(mant_sum'left-1 downto 0), 1);
         mant_sum(mant_sum'left) := '0';
-        exp_res := exp_res + 1;
+        if exp_res /= (others => '1') then
+          exp_res := exp_res + 1;
+        end if;
       end if;
     else
       if mant_a_ext >= mant_b_ext then
@@ -250,7 +252,9 @@ package body mc68881_pkg is
       mant_round := ('0' & mant_main) + 1;
       if mant_round(mant_round'left) = '1' then
         mant_main := shift_right_with_sticky(mant_round(mant_round'left-1 downto 0), 1);
-        exp_res := exp_res + 1;
+        if exp_res /= (others => '1') then
+          exp_res := exp_res + 1;
+        end if;
       else
         mant_main := mant_round(mant_round'left-1 downto 0);
       end if;

--- a/tb/tb_mc68881_alu.vhd
+++ b/tb/tb_mc68881_alu.vhd
@@ -64,17 +64,17 @@ begin
 
     -- MUL
     op_sel <= FPU_OP_MUL;
-    a_in   <= to_fp80(to_unsigned(7, 32));
-    b_in   <= to_fp80(to_unsigned(9, 32));
+    a_in   <= fp80_from_int(7);
+    b_in   <= fp80_from_int(9);
     wait for 10 ns;
-    check_result(to_fp80(to_unsigned(63, 32)), "MUL 7*9");
+    check_result(fp80_from_int(63), "MUL 7*9");
 
     -- DIV
     op_sel <= FPU_OP_DIV;
-    a_in   <= to_fp80(to_unsigned(40, 32));
-    b_in   <= to_fp80(to_unsigned(5, 32));
+    a_in   <= fp80_from_int(40);
+    b_in   <= fp80_from_int(5);
     wait for 10 ns;
-    check_result(to_fp80(to_unsigned(8, 32)), "DIV 40/5");
+    check_result(fp80_from_int(8), "DIV 40/5");
 
     wait;
   end process;

--- a/tb/tb_mc68881_alu.vhd
+++ b/tb/tb_mc68881_alu.vhd
@@ -24,11 +24,9 @@ architecture sim of tb_mc68881_alu is
       severity failure;
   end procedure;
 
-  function fp80_of(value : natural) return fp80_t is
-    variable tmp : fp80_t := (others => '0');
+  function fp80_from_int(value : integer) return fp80_t is
   begin
-    tmp(31 downto 0) := std_logic_vector(to_unsigned(value, 32));
-    return tmp;
+    return work.mc68881_pkg.fp80_from_int(value);
   end function;
 
 begin
@@ -45,31 +43,38 @@ begin
   begin
     -- ADD
     op_sel <= FPU_OP_ADD;
-    a_in   <= fp80_of(10);
-    b_in   <= fp80_of(5);
+    a_in   <= fp80_from_int(10);
+    b_in   <= fp80_from_int(5);
     wait for 10 ns;
-    check_result(fp80_of(15), "ADD 10+5");
+    check_result(fp80_from_int(15), "ADD 10+5");
 
     -- SUB
     op_sel <= FPU_OP_SUB;
-    a_in   <= fp80_of(10);
-    b_in   <= fp80_of(3);
+    a_in   <= fp80_from_int(10);
+    b_in   <= fp80_from_int(3);
     wait for 10 ns;
-    check_result(fp80_of(7), "SUB 10-3");
+    check_result(fp80_from_int(7), "SUB 10-3");
+
+    -- SUB negative result
+    op_sel <= FPU_OP_SUB;
+    a_in   <= fp80_from_int(3);
+    b_in   <= fp80_from_int(10);
+    wait for 10 ns;
+    check_result(fp80_from_int(-7), "SUB 3-10");
 
     -- MUL
     op_sel <= FPU_OP_MUL;
-    a_in   <= fp80_of(7);
-    b_in   <= fp80_of(9);
+    a_in   <= to_fp80(to_unsigned(7, 32));
+    b_in   <= to_fp80(to_unsigned(9, 32));
     wait for 10 ns;
-    check_result(fp80_of(63), "MUL 7*9");
+    check_result(to_fp80(to_unsigned(63, 32)), "MUL 7*9");
 
     -- DIV
     op_sel <= FPU_OP_DIV;
-    a_in   <= fp80_of(40);
-    b_in   <= fp80_of(5);
+    a_in   <= to_fp80(to_unsigned(40, 32));
+    b_in   <= to_fp80(to_unsigned(5, 32));
     wait for 10 ns;
-    check_result(fp80_of(8), "DIV 40/5");
+    check_result(to_fp80(to_unsigned(8, 32)), "DIV 40/5");
 
     wait;
   end process;


### PR DESCRIPTION
### Motivation
- Provide a proper FP80 add/sub implementation (alignment, normalization and rounding) to replace the previous integer-style add/sub and enable correct FP arithmetic in the ALU.

### Description
- Add FP parameters, unpack/pack helpers, `fp80_from_int`, `add_sub_fp80`, `shift_right_with_sticky` and `normalize_left` to `src/mc68881_pkg.vhd` to implement aligned add/sub with GRS rounding and basic normalization.
- Replace integer add/sub in `src/mc68881_alu.vhd` with calls to `add_sub_fp80` so the ALU uses the new FP helpers for `FPU_OP_ADD` and `FPU_OP_SUB`.
- Extend `tb/tb_mc68881_alu.vhd` to use `fp80_from_int`/`to_fp80` and add a negative-result subtraction case while keeping existing multiply/div checks.

### Testing
- No automated simulations were executed; the testbench `tb/tb_mc68881_alu.vhd` was extended to exercise the new add/sub behavior but was not run in CI or locally.
- No other automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987134c8c5c8321a403c5457312ffed)