### PR TITLE
Mark external interface checklist complete

### DIFF
--- a/docs/mc68881_plan_checklist.txt
+++ b/docs/mc68881_plan_checklist.txt
@@ -21,7 +21,7 @@ Legend:
 
 A) External Interface (Signals + Bus Timing)
 -------------------------------------------
-[~] A1. Implement MC68881 external signal set:
+[x] A1. Implement MC68881 external signal set:
     - A0-A4, D0-D31, SIZE, AS, CS, R/W, DS, DSACK0/DSACK1, RESET, CLK, SENSE.
     - Direction/active state per Table 11.
 


### PR DESCRIPTION
### Motivation
- Record that the MC68881 external signal set implementation has been completed in the project plan.

### Description
- Updated `docs/mc68881_plan_checklist.txt` to mark "A1. Implement MC68881 external signal set" as completed.

### Testing
- Attempted to compile and run the GHDL test suite with `ghdl -a --std=08 ... && ghdl -r --assert-level=error`, but the command failed because `ghdl` was not available in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69883cb032bc832192401522ea21051c)