### PR TITLE
Improve microsequencer extensibility and add package-level tests

### DIFF
--- a/src/mc68881_pkg.vhd
+++ b/src/mc68881_pkg.vhd
@@ -19,6 +19,11 @@ package mc68881_pkg is
     FPU_OP_DIV
   );
 
+  type fpu_op_class_t is (
+    OP_CLASS_NONE,
+    OP_CLASS_ARITH
+  );
+
   type fp_round_mode_t is (
     FP_RND_NEAREST,
     FP_RND_ZERO,
@@ -75,9 +80,20 @@ package mc68881_pkg is
 
   function decode_round_mode(bits : std_logic_vector(1 downto 0)) return fp_round_mode_t;
   function decode_round_prec(bits : std_logic_vector(1 downto 0)) return fp_round_prec_t;
+  function decode_op_sel(bits : std_logic_vector(2 downto 0)) return fpu_op_t;
+  function op_class(op_sel : fpu_op_t) return fpu_op_class_t;
   function ea_cycles(mode : ea_mode_t; cycle_case : ea_cycle_case_t) return natural;
   function base_arith_cycles(op_sel : fpu_op_t; src_kind : fpu_src_kind_t) return natural;
   function total_arith_cycles(
+    op_sel : fpu_op_t;
+    src_kind : fpu_src_kind_t;
+    ea_mode : ea_mode_t;
+    cycle_case : ea_cycle_case_t;
+    mc68020_src : boolean;
+    mc68020_dst : boolean;
+    packed_dynamic_k : boolean
+  ) return natural;
+  function op_cycle_count(
     op_sel : fpu_op_t;
     src_kind : fpu_src_kind_t;
     ea_mode : ea_mode_t;
@@ -115,6 +131,15 @@ package body mc68881_pkg is
   constant FP_MANT_EXT_WIDTH : natural := FP_MANT_WIDTH + FP_GRS_BITS;
   constant FP_EXP_ALL_ONES : unsigned(FP_EXP_WIDTH-1 downto 0) := (others => '1');
   constant FP_EXP_MAX : integer := (2**FP_EXP_WIDTH) - 1;
+  type op_decode_table_t is array (0 to 7) of fpu_op_t;
+  constant OP_DECODE_TABLE : op_decode_table_t := (
+    0 => FPU_OP_NOP,
+    1 => FPU_OP_ADD,
+    2 => FPU_OP_SUB,
+    3 => FPU_OP_MUL,
+    4 => FPU_OP_DIV,
+    others => FPU_OP_NOP
+  );
 
   type fp_unpacked_t is record
     sign : std_logic;
@@ -139,6 +164,26 @@ package body mc68881_pkg is
       when "01" => return FP_PREC_SINGLE;
       when "10" => return FP_PREC_DOUBLE;
       when others => return FP_PREC_RESERVED;
+    end case;
+  end function;
+
+  function decode_op_sel(bits : std_logic_vector(2 downto 0)) return fpu_op_t is
+    variable idx : natural := 0;
+  begin
+    idx := to_integer(unsigned(bits));
+    if idx <= OP_DECODE_TABLE'high then
+      return OP_DECODE_TABLE(idx);
+    end if;
+    return FPU_OP_NOP;
+  end function;
+
+  function op_class(op_sel : fpu_op_t) return fpu_op_class_t is
+  begin
+    case op_sel is
+      when FPU_OP_ADD | FPU_OP_SUB | FPU_OP_MUL | FPU_OP_DIV =>
+        return OP_CLASS_ARITH;
+      when others =>
+        return OP_CLASS_NONE;
     end case;
   end function;
 
@@ -262,6 +307,32 @@ package body mc68881_pkg is
       total_cycles := 0;
     end if;
     return natural(total_cycles);
+  end function;
+
+  function op_cycle_count(
+    op_sel : fpu_op_t;
+    src_kind : fpu_src_kind_t;
+    ea_mode : ea_mode_t;
+    cycle_case : ea_cycle_case_t;
+    mc68020_src : boolean;
+    mc68020_dst : boolean;
+    packed_dynamic_k : boolean
+  ) return natural is
+  begin
+    case op_class(op_sel) is
+      when OP_CLASS_ARITH =>
+        return total_arith_cycles(
+          op_sel,
+          src_kind,
+          ea_mode,
+          cycle_case,
+          mc68020_src,
+          mc68020_dst,
+          packed_dynamic_k
+        );
+      when others =>
+        return 0;
+    end case;
   end function;
 
   function prec_bits(prec : fp_round_prec_t) return natural is

--- a/src/mc68881_pkg.vhd
+++ b/src/mc68881_pkg.vhd
@@ -170,6 +170,9 @@ package body mc68881_pkg is
   function decode_op_sel(bits : std_logic_vector(2 downto 0)) return fpu_op_t is
     variable idx : natural := 0;
   begin
+    if is_x(bits) then
+      return FPU_OP_NOP;
+    end if;
     idx := to_integer(unsigned(bits));
     if idx <= OP_DECODE_TABLE'high then
       return OP_DECODE_TABLE(idx);

--- a/src/mc68881_top.vhd
+++ b/src/mc68881_top.vhd
@@ -314,13 +314,7 @@ begin
       if bus_write = '1' then
         case addr is
           when ADDR_OPSEL =>
-            case d_in(2 downto 0) is
-              when "001" => op_sel_next := FPU_OP_ADD;
-              when "010" => op_sel_next := FPU_OP_SUB;
-              when "011" => op_sel_next := FPU_OP_MUL;
-              when "100" => op_sel_next := FPU_OP_DIV;
-              when others => op_sel_next := FPU_OP_NOP;
-            end case;
+            op_sel_next := decode_op_sel(d_in(2 downto 0));
             op_sel <= op_sel_next;
             if micro_active = '0' and frame_busy = '0' and busy = '0' then
               if op_sel_next /= FPU_OP_NOP then
@@ -329,7 +323,7 @@ begin
                 result_ready <= '0';
                 last_op_sel <= op_sel_next;
                 micro_active <= '1';
-                total_cycles := total_arith_cycles(
+                total_cycles := op_cycle_count(
                   op_sel_next,
                   src_kind_reg,
                   ea_mode_reg,

--- a/tb/mc68881_microseq_tb.vhd
+++ b/tb/mc68881_microseq_tb.vhd
@@ -1,0 +1,60 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+use work.mc68881_pkg.all;
+
+entity mc68881_microseq_tb is
+end entity mc68881_microseq_tb;
+
+architecture sim of mc68881_microseq_tb is
+begin
+  process
+    variable cycles : natural := 0;
+  begin
+    report "Starting microsequencer package tests." severity note;
+
+    assert decode_op_sel("001") = FPU_OP_ADD
+      report "decode_op_sel ADD mapping failed." severity failure;
+    assert decode_op_sel("010") = FPU_OP_SUB
+      report "decode_op_sel SUB mapping failed." severity failure;
+    assert decode_op_sel("011") = FPU_OP_MUL
+      report "decode_op_sel MUL mapping failed." severity failure;
+    assert decode_op_sel("100") = FPU_OP_DIV
+      report "decode_op_sel DIV mapping failed." severity failure;
+    assert decode_op_sel("111") = FPU_OP_NOP
+      report "decode_op_sel default mapping failed." severity failure;
+
+    assert op_class(FPU_OP_ADD) = OP_CLASS_ARITH
+      report "op_class ADD mapping failed." severity failure;
+    assert op_class(FPU_OP_NOP) = OP_CLASS_NONE
+      report "op_class NOP mapping failed." severity failure;
+
+    cycles := op_cycle_count(
+      FPU_OP_ADD,
+      FPU_SRC_FPM,
+      EA_MODE_DN_AN,
+      EA_CYCLE_BEST,
+      false,
+      false,
+      false
+    );
+    assert cycles = 51
+      report "op_cycle_count ADD baseline mismatch." severity failure;
+
+    cycles := op_cycle_count(
+      FPU_OP_DIV,
+      FPU_SRC_MEM_PACKED,
+      EA_MODE_AN_POSTINC,
+      EA_CYCLE_WORST,
+      true,
+      true,
+      true
+    );
+    assert cycles = 953
+      report "op_cycle_count DIV packed mismatch." severity failure;
+
+    report "Microsequencer package tests completed." severity note;
+    wait;
+  end process;
+end architecture sim;


### PR DESCRIPTION
### Motivation

- Centralize operation decoding and cycle-count dispatch so the microsequencer can be extended without editing top-level logic. 
- Provide a clear op-class abstraction to separate arithmetic ops from other classes and simplify dispatch policy. 
- Add automated checks to prevent regressions in op decoding and cycle-calculation logic.

### Description

- Introduced `fpu_op_class_t` and `op_class` to classify operations and added a table-driven `OP_DECODE_TABLE` with `decode_op_sel` for opcode-to-op mapping in `src/mc68881_pkg.vhd`. 
- Added `op_cycle_count` in the package which dispatches to `total_arith_cycles` for arithmetic classes, and replaced inline op-specific dispatch in the top-level with calls to `decode_op_sel` and `op_cycle_count` in `src/mc68881_top.vhd`. 
- Added a self-checking VHDL testbench `tb/mc68881_microseq_tb.vhd` that validates `decode_op_sel`, `op_class`, and representative `op_cycle_count` results. 

### Testing

- Compiled and ran the package and testbench with `ghdl -a --std=08 src/mc68881_pkg.vhd`, `ghdl -a --std=08 tb/mc68881_microseq_tb.vhd`, `ghdl -e --std=08 mc68881_microseq_tb`, and `ghdl -r --std=08 mc68881_microseq_tb`, and all steps completed successfully. 
- The testbench emitted the expected start and completion reports and no assertion failures were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988a16b47f083219f84436513d1dc0b)