### PR TITLE
Implement FP80 multiply/divide, multi-cycle ALU with status, and testbench coverage

### DIFF
--- a/src/mc68881_alu.vhd
+++ b/src/mc68881_alu.vhd
@@ -6,48 +6,86 @@ use work.mc68881_pkg.all;
 
 entity mc68881_alu is
   port (
+    clk     : in  std_logic;
+    reset_n : in  std_logic;
+    start   : in  std_logic;
     op_sel  : in  fpu_op_t;
     a_in    : in  fp80_t;
     b_in    : in  fp80_t;
     result  : out fp80_t;
-    valid   : out std_logic
+    valid   : out std_logic;
+    busy    : out std_logic
   );
 end entity mc68881_alu;
 
 architecture rtl of mc68881_alu is
-  signal a_u : unsigned(FP_WIDTH-1 downto 0);
-  signal b_u : unsigned(FP_WIDTH-1 downto 0);
-  signal r_u : unsigned(FP_WIDTH-1 downto 0);
-begin
-  a_u <= unsigned(a_in);
-  b_u <= unsigned(b_in);
+  signal result_reg : fp80_t := (others => '0');
+  signal valid_reg  : std_logic := '0';
+  signal busy_reg   : std_logic := '0';
+  signal cycle_cnt  : natural := 0;
 
-  process(op_sel, a_u, b_u)
-    variable product : unsigned((FP_WIDTH*2)-1 downto 0);
+  constant ADD_LATENCY : natural := 1;
+  constant SUB_LATENCY : natural := 1;
+  constant MUL_LATENCY : natural := 4;
+  constant DIV_LATENCY : natural := 8;
+
+  function op_latency(op_sel : fpu_op_t) return natural is
   begin
-    r_u   <= (others => '0');
-    valid <= '1';
-    product := (others => '0');
-
     case op_sel is
-      when FPU_OP_ADD =>
-        r_u <= unsigned(add_sub_fp80(a_in, b_in, false));
-      when FPU_OP_SUB =>
-        r_u <= unsigned(add_sub_fp80(a_in, b_in, true));
-      when FPU_OP_MUL =>
-        product := a_u * b_u;
-        r_u     <= product(FP_WIDTH-1 downto 0);
-      when FPU_OP_DIV =>
-        if b_u = 0 then
-          r_u <= (others => '0');
-        else
-          r_u <= a_u / b_u;
-        end if;
-      when others =>
-        valid <= '0';
-        r_u   <= (others => '0');
+      when FPU_OP_ADD => return ADD_LATENCY;
+      when FPU_OP_SUB => return SUB_LATENCY;
+      when FPU_OP_MUL => return MUL_LATENCY;
+      when FPU_OP_DIV => return DIV_LATENCY;
+      when others     => return 0;
     end case;
+  end function;
+begin
+  process(clk, reset_n)
+    variable latency : natural := 0;
+  begin
+    if reset_n = '0' then
+      result_reg <= (others => '0');
+      valid_reg  <= '0';
+      busy_reg   <= '0';
+      cycle_cnt  <= 0;
+    elsif rising_edge(clk) then
+      valid_reg <= '0';
+
+      if start = '1' and busy_reg = '0' then
+        latency := op_latency(op_sel);
+        case op_sel is
+          when FPU_OP_ADD =>
+            result_reg <= add_sub_fp80(a_in, b_in, false);
+          when FPU_OP_SUB =>
+            result_reg <= add_sub_fp80(a_in, b_in, true);
+          when FPU_OP_MUL =>
+            result_reg <= mul_fp80(a_in, b_in);
+          when FPU_OP_DIV =>
+            result_reg <= div_fp80(a_in, b_in);
+          when others =>
+            result_reg <= (others => '0');
+        end case;
+
+        if latency = 0 then
+          valid_reg <= '1';
+          busy_reg  <= '0';
+          cycle_cnt <= 0;
+        else
+          busy_reg  <= '1';
+          cycle_cnt <= latency - 1;
+        end if;
+      elsif busy_reg = '1' then
+        if cycle_cnt = 0 then
+          valid_reg <= '1';
+          busy_reg  <= '0';
+        else
+          cycle_cnt <= cycle_cnt - 1;
+        end if;
+      end if;
+    end if;
   end process;
 
-  result <= std_logic_vector(r_u);
+  result <= result_reg;
+  valid  <= valid_reg;
+  busy   <= busy_reg;
 end architecture rtl;

--- a/src/mc68881_pkg.vhd
+++ b/src/mc68881_pkg.vhd
@@ -26,12 +26,21 @@ package mc68881_pkg is
     b        : fp80_t;
     subtract : boolean
   ) return fp80_t;
+  function mul_fp80(
+    a : fp80_t;
+    b : fp80_t
+  ) return fp80_t;
+  function div_fp80(
+    a : fp80_t;
+    b : fp80_t
+  ) return fp80_t;
 end package mc68881_pkg;
 
 package body mc68881_pkg is
   constant FP_GRS_BITS : natural := 3;
   constant FP_MANT_EXT_WIDTH : natural := FP_MANT_WIDTH + FP_GRS_BITS;
   constant FP_EXP_ALL_ONES : unsigned(FP_EXP_WIDTH-1 downto 0) := (others => '1');
+  constant FP_EXP_MAX : integer := (2**FP_EXP_WIDTH) - 1;
 
   type fp_unpacked_t is record
     sign : std_logic;
@@ -274,6 +283,231 @@ package body mc68881_pkg is
       return pack_fp80(res_u);
     end if;
 
+    res_u.exp := exp_res;
+    res_u.mant := mant_main;
+    return pack_fp80(res_u);
+  end function;
+
+  function mul_fp80(
+    a : fp80_t;
+    b : fp80_t
+  ) return fp80_t is
+    variable a_u : fp_unpacked_t := unpack_fp80(a);
+    variable b_u : fp_unpacked_t := unpack_fp80(b);
+    variable res_u : fp_unpacked_t;
+    variable mant_prod : unsigned((FP_MANT_WIDTH*2)-1 downto 0) := (others => '0');
+    variable mant_ext  : unsigned(FP_MANT_EXT_WIDTH-1 downto 0) := (others => '0');
+    variable mant_main : unsigned(FP_MANT_WIDTH-1 downto 0) := (others => '0');
+    variable exp_res_i : integer := 0;
+    variable exp_res   : unsigned(FP_EXP_WIDTH-1 downto 0) := (others => '0');
+    variable shift     : integer := 0;
+    variable sticky    : std_logic := '0';
+    variable guard     : std_logic := '0';
+    variable round_bit : std_logic := '0';
+    variable increment : std_logic := '0';
+    variable mant_round : unsigned(FP_MANT_WIDTH downto 0) := (others => '0');
+    variable low_or : std_logic := '0';
+  begin
+    res_u.sign := a_u.sign xor b_u.sign;
+    res_u.exp  := (others => '0');
+    res_u.mant := (others => '0');
+
+    if (a_u.exp = 0 and a_u.mant = 0) or (b_u.exp = 0 and b_u.mant = 0) then
+      res_u.sign := '0';
+      return pack_fp80(res_u);
+    end if;
+
+    if a_u.exp = FP_EXP_ALL_ONES or b_u.exp = FP_EXP_ALL_ONES then
+      res_u.exp := FP_EXP_ALL_ONES;
+      res_u.mant := (others => '0');
+      return pack_fp80(res_u);
+    end if;
+
+    exp_res_i := to_integer(a_u.exp) + to_integer(b_u.exp) - FP_EXP_BIAS;
+    mant_prod := a_u.mant * b_u.mant;
+
+    if mant_prod(mant_prod'left) = '1' then
+      shift := 1;
+      exp_res_i := exp_res_i + 1;
+    else
+      shift := 0;
+    end if;
+
+    mant_ext := mant_prod(mant_prod'left-shift downto mant_prod'left-shift-(FP_MANT_EXT_WIDTH-1));
+    if (mant_prod'left-shift-(FP_MANT_EXT_WIDTH) >= 0) then
+      for idx in 0 to mant_prod'left-shift-FP_MANT_EXT_WIDTH loop
+        if mant_prod(idx) = '1' then
+          low_or := '1';
+        end if;
+      end loop;
+    end if;
+
+    if low_or = '1' then
+      mant_ext(0) := mant_ext(0) or low_or;
+    end if;
+
+    guard := mant_ext(2);
+    round_bit := mant_ext(1);
+    sticky := mant_ext(0);
+    mant_main := mant_ext(FP_MANT_EXT_WIDTH-1 downto FP_GRS_BITS);
+
+    if guard = '1' and (round_bit = '1' or sticky = '1' or mant_main(0) = '1') then
+      increment := '1';
+    end if;
+
+    if increment = '1' then
+      mant_round := ('0' & mant_main) + 1;
+      if mant_round(mant_round'left) = '1' then
+        mant_main := shift_right_with_sticky(mant_round(mant_round'left-1 downto 0), 1);
+        exp_res_i := exp_res_i + 1;
+      else
+        mant_main := mant_round(mant_round'left-1 downto 0);
+      end if;
+    end if;
+
+    if exp_res_i <= 0 then
+      res_u.sign := '0';
+      res_u.exp := (others => '0');
+      res_u.mant := (others => '0');
+      return pack_fp80(res_u);
+    end if;
+
+    if exp_res_i >= FP_EXP_MAX then
+      res_u.exp := FP_EXP_ALL_ONES;
+      res_u.mant := (others => '0');
+      return pack_fp80(res_u);
+    end if;
+
+    exp_res := to_unsigned(exp_res_i, FP_EXP_WIDTH);
+    res_u.exp := exp_res;
+    res_u.mant := mant_main;
+    return pack_fp80(res_u);
+  end function;
+
+  function div_fp80(
+    a : fp80_t;
+    b : fp80_t
+  ) return fp80_t is
+    variable a_u : fp_unpacked_t := unpack_fp80(a);
+    variable b_u : fp_unpacked_t := unpack_fp80(b);
+    variable res_u : fp_unpacked_t;
+    variable num : unsigned((FP_MANT_WIDTH*2)+FP_GRS_BITS-1 downto 0) := (others => '0');
+    variable quot : unsigned((FP_MANT_WIDTH*2)+FP_GRS_BITS-1 downto 0) := (others => '0');
+    variable mant_ext : unsigned(FP_MANT_EXT_WIDTH-1 downto 0) := (others => '0');
+    variable mant_main : unsigned(FP_MANT_WIDTH-1 downto 0) := (others => '0');
+    variable exp_res_i : integer := 0;
+    variable exp_res   : unsigned(FP_EXP_WIDTH-1 downto 0) := (others => '0');
+    variable shift     : integer := 0;
+    variable guard     : std_logic := '0';
+    variable round_bit : std_logic := '0';
+    variable sticky    : std_logic := '0';
+    variable increment : std_logic := '0';
+    variable mant_round : unsigned(FP_MANT_WIDTH downto 0) := (others => '0');
+    variable low_or : std_logic := '0';
+    variable top_index : integer := FP_MANT_WIDTH + FP_GRS_BITS;
+  begin
+    res_u.sign := a_u.sign xor b_u.sign;
+    res_u.exp  := (others => '0');
+    res_u.mant := (others => '0');
+
+    if b_u.exp = 0 and b_u.mant = 0 then
+      res_u.exp := FP_EXP_ALL_ONES;
+      res_u.mant := (others => '0');
+      return pack_fp80(res_u);
+    end if;
+
+    if a_u.exp = 0 and a_u.mant = 0 then
+      res_u.sign := '0';
+      return pack_fp80(res_u);
+    end if;
+
+    if a_u.exp = FP_EXP_ALL_ONES or b_u.exp = FP_EXP_ALL_ONES then
+      res_u.exp := FP_EXP_ALL_ONES;
+      res_u.mant := (others => '0');
+      return pack_fp80(res_u);
+    end if;
+
+    exp_res_i := to_integer(a_u.exp) - to_integer(b_u.exp) + FP_EXP_BIAS;
+
+    num := a_u.mant & (FP_MANT_WIDTH+FP_GRS_BITS-1 downto 0 => '0');
+    quot := num / b_u.mant;
+
+    if quot(top_index+1) = '1' then
+      shift := 1;
+      exp_res_i := exp_res_i + 1;
+    elsif quot(top_index) = '0' then
+      shift := -1;
+      exp_res_i := exp_res_i - 1;
+    else
+      shift := 0;
+    end if;
+
+    if shift = 1 then
+      mant_ext := quot(top_index+1 downto top_index+1-(FP_MANT_EXT_WIDTH-1));
+      if top_index+1-FP_MANT_EXT_WIDTH >= 0 then
+        for idx in 0 to top_index+1-FP_MANT_EXT_WIDTH loop
+          if quot(idx) = '1' then
+            low_or := '1';
+          end if;
+        end loop;
+      end if;
+    elsif shift = -1 then
+      mant_ext := quot(top_index-1 downto top_index-1-(FP_MANT_EXT_WIDTH-1));
+      if top_index-1-FP_MANT_EXT_WIDTH >= 0 then
+        for idx in 0 to top_index-1-FP_MANT_EXT_WIDTH loop
+          if quot(idx) = '1' then
+            low_or := '1';
+          end if;
+        end loop;
+      end if;
+    else
+      mant_ext := quot(top_index downto top_index-(FP_MANT_EXT_WIDTH-1));
+      if top_index-FP_MANT_EXT_WIDTH >= 0 then
+        for idx in 0 to top_index-FP_MANT_EXT_WIDTH loop
+          if quot(idx) = '1' then
+            low_or := '1';
+          end if;
+        end loop;
+      end if;
+    end if;
+
+    if low_or = '1' then
+      mant_ext(0) := mant_ext(0) or low_or;
+    end if;
+
+    guard := mant_ext(2);
+    round_bit := mant_ext(1);
+    sticky := mant_ext(0);
+    mant_main := mant_ext(FP_MANT_EXT_WIDTH-1 downto FP_GRS_BITS);
+
+    if guard = '1' and (round_bit = '1' or sticky = '1' or mant_main(0) = '1') then
+      increment := '1';
+    end if;
+
+    if increment = '1' then
+      mant_round := ('0' & mant_main) + 1;
+      if mant_round(mant_round'left) = '1' then
+        mant_main := shift_right_with_sticky(mant_round(mant_round'left-1 downto 0), 1);
+        exp_res_i := exp_res_i + 1;
+      else
+        mant_main := mant_round(mant_round'left-1 downto 0);
+      end if;
+    end if;
+
+    if exp_res_i <= 0 then
+      res_u.sign := '0';
+      res_u.exp := (others => '0');
+      res_u.mant := (others => '0');
+      return pack_fp80(res_u);
+    end if;
+
+    if exp_res_i >= FP_EXP_MAX then
+      res_u.exp := FP_EXP_ALL_ONES;
+      res_u.mant := (others => '0');
+      return pack_fp80(res_u);
+    end if;
+
+    exp_res := to_unsigned(exp_res_i, FP_EXP_WIDTH);
     res_u.exp := exp_res;
     res_u.mant := mant_main;
     return pack_fp80(res_u);

--- a/src/mc68881_top.vhd
+++ b/src/mc68881_top.vhd
@@ -33,6 +33,10 @@ architecture rtl of mc68881_top is
   signal result_hi : std_logic_vector(31 downto 0) := (others => '0');
   signal result_ex : std_logic_vector(15 downto 0) := (others => '0');
   signal valid     : std_logic := '0';
+  signal busy      : std_logic := '0';
+  signal op_start  : std_logic := '0';
+  signal status_valid : std_logic := '0';
+  signal status_busy  : std_logic := '0';
 
   signal dsack0_i  : std_logic := '1';
   signal dsack1_i  : std_logic := '1';
@@ -51,6 +55,7 @@ architecture rtl of mc68881_top is
   constant ADDR_RES_L  : unsigned(4 downto 0) := to_unsigned(7, 5);
   constant ADDR_RES_H  : unsigned(4 downto 0) := to_unsigned(8, 5);
   constant ADDR_RES_E  : unsigned(4 downto 0) := to_unsigned(9, 5);
+  constant ADDR_STATUS : unsigned(4 downto 0) := to_unsigned(10, 5);
 
 begin
   addr      <= unsigned(a_in);
@@ -59,11 +64,15 @@ begin
 
   alu_inst : entity work.mc68881_alu
     port map (
+      clk    => clk,
+      reset_n => reset_n,
+      start  => op_start,
       op_sel => op_sel,
       a_in   => operand(0),
       b_in   => operand(1),
       result => result,
-      valid  => valid
+      valid  => valid,
+      busy   => busy
     );
 
   process(clk, reset_n)
@@ -74,7 +83,12 @@ begin
       result_lo   <= (others => '0');
       result_hi   <= (others => '0');
       result_ex   <= (others => '0');
+      op_start    <= '0';
+      status_valid <= '0';
+      status_busy  <= '0';
     elsif rising_edge(clk) then
+      op_start <= '0';
+
       if bus_write = '1' then
         case addr is
           when ADDR_OPSEL =>
@@ -85,6 +99,10 @@ begin
               when "100" => op_sel <= FPU_OP_DIV;
               when others => op_sel <= FPU_OP_NOP;
             end case;
+            if busy = '0' then
+              op_start <= '1';
+              status_valid <= '0';
+            end if;
           when ADDR_OPA_L => operand(0)(31 downto 0)  <= d_in;
           when ADDR_OPA_H => operand(0)(63 downto 32) <= d_in;
           when ADDR_OPA_E => operand(0)(79 downto 64) <= d_in(15 downto 0);
@@ -99,11 +117,17 @@ begin
         result_lo <= result(31 downto 0);
         result_hi <= result(63 downto 32);
         result_ex <= result(79 downto 64);
+        status_valid <= '1';
+      end if;
+
+      status_busy <= busy;
+      if bus_read = '1' and addr = ADDR_STATUS then
+        status_valid <= '0';
       end if;
     end if;
   end process;
 
-  process(addr, bus_read, result_lo, result_hi, result_ex)
+  process(addr, bus_read, result_lo, result_hi, result_ex, status_valid, status_busy)
   begin
     d_out <= (others => '0');
     if bus_read = '1' then
@@ -111,6 +135,9 @@ begin
         when ADDR_RES_L => d_out <= result_lo;
         when ADDR_RES_H => d_out <= result_hi;
         when ADDR_RES_E => d_out(15 downto 0) <= result_ex;
+        when ADDR_STATUS =>
+          d_out(0) <= status_valid;
+          d_out(1) <= status_busy;
         when others => d_out <= (others => '0');
       end case;
     end if;

--- a/src/mc68881_top.vhd
+++ b/src/mc68881_top.vhd
@@ -121,7 +121,7 @@ begin
       end if;
 
       status_busy <= busy;
-      if bus_read = '1' and addr = ADDR_STATUS then
+      if bus_read = '1' and addr = ADDR_STATUS and valid = '0' then
         status_valid <= '0';
       end if;
     end if;

--- a/tb/tb_mc68881_alu.vhd
+++ b/tb/tb_mc68881_alu.vhd
@@ -8,19 +8,52 @@ entity tb_mc68881_alu is
 end entity tb_mc68881_alu;
 
 architecture sim of tb_mc68881_alu is
+  signal clk    : std_logic := '0';
+  signal reset_n: std_logic := '0';
+  signal start  : std_logic := '0';
   signal op_sel : fpu_op_t := FPU_OP_NOP;
   signal a_in   : fp80_t := (others => '0');
   signal b_in   : fp80_t := (others => '0');
   signal result : fp80_t;
   signal valid  : std_logic;
+  signal busy   : std_logic;
+  signal cycle_cnt : natural := 0;
+
+  constant CLK_PERIOD : time := 10 ns;
+  constant ADD_LATENCY : natural := 1;
+  constant SUB_LATENCY : natural := 1;
+  constant MUL_LATENCY : natural := 4;
+  constant DIV_LATENCY : natural := 8;
+
+  procedure split_fp80(
+    constant value : fp80_t;
+    variable sign  : out std_logic;
+    variable exp   : out unsigned(FP_EXP_WIDTH-1 downto 0);
+    variable mant  : out unsigned(FP_MANT_WIDTH-1 downto 0)
+  ) is
+  begin
+    sign := value(FP_WIDTH-1);
+    exp  := unsigned(value(FP_WIDTH-2 downto FP_WIDTH-1-FP_EXP_WIDTH));
+    mant := unsigned(value(FP_MANT_WIDTH-1 downto 0));
+  end procedure;
 
   procedure check_result(
     constant expected  : fp80_t;
     constant test_name : string
   ) is
+    variable got_sign  : std_logic := '0';
+    variable exp_sign  : std_logic := '0';
+    variable got_exp   : unsigned(FP_EXP_WIDTH-1 downto 0) := (others => '0');
+    variable exp_exp   : unsigned(FP_EXP_WIDTH-1 downto 0) := (others => '0');
+    variable got_mant  : unsigned(FP_MANT_WIDTH-1 downto 0) := (others => '0');
+    variable exp_mant  : unsigned(FP_MANT_WIDTH-1 downto 0) := (others => '0');
   begin
-    assert result = expected
-      report "Mismatch: " & test_name
+    split_fp80(result, got_sign, got_exp, got_mant);
+    split_fp80(expected, exp_sign, exp_exp, exp_mant);
+    assert got_sign = exp_sign and got_exp = exp_exp and got_mant = exp_mant
+      report "Mismatch: " & test_name &
+             " expected=" & to_hstring(expected) &
+             " got=" & to_hstring(result)
       severity failure;
   end procedure;
 
@@ -30,50 +63,113 @@ architecture sim of tb_mc68881_alu is
   end function;
 
 begin
+  clk <= not clk after CLK_PERIOD/2;
+  cycle_counter : process(clk)
+  begin
+    if rising_edge(clk) then
+      cycle_cnt <= cycle_cnt + 1;
+    end if;
+  end process;
+
   dut : entity work.mc68881_alu
     port map (
+      clk    => clk,
+      reset_n => reset_n,
+      start  => start,
       op_sel => op_sel,
       a_in   => a_in,
       b_in   => b_in,
       result => result,
-      valid  => valid
+      valid  => valid,
+      busy   => busy
     );
 
   process
+    variable start_cycle : natural := 0;
   begin
+    reset_n <= '0';
+    wait for 2 * CLK_PERIOD;
+    reset_n <= '1';
+    wait for 2 * CLK_PERIOD;
+
     -- ADD
     op_sel <= FPU_OP_ADD;
     a_in   <= fp80_from_int(10);
     b_in   <= fp80_from_int(5);
-    wait for 10 ns;
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    start_cycle := cycle_cnt;
+    wait until valid = '1';
+    report "ADD latency cycles: " & integer'image(cycle_cnt - start_cycle)
+      severity note;
+    assert cycle_cnt - start_cycle = ADD_LATENCY
+      report "ADD latency mismatch"
+      severity failure;
     check_result(fp80_from_int(15), "ADD 10+5");
 
     -- SUB
     op_sel <= FPU_OP_SUB;
     a_in   <= fp80_from_int(10);
     b_in   <= fp80_from_int(3);
-    wait for 10 ns;
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    start_cycle := cycle_cnt;
+    wait until valid = '1';
+    report "SUB latency cycles: " & integer'image(cycle_cnt - start_cycle)
+      severity note;
+    assert cycle_cnt - start_cycle = SUB_LATENCY
+      report "SUB latency mismatch"
+      severity failure;
     check_result(fp80_from_int(7), "SUB 10-3");
 
     -- SUB negative result
     op_sel <= FPU_OP_SUB;
     a_in   <= fp80_from_int(3);
     b_in   <= fp80_from_int(10);
-    wait for 10 ns;
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    start_cycle := cycle_cnt;
+    wait until valid = '1';
+    report "SUB neg latency cycles: " & integer'image(cycle_cnt - start_cycle)
+      severity note;
+    assert cycle_cnt - start_cycle = SUB_LATENCY
+      report "SUB negative latency mismatch"
+      severity failure;
     check_result(fp80_from_int(-7), "SUB 3-10");
 
     -- MUL
     op_sel <= FPU_OP_MUL;
     a_in   <= fp80_from_int(7);
     b_in   <= fp80_from_int(9);
-    wait for 10 ns;
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    start_cycle := cycle_cnt;
+    wait until valid = '1';
+    report "MUL latency cycles: " & integer'image(cycle_cnt - start_cycle)
+      severity note;
+    assert cycle_cnt - start_cycle = MUL_LATENCY
+      report "MUL latency mismatch"
+      severity failure;
     check_result(fp80_from_int(63), "MUL 7*9");
 
     -- DIV
     op_sel <= FPU_OP_DIV;
     a_in   <= fp80_from_int(40);
     b_in   <= fp80_from_int(5);
-    wait for 10 ns;
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    start_cycle := cycle_cnt;
+    wait until valid = '1';
+    report "DIV latency cycles: " & integer'image(cycle_cnt - start_cycle)
+      severity note;
+    assert cycle_cnt - start_cycle = DIV_LATENCY
+      report "DIV latency mismatch"
+      severity failure;
     check_result(fp80_from_int(8), "DIV 40/5");
 
     wait;

--- a/tb/tb_mc68881_top.vhd
+++ b/tb/tb_mc68881_top.vhd
@@ -28,6 +28,40 @@ architecture sim of tb_mc68881_top is
   signal cycle_cnt: natural := 0;
 
   constant CLK_PERIOD : time := 10 ns;
+  constant ADDR_STATUS : unsigned(4 downto 0) := to_unsigned(10, 5);
+
+  procedure split_fp80(
+    constant value : fp80_t;
+    variable sign  : out std_logic;
+    variable exp   : out unsigned(FP_EXP_WIDTH-1 downto 0);
+    variable mant  : out unsigned(FP_MANT_WIDTH-1 downto 0)
+  ) is
+  begin
+    sign := value(FP_WIDTH-1);
+    exp  := unsigned(value(FP_WIDTH-2 downto FP_WIDTH-1-FP_EXP_WIDTH));
+    mant := unsigned(value(FP_MANT_WIDTH-1 downto 0));
+  end procedure;
+
+  procedure check_fp80(
+    constant got      : fp80_t;
+    constant expected : fp80_t;
+    constant test_name: string
+  ) is
+    variable got_sign  : std_logic := '0';
+    variable exp_sign  : std_logic := '0';
+    variable got_exp   : unsigned(FP_EXP_WIDTH-1 downto 0) := (others => '0');
+    variable exp_exp   : unsigned(FP_EXP_WIDTH-1 downto 0) := (others => '0');
+    variable got_mant  : unsigned(FP_MANT_WIDTH-1 downto 0) := (others => '0');
+    variable exp_mant  : unsigned(FP_MANT_WIDTH-1 downto 0) := (others => '0');
+  begin
+    split_fp80(got, got_sign, got_exp, got_mant);
+    split_fp80(expected, exp_sign, exp_exp, exp_mant);
+    assert got_sign = exp_sign and got_exp = exp_exp and got_mant = exp_mant
+      report "Mismatch: " & test_name &
+             " expected=" & to_hstring(expected) &
+             " got=" & to_hstring(got)
+      severity failure;
+  end procedure;
 
   procedure bus_write(
     signal a_in_s  : out std_logic_vector(4 downto 0);
@@ -82,6 +116,28 @@ architecture sim of tb_mc68881_top is
     wait for CLK_PERIOD;
   end procedure;
 
+  procedure wait_for_valid(
+    signal a_in_s    : out std_logic_vector(4 downto 0);
+    signal rw_s      : out std_logic;
+    signal cs_n_s    : out std_logic;
+    signal as_n_s    : out std_logic;
+    signal ds_n_s    : out std_logic;
+    signal dsack0_n_s: in  std_logic;
+    signal dsack1_n_s: in  std_logic;
+    signal d_out_s   : in  std_logic_vector(31 downto 0)
+  ) is
+    variable status_word : std_logic_vector(31 downto 0) := (others => '0');
+  begin
+    loop
+      bus_read(a_in_s, rw_s, cs_n_s, as_n_s, ds_n_s, dsack0_n_s, dsack1_n_s, d_out_s, status_word, ADDR_STATUS);
+      report "STATUS poll: valid=" & std_logic'image(status_word(0)) &
+             " busy=" & std_logic'image(status_word(1)) &
+             " cycle=" & integer'image(cycle_cnt)
+        severity note;
+      exit when status_word(0) = '1';
+    end loop;
+  end procedure;
+
 begin
   clk <= not clk after CLK_PERIOD/2;
   cycle_counter : process(clk)
@@ -131,15 +187,14 @@ begin
     report "ADD cycle start: " & integer'image(cycle_cnt)
       severity note;
 
-    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(0, 5), x"00000001");
     bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(1, 5), op_a(31 downto 0));
     bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(2, 5), op_a(63 downto 32));
     bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(3, 5), x"0000" & op_a(79 downto 64));
     bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(4, 5), op_b(31 downto 0));
     bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(5, 5), op_b(63 downto 32));
     bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(6, 5), x"0000" & op_b(79 downto 64));
-    wait until rising_edge(clk);
-    wait for CLK_PERIOD/2;
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(0, 5), x"00000001");
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out);
 
     bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_lo, to_unsigned(7, 5));
     bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_hi, to_unsigned(8, 5));
@@ -153,9 +208,77 @@ begin
       severity note;
     report "ADD cycle end: " & integer'image(cycle_cnt)
       severity note;
-    assert rd_full = exp_r
-      report "ADD result mismatch (full FP80)"
-      severity failure;
+    check_fp80(rd_full, exp_r, "ADD result");
+
+    -- MUL
+    op_a := fp80_from_int(7);
+    op_b := fp80_from_int(9);
+    exp_r := mul_fp80(op_a, op_b);
+    report "MUL operands: op_a=" & to_hstring(op_a) & " op_b=" & to_hstring(op_b)
+      severity note;
+    report "MUL expected: " & to_hstring(exp_r)
+      severity note;
+    report "MUL cycle start: " & integer'image(cycle_cnt)
+      severity note;
+
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(1, 5), op_a(31 downto 0));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(2, 5), op_a(63 downto 32));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(3, 5), x"0000" & op_a(79 downto 64));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(4, 5), op_b(31 downto 0));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(5, 5), op_b(63 downto 32));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(6, 5), x"0000" & op_b(79 downto 64));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(0, 5), x"00000003");
+
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out);
+
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_lo, to_unsigned(7, 5));
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_hi, to_unsigned(8, 5));
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_ex, to_unsigned(9, 5));
+
+    rd_full := rd_ex(15 downto 0) & rd_hi & rd_lo;
+    rd_res  <= rd_full;
+    report "MUL readback: ex=" & to_hstring(rd_ex) & " hi=" & to_hstring(rd_hi) & " lo=" & to_hstring(rd_lo)
+      severity note;
+    report "MUL result:  " & to_hstring(rd_full)
+      severity note;
+    report "MUL cycle end: " & integer'image(cycle_cnt)
+      severity note;
+    check_fp80(rd_full, exp_r, "MUL result");
+
+    -- DIV
+    op_a := fp80_from_int(40);
+    op_b := fp80_from_int(5);
+    exp_r := div_fp80(op_a, op_b);
+    report "DIV operands: op_a=" & to_hstring(op_a) & " op_b=" & to_hstring(op_b)
+      severity note;
+    report "DIV expected: " & to_hstring(exp_r)
+      severity note;
+    report "DIV cycle start: " & integer'image(cycle_cnt)
+      severity note;
+
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(1, 5), op_a(31 downto 0));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(2, 5), op_a(63 downto 32));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(3, 5), x"0000" & op_a(79 downto 64));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(4, 5), op_b(31 downto 0));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(5, 5), op_b(63 downto 32));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(6, 5), x"0000" & op_b(79 downto 64));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(0, 5), x"00000004");
+
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out);
+
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_lo, to_unsigned(7, 5));
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_hi, to_unsigned(8, 5));
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_ex, to_unsigned(9, 5));
+
+    rd_full := rd_ex(15 downto 0) & rd_hi & rd_lo;
+    rd_res  <= rd_full;
+    report "DIV readback: ex=" & to_hstring(rd_ex) & " hi=" & to_hstring(rd_hi) & " lo=" & to_hstring(rd_lo)
+      severity note;
+    report "DIV result:  " & to_hstring(rd_full)
+      severity note;
+    report "DIV cycle end: " & integer'image(cycle_cnt)
+      severity note;
+    check_fp80(rd_full, exp_r, "DIV result");
 
     -- DSACK behavior coverage
     size_n <= "11";


### PR DESCRIPTION
### Motivation

- Provide full FP80 multiply and divide datapath functions with normalization and rounding to complete arithmetic support beyond add/sub.
- Model realistic multi-cycle ALU behavior with latency, busy/valid handshake and a readable status register so the top-level bus can poll for completion.
- Extend testbenches to be self-checking and validate both functional correctness and cycle-count latency for each operation.

### Description

- Added `mul_fp80` and `div_fp80` to `src/mc68881_pkg.vhd` implementing mantissa multiply/divide, normalization, GRS rounding, and overflow/underflow handling, plus `FP_EXP_MAX` constant for exponent bounds.
- Converted ALU to a multi-cycle unit in `src/mc68881_alu.vhd` with `clk`, `reset_n`, and `start` inputs, `busy`/`valid` outputs, latency constants (`ADD_LATENCY`, `MUL_LATENCY`, `DIV_LATENCY`), and a simple latency scheduler that asserts `valid` when the operation completes and `busy` while counting down cycles.
- Updated top-level glue in `src/mc68881_top.vhd` to drive the new ALU `start` signal, expose a status register at `ADDR_STATUS` with `valid`/`busy` bits, and preserve result readback behavior.
- Expanded and hardened testbenches `tb/tb_mc68881_alu.vhd` and `tb/tb_mc68881_top.vhd` to be self-checking by decomposing FP80 into sign/exp/mant fields for comparisons, poll the top-level status register for multi-cycle operations, measure and assert expected latency for add/sub/mul/div, and add diagnostic `report` messages on transactions.

### Testing

- No automated simulations were executed as part of this change; testbenches were added/updated to be self-checking and will fail simulations on mismatches or latency deviations. 
- The ALU and top-level testbenches include assertions that check FP80 fieldwise equality and explicit cycle-count latency checks for `ADD`, `SUB`, `MUL`, and `DIV`.
- The testbench updates follow the repository testbench standards (self-checking assertions, wait for DUT-valid before checking, and FP80 decomposition) and are ready to be run in the simulator of choice.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987252c613483219f9b5e3ad606e005)