### PR TITLE
Fix ALU testbench reserved identifier, document testbench requirements, add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# MC68881 FPGA Core
+
+## Overview
+This repository contains a VHDL-2008 implementation of an MC68881-compatible
+floating-point unit targeting Xilinx Artix-7 devices. The focus is on cycle-accurate
+external behavior (bus timing, DSACK sequencing) while using DSP-friendly pipelines
+for the core arithmetic datapath. The current plan and progress tracking live in
+`docs/mc68881_plan_checklist.txt`. 
+
+## Repository layout
+- `src/`: RTL sources for the MC68881-compatible core.
+- `tb/`: VHDL-2008 self-checking testbenches.
+- `docs/`: Implementation plan, timing notes, and related documentation.
+- `mc68881_codex_exports/`: Datasheet-derived CSV/JSON reference material used by the plan.
+- `AN-0947_MC68881_Floating-Point_Coprocessor_as_a_Peripheral_in_a_M68000_System_[Motorola_1987_37p].pdf`
+  and `MC68881.PDF`: Reference documentation.
+
+## Plan and milestones
+The implementation plan is tracked as a checklist in `docs/mc68881_plan_checklist.txt`,
+covering:
+- External interface and bus timing behavior.
+- Instruction cycle accounting and effective address additions.
+- Core microarchitecture and datapath pipelines for ADD/SUB/MUL/DIV.
+- Verification goals for arithmetic, bus behavior, and cycle counts.
+
+## Running simulations (example)
+Use a VHDL-2008 capable simulator (such as GHDL or ModelSim). For example, with GHDL:
+
+```sh
+ghdl -a --std=08 src/mc68881_pkg.vhd src/mc68881_alu.vhd tb/tb_mc68881_alu.vhd
+ghdl -e --std=08 tb_mc68881_alu
+ghdl -r --std=08 tb_mc68881_alu
+```
+
+Adjust the compilation list as new RTL/testbench files are added.

--- a/agents.md
+++ b/agents.md
@@ -8,3 +8,6 @@
 - Keep updates aligned with `docs/mc68881_plan_checklist.txt`.
 - Add or extend testbench coverage in `tb/` for any new RTL behavior.
 - Maintain VHDL-2008 compatibility and avoid vendor-specific primitives.
+- Testbenches in `tb/` must be self-checking (assertions with descriptive names), wait on
+   DUT-valid signals before checking results, and avoid reserved identifiers (e.g., `label`)
+   in procedure/function arguments or signal names.

--- a/tb/tb_mc68881_alu.vhd
+++ b/tb/tb_mc68881_alu.vhd
@@ -15,12 +15,12 @@ architecture sim of tb_mc68881_alu is
   signal valid  : std_logic;
 
   procedure check_result(
-    constant expected : fp80_t;
-    constant label    : string
+    constant expected  : fp80_t;
+    constant test_name : string
   ) is
   begin
     assert result = expected
-      report "Mismatch: " & label
+      report "Mismatch: " & test_name
       severity failure;
   end procedure;
 


### PR DESCRIPTION
### Motivation
- Fix a VHDL syntax issue where the ALU testbench used a reserved/ambiguous identifier for its assertion label and make testbenches more robust and self-checking.
- Provide clear repository-level guidance and a top-level README so contributors know project layout, verification expectations, and example simulation commands.

### Description
- Renamed the procedure parameter in `tb/tb_mc68881_alu.vhd` from `label` to `test_name` and updated the assertion report string to `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698716b621448321bc06626ad669f46c)