### PR TITLE
Drive SENSE from core busy signal and add idle assertions to top testbench

### DIFF
--- a/src/mc68881_top.vhd
+++ b/src/mc68881_top.vhd
@@ -39,6 +39,7 @@ architecture rtl of mc68881_top is
   signal status_busy  : std_logic := '0';
   signal status_frame_valid : std_logic := '0';
   signal status_frame_busy  : std_logic := '0';
+  signal sense_drive : std_logic := '1';
   signal fpcr_reg  : std_logic_vector(31 downto 0) := (others => '0');
   signal fpsr_reg  : std_logic_vector(31 downto 0) := (others => '0');
   signal round_mode : fp_round_mode_t := FP_RND_NEAREST;
@@ -638,5 +639,6 @@ begin
   d_out <= d_out_reg when sync_read = '1' else d_out_comb;
   dsack0_n <= dsack0_i;
   dsack1_n <= dsack1_i;
-  sense_n  <= 'Z';
+  sense_drive <= '0' when status_busy = '1' else '1';
+  sense_n  <= sense_drive;
 end architecture rtl;

--- a/tb/tb_mc68881_top.vhd
+++ b/tb/tb_mc68881_top.vhd
@@ -176,6 +176,53 @@ architecture sim of tb_mc68881_top is
     end loop;
   end procedure;
 
+  procedure wait_for_sense(
+    signal sense_n_s : in std_logic;
+    constant expected : std_logic;
+    constant test_name : string
+  ) is
+    variable seen : boolean := false;
+  begin
+    for idx in 0 to 200 loop
+      wait for CLK_PERIOD;
+      if sense_n_s = expected then
+        seen := true;
+        exit;
+      end if;
+    end loop;
+    assert seen
+      report "SENSE did not reach expected state for " & test_name &
+             " expected=" & std_logic'image(expected) &
+             " got=" & std_logic'image(sense_n_s)
+      severity failure;
+    report "SENSE state: " & test_name &
+           " value=" & std_logic'image(sense_n_s)
+      severity note;
+  end procedure;
+
+  procedure assert_idle_outputs(
+    signal dsack0_n_s : in std_logic;
+    signal dsack1_n_s : in std_logic;
+    signal sense_n_s  : in std_logic;
+    constant test_name : string
+  ) is
+  begin
+    assert dsack0_n_s = '1' and dsack1_n_s = '1'
+      report "DSACK lines should be deasserted during idle for " & test_name &
+             " dsack1_n=" & std_logic'image(dsack1_n_s) &
+             " dsack0_n=" & std_logic'image(dsack0_n_s)
+      severity failure;
+    assert sense_n_s = '1'
+      report "SENSE should be deasserted during idle for " & test_name &
+             " sense_n=" & std_logic'image(sense_n_s)
+      severity failure;
+    report "Idle output check: " & test_name &
+           " dsack1_n=" & std_logic'image(dsack1_n_s) &
+           " dsack0_n=" & std_logic'image(dsack0_n_s) &
+           " sense_n=" & std_logic'image(sense_n_s)
+      severity note;
+  end procedure;
+
 begin
   clk <= not clk after CLK_PERIOD/2;
   cycle_counter : process(clk)
@@ -212,6 +259,7 @@ begin
     wait for 2 * CLK_PERIOD;
     reset_n <= '1';
     wait for 2 * CLK_PERIOD;
+    assert_idle_outputs(dsack0_n, dsack1_n, sense_n, "post-reset idle");
 
     -- Write operands and op select (ADD)
     size_n <= "11";
@@ -232,7 +280,9 @@ begin
     bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(5, 5), op_b(63 downto 32));
     bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(6, 5), x"0000" & op_b(79 downto 64));
     bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(0, 5), x"00000001");
+    wait_for_sense(sense_n, '0', "busy assert after ADD start");
     wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
+    wait_for_sense(sense_n, '1', "idle deassert after ADD completion");
 
     bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_lo, to_unsigned(7, 5));
     bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_hi, to_unsigned(8, 5));
@@ -577,6 +627,7 @@ begin
     as_n <= '1';
     ds_n <= '1';
     wait for CLK_PERIOD;
+    assert_idle_outputs(dsack0_n, dsack1_n, sense_n, "post-DSACK tests idle");
 
     report "TB SUCCESS: all checks passed"
       severity note;


### PR DESCRIPTION
### Motivation
- Ensure deterministic external SENSE behavior by driving it from the core busy status instead of leaving it tri-stated. 
- Prevent regressions by adding self-checking testbench assertions for SENSE and DSACK idle states.

### Description
- In `src/mc68881_top.vhd` add an internal `sense_drive` signal and drive the `sense_n` port from the core `status_busy` signal so SENSE reflects busy/idle (`'0'` = busy, `'1'` = idle) rather than remaining `Z`.
- In `tb/tb_mc68881_top.vhd` add `wait_for_sense` and `assert_idle_outputs` procedures and insert checks that verify `sense_n` and `dsack0_n`/`dsack1_n` are deasserted after reset and after DSACK test sequences, and that SENSE asserts when an operation starts and deasserts after completion.
- Update test flow to call the new checks around the ADD case and after DSACK exercises.

### Testing
- Compiled with `ghdl -a --std=08` and elaborated and ran the full suite of testbenches including `tb_mc68881_alu`, `tb_mc68881_fpcr_fpsr`, `tb_mc68881_top`, `mc68881_microseq_tb`, `tb_mc68881_cycle_counts`, and `tb_mc68881_ea_cycles`.
- All simulated testbenches ran to completion and reported their self-checking messages (including `TB SUCCESS`), and the new SENSE checks observed assertion on start and deassertion on completion as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988a6d7c2288321a02f591258f24424)