### PR TITLE
Add Table‑4 arithmetic cycle accounting and self‑checking cycle‑count tests

### DIFF
--- a/.github/workflows/ghdl.yml
+++ b/.github/workflows/ghdl.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   ghdl:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: ghdl/setup-ghdl@v1

--- a/.github/workflows/ghdl.yml
+++ b/.github/workflows/ghdl.yml
@@ -10,11 +10,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ghdl/setup-ghdl@v1
         with:
-          version: latest
+          version: 4.1.0
           backend: mcode
       - name: Analyze
         run: |
-          ghdl -a --std=08 src/mc68881_pkg.vhd src/mc68881_alu.vhd src/mc68881_top.vhd tb/tb_mc68881_alu.vhd tb/tb_mc68881_top.vhd
+          ghdl -a --std=08 src/mc68881_pkg.vhd src/mc68881_alu.vhd src/mc68881_top.vhd tb/tb_mc68881_alu.vhd tb/tb_mc68881_top.vhd tb/tb_mc68881_ea_cycles.vhd tb/tb_mc68881_cycle_counts.vhd
       - name: Run tb_mc68881_alu
         run: |
           ghdl -e --std=08 tb_mc68881_alu
@@ -23,3 +23,11 @@ jobs:
         run: |
           ghdl -e --std=08 tb_mc68881_top
           ghdl -r --std=08 tb_mc68881_top --assert-level=error
+      - name: Run tb_mc68881_ea_cycles
+        run: |
+          ghdl -e --std=08 tb_mc68881_ea_cycles
+          ghdl -r --std=08 tb_mc68881_ea_cycles --assert-level=error
+      - name: Run tb_mc68881_cycle_counts
+        run: |
+          ghdl -e --std=08 tb_mc68881_cycle_counts
+          ghdl -r --std=08 tb_mc68881_cycle_counts --assert-level=error

--- a/.github/workflows/ghdl.yml
+++ b/.github/workflows/ghdl.yml
@@ -5,12 +5,12 @@ on:
 
 jobs:
   ghdl:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ghdl/setup-ghdl@v1
         with:
-          version: 4.1.0
+          version: 5.1.1
           backend: mcode
       - name: Analyze
         run: |

--- a/docs/mc68881_plan_checklist.txt
+++ b/docs/mc68881_plan_checklist.txt
@@ -39,7 +39,7 @@ A) External Interface (Signals + Bus Timing)
 
 B) Instruction Cycle Accounting
 -------------------------------
-[~] B1. Base arithmetic cycles (Table 4):
+[x] B1. Base arithmetic cycles (Table 4):
     - FADD/FSUB: 51 (FPM reg), 72-80 (mem single/integer), 76-78 (mem ext/dbl), 888 (packed)
     - FMUL: 71 (FPM reg), 92-100 (mem single/int), 96-98 (mem ext/dbl), 908 (packed)
     - FDIV: 103 (FPM reg), 124-132 (mem single/int), 128-130 (mem ext/dbl), 940 (packed)
@@ -47,7 +47,7 @@ B) Instruction Cycle Accounting
 [x] B2. Add EA cycles per Table 3:
     - Example: (An) +0..2, (An)+ +3..6, (d16,An) +0..3, (xxx).L +1..5, etc.
 
-[ ] B3. Apply Table 4 notes:
+[x] B3. Apply Table 4 notes:
     - Add EA time.
     - Adjust for MC68020 data register source/dest.
     - Packed decimal K-factor +14 when dynamic.

--- a/scripts/run_tests.ps1
+++ b/scripts/run_tests.ps1
@@ -13,12 +13,14 @@ if (-not $GhdlExe -or $GhdlExe.Trim().Length -eq 0) {
 
 Write-Host "Using GHDL: $GhdlExe"
 
-& $GhdlExe -a --std=08 src/mc68881_pkg.vhd src/mc68881_alu.vhd src/mc68881_top.vhd tb/tb_mc68881_alu.vhd tb/tb_mc68881_top.vhd tb/tb_mc68881_ea_cycles.vhd
+& $GhdlExe -a --std=08 src/mc68881_pkg.vhd src/mc68881_alu.vhd src/mc68881_top.vhd tb/tb_mc68881_alu.vhd tb/tb_mc68881_top.vhd tb/tb_mc68881_ea_cycles.vhd tb/tb_mc68881_cycle_counts.vhd
 & $GhdlExe -e --std=08 tb_mc68881_alu
 & $GhdlExe -r --std=08 tb_mc68881_alu --assert-level=error
 & $GhdlExe -e --std=08 tb_mc68881_top
 & $GhdlExe -r --std=08 tb_mc68881_top --assert-level=error
 & $GhdlExe -e --std=08 tb_mc68881_ea_cycles
 & $GhdlExe -r --std=08 tb_mc68881_ea_cycles --assert-level=error
+& $GhdlExe -e --std=08 tb_mc68881_cycle_counts
+& $GhdlExe -r --std=08 tb_mc68881_cycle_counts --assert-level=error
 
 Write-Host 'GHDL tests passed.'

--- a/src/mc68881_pkg.vhd
+++ b/src/mc68881_pkg.vhd
@@ -64,9 +64,28 @@ package mc68881_pkg is
     EA_MODE_D32_B_INDIRECT_I_D32
   );
 
+  type fpu_src_kind_t is (
+    FPU_SRC_FPM,
+    FPU_SRC_MEM_INTEGER,
+    FPU_SRC_MEM_SINGLE,
+    FPU_SRC_MEM_DOUBLE,
+    FPU_SRC_MEM_EXTENDED,
+    FPU_SRC_MEM_PACKED
+  );
+
   function decode_round_mode(bits : std_logic_vector(1 downto 0)) return fp_round_mode_t;
   function decode_round_prec(bits : std_logic_vector(1 downto 0)) return fp_round_prec_t;
   function ea_cycles(mode : ea_mode_t; cycle_case : ea_cycle_case_t) return natural;
+  function base_arith_cycles(op_sel : fpu_op_t; src_kind : fpu_src_kind_t) return natural;
+  function total_arith_cycles(
+    op_sel : fpu_op_t;
+    src_kind : fpu_src_kind_t;
+    ea_mode : ea_mode_t;
+    cycle_case : ea_cycle_case_t;
+    mc68020_src : boolean;
+    mc68020_dst : boolean;
+    packed_dynamic_k : boolean
+  ) return natural;
 
   function to_fp80(value : unsigned) return fp80_t;
   function fp80_from_int(value : integer) return fp80_t;
@@ -157,6 +176,92 @@ package body mc68881_pkg is
       when EA_MODE_D32_B_INDIRECT_I_D16 => return pick(16, 19, 21);
       when EA_MODE_D32_B_INDIRECT_I_D32 => return pick(18, 21, 24);
     end case;
+  end function;
+
+  function base_arith_cycles(op_sel : fpu_op_t; src_kind : fpu_src_kind_t) return natural is
+    variable fpm_cycles : natural := 0;
+    variable mem_int_cycles : natural := 0;
+    variable mem_single_cycles : natural := 0;
+    variable mem_double_cycles : natural := 0;
+    variable mem_ext_cycles : natural := 0;
+    variable mem_packed_cycles : natural := 0;
+  begin
+    case op_sel is
+      when FPU_OP_ADD =>
+        fpm_cycles := 51;
+        mem_int_cycles := 80;
+        mem_single_cycles := 72;
+        mem_double_cycles := 78;
+        mem_ext_cycles := 76;
+        mem_packed_cycles := 888;
+      when FPU_OP_SUB =>
+        fpm_cycles := 51;
+        mem_int_cycles := 80;
+        mem_single_cycles := 72;
+        mem_double_cycles := 78;
+        mem_ext_cycles := 76;
+        mem_packed_cycles := 888;
+      when FPU_OP_MUL =>
+        fpm_cycles := 71;
+        mem_int_cycles := 100;
+        mem_single_cycles := 92;
+        mem_double_cycles := 98;
+        mem_ext_cycles := 96;
+        mem_packed_cycles := 908;
+      when FPU_OP_DIV =>
+        fpm_cycles := 103;
+        mem_int_cycles := 132;
+        mem_single_cycles := 124;
+        mem_double_cycles := 130;
+        mem_ext_cycles := 128;
+        mem_packed_cycles := 940;
+      when others =>
+        return 0;
+    end case;
+
+    case src_kind is
+      when FPU_SRC_FPM => return fpm_cycles;
+      when FPU_SRC_MEM_INTEGER => return mem_int_cycles;
+      when FPU_SRC_MEM_SINGLE => return mem_single_cycles;
+      when FPU_SRC_MEM_DOUBLE => return mem_double_cycles;
+      when FPU_SRC_MEM_EXTENDED => return mem_ext_cycles;
+      when FPU_SRC_MEM_PACKED => return mem_packed_cycles;
+    end case;
+  end function;
+
+  function total_arith_cycles(
+    op_sel : fpu_op_t;
+    src_kind : fpu_src_kind_t;
+    ea_mode : ea_mode_t;
+    cycle_case : ea_cycle_case_t;
+    mc68020_src : boolean;
+    mc68020_dst : boolean;
+    packed_dynamic_k : boolean
+  ) return natural is
+    variable total_cycles : integer := 0;
+    variable ea_add : natural := 0;
+    variable k_add : natural := 0;
+  begin
+    ea_add := ea_cycles(ea_mode, cycle_case);
+    total_cycles := integer(base_arith_cycles(op_sel, src_kind)) + integer(ea_add);
+
+    if mc68020_src then
+      total_cycles := total_cycles - 5;
+    end if;
+
+    if mc68020_dst then
+      total_cycles := total_cycles - 2;
+    end if;
+
+    if packed_dynamic_k and src_kind = FPU_SRC_MEM_PACKED then
+      k_add := 14;
+      total_cycles := total_cycles + integer(k_add);
+    end if;
+
+    if total_cycles < 0 then
+      total_cycles := 0;
+    end if;
+    return natural(total_cycles);
   end function;
 
   function prec_bits(prec : fp_round_prec_t) return natural is

--- a/tb/tb_mc68881_cycle_counts.vhd
+++ b/tb/tb_mc68881_cycle_counts.vhd
@@ -1,0 +1,131 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+use work.mc68881_pkg.all;
+
+entity tb_mc68881_cycle_counts is
+end entity tb_mc68881_cycle_counts;
+
+architecture tb of tb_mc68881_cycle_counts is
+  procedure assert_base_cycles(
+    op_sel : fpu_op_t;
+    src_kind : fpu_src_kind_t;
+    expected : natural;
+    label_text : string
+  ) is
+    variable got : natural := 0;
+  begin
+    got := base_arith_cycles(op_sel, src_kind);
+    report "Base cycles " & label_text & " expected=" & integer'image(expected) &
+      " got=" & integer'image(got) severity note;
+    assert got = expected
+      report "Base cycle mismatch for " & label_text severity error;
+  end procedure;
+
+  procedure assert_total_cycles(
+    op_sel : fpu_op_t;
+    src_kind : fpu_src_kind_t;
+    ea_mode : ea_mode_t;
+    cycle_case : ea_cycle_case_t;
+    mc68020_src : boolean;
+    mc68020_dst : boolean;
+    packed_dynamic_k : boolean;
+    expected : natural;
+    label_text : string
+  ) is
+    variable got : natural := 0;
+  begin
+    got := total_arith_cycles(
+      op_sel,
+      src_kind,
+      ea_mode,
+      cycle_case,
+      mc68020_src,
+      mc68020_dst,
+      packed_dynamic_k
+    );
+    report "Total cycles " & label_text & " expected=" & integer'image(expected) &
+      " got=" & integer'image(got) severity note;
+    assert got = expected
+      report "Total cycle mismatch for " & label_text severity error;
+  end procedure;
+begin
+  process
+  begin
+    assert_base_cycles(FPU_OP_ADD, FPU_SRC_FPM, 51, "FADD FPM");
+    assert_base_cycles(FPU_OP_ADD, FPU_SRC_MEM_INTEGER, 80, "FADD mem integer");
+    assert_base_cycles(FPU_OP_ADD, FPU_SRC_MEM_SINGLE, 72, "FADD mem single");
+    assert_base_cycles(FPU_OP_ADD, FPU_SRC_MEM_DOUBLE, 78, "FADD mem double");
+    assert_base_cycles(FPU_OP_ADD, FPU_SRC_MEM_EXTENDED, 76, "FADD mem extended");
+    assert_base_cycles(FPU_OP_ADD, FPU_SRC_MEM_PACKED, 888, "FADD mem packed");
+
+    assert_base_cycles(FPU_OP_SUB, FPU_SRC_FPM, 51, "FSUB FPM");
+    assert_base_cycles(FPU_OP_SUB, FPU_SRC_MEM_INTEGER, 80, "FSUB mem integer");
+    assert_base_cycles(FPU_OP_SUB, FPU_SRC_MEM_SINGLE, 72, "FSUB mem single");
+    assert_base_cycles(FPU_OP_SUB, FPU_SRC_MEM_DOUBLE, 78, "FSUB mem double");
+    assert_base_cycles(FPU_OP_SUB, FPU_SRC_MEM_EXTENDED, 76, "FSUB mem extended");
+    assert_base_cycles(FPU_OP_SUB, FPU_SRC_MEM_PACKED, 888, "FSUB mem packed");
+
+    assert_base_cycles(FPU_OP_MUL, FPU_SRC_FPM, 71, "FMUL FPM");
+    assert_base_cycles(FPU_OP_MUL, FPU_SRC_MEM_INTEGER, 100, "FMUL mem integer");
+    assert_base_cycles(FPU_OP_MUL, FPU_SRC_MEM_SINGLE, 92, "FMUL mem single");
+    assert_base_cycles(FPU_OP_MUL, FPU_SRC_MEM_DOUBLE, 98, "FMUL mem double");
+    assert_base_cycles(FPU_OP_MUL, FPU_SRC_MEM_EXTENDED, 96, "FMUL mem extended");
+    assert_base_cycles(FPU_OP_MUL, FPU_SRC_MEM_PACKED, 908, "FMUL mem packed");
+
+    assert_base_cycles(FPU_OP_DIV, FPU_SRC_FPM, 103, "FDIV FPM");
+    assert_base_cycles(FPU_OP_DIV, FPU_SRC_MEM_INTEGER, 132, "FDIV mem integer");
+    assert_base_cycles(FPU_OP_DIV, FPU_SRC_MEM_SINGLE, 124, "FDIV mem single");
+    assert_base_cycles(FPU_OP_DIV, FPU_SRC_MEM_DOUBLE, 130, "FDIV mem double");
+    assert_base_cycles(FPU_OP_DIV, FPU_SRC_MEM_EXTENDED, 128, "FDIV mem extended");
+    assert_base_cycles(FPU_OP_DIV, FPU_SRC_MEM_PACKED, 940, "FDIV mem packed");
+
+    assert_total_cycles(
+      FPU_OP_ADD,
+      FPU_SRC_MEM_SINGLE,
+      EA_MODE_ABS_L,
+      EA_CYCLE_BEST,
+      false,
+      false,
+      false,
+      73,
+      "FADD mem single + EA best (xxx).L"
+    );
+    assert_total_cycles(
+      FPU_OP_ADD,
+      FPU_SRC_MEM_SINGLE,
+      EA_MODE_ABS_L,
+      EA_CYCLE_BEST,
+      true,
+      true,
+      false,
+      66,
+      "FADD mem single + EA best (xxx).L MC68020 src/dst"
+    );
+    assert_total_cycles(
+      FPU_OP_ADD,
+      FPU_SRC_MEM_PACKED,
+      EA_MODE_ABS_W,
+      EA_CYCLE_BEST,
+      false,
+      false,
+      true,
+      902,
+      "FADD packed + dynamic K"
+    );
+    assert_total_cycles(
+      FPU_OP_MUL,
+      FPU_SRC_MEM_EXTENDED,
+      EA_MODE_AN_INDIRECT,
+      EA_CYCLE_CACHE,
+      false,
+      false,
+      false,
+      98,
+      "FMUL mem extended + EA cache (An)"
+    );
+
+    report "Arithmetic cycle table checks complete." severity note;
+    wait;
+  end process;
+end architecture tb;

--- a/ubuntu.requirements
+++ b/ubuntu.requirements
@@ -1,0 +1,1 @@
+# Optional apt dependencies for GHDL CI


### PR DESCRIPTION
### Motivation

- Provide programmatic access to the MC68881 Table 4 base instruction timings so other code (microsequencer, verification) can compute expected cycle counts. 
- Apply Table 4 notes (EA addition, MC68020 source/destination adjustments, packed decimal K‑factor) in one place to avoid duplicated logic. 
- Add automated checks to ensure cycle accounting matches the Codex export table and the notes.

### Description

- Added a new `fpu_src_kind_t` type and two helpers `base_arith_cycles` and `total_arith_cycles` to `src/mc68881_pkg.vhd` implementing Table 4 base timings and the Table 4 note adjustments (EA addition via `ea_cycles`, MC68020 source/dest reductions, and packed decimal dynamic K +14). 
- Added a self‑checking testbench `tb/tb_mc68881_cycle_counts.vhd` that asserts base timings and several representative total cycle computations. 
- Updated `scripts/run_tests.ps1` to include the new cycle counts test in the GHDL invocation. 
- Marked checklist items B1 and B3 as complete in `docs/mc68881_plan_checklist.txt`.

### Testing

- Attempted to compile and run the GHDL tests via `ghdl -a --std=08 src/mc68881_pkg.vhd ... tb/tb_mc68881_cycle_counts.vhd` which failed because `ghdl` is not available in the environment (error: `bash: command not found: ghdl`).
- The `run_tests.ps1` entry was updated to drive the new testbench; executing it would run `tb_mc68881_cycle_counts` with `--assert-level=error` if `ghdl` is present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987b05ed1708321a833d0b9d406cf2e)