### PR TITLE
B6 FScc Progress + Timing Stabilization (modpost/trig/divrem)

### DIFF
--- a/docs/fpu-progress-checklist.md
+++ b/docs/fpu-progress-checklist.md
@@ -83,10 +83,13 @@ B) Functional Completeness (Core Missing Ops)
     - Done: FETOX, FETOXM1, FLOGN, FLOGNP1, FLOG10, FLOG2.
     - Done: FSINH, FTANH, FTENTOX, FTWOTOX.
 
-[ ] B6. Implement program-control instruction set (guide section 3.3.4).
+[~] B6. Implement program-control instruction set (guide section 3.3.4).
     - FBcc, FDBcc, FScc, FNOP.
     - Ordered/unordered condition-code variants and NaN behavior.
     - FPU condition-code generation from FCMP/FTST results.
+    - In progress: core-v1 decode/class metadata added for FScc/FBcc/FDBcc.
+      FScc now evaluates FPSR CC flags and returns byte true/false in result low byte.
+      FBcc/FDBcc remain placeholders pending branch/decrement dialog wiring.
 
 [ ] B7. Implement system-control instruction set (guide section 3.3.5).
     - FSAVE, FRESTORE.

--- a/project/fpga68881/fpga68881.xpr
+++ b/project/fpga68881/fpga68881.xpr
@@ -298,7 +298,7 @@
       <Report Name="ROUTE_DESIGN.REPORT_METHODOLOGY" Enabled="1"/>
       <RQSFiles/>
     </Run>
-    <Run Id="impl_1" Type="Ft2:EntireDesign" Part="xc7a200tfbg676-1" ConstrsSet="constrs_1" Description="Default settings for Implementation." AutoIncrementalCheckpoint="false" WriteIncrSynthDcp="false" State="current" Dir="$PRUNDIR/impl_1" SynthRun="synth_1" IncludeInArchive="true" IsChild="false" GenFullBitstream="true" AutoIncrementalDir="$PSRCDIR/utils_1/imports/impl_1" LaunchOptions="-jobs 1 " AutoRQSDir="$PSRCDIR/utils_1/imports/impl_1" ParallelReportGen="true">
+    <Run Id="impl_1" Type="Ft2:EntireDesign" Part="xc7a200tfbg676-1" ConstrsSet="constrs_1" Description="Default settings for Implementation." AutoIncrementalCheckpoint="false" WriteIncrSynthDcp="false" State="current" Dir="$PRUNDIR/impl_1" SynthRun="synth_1" IncludeInArchive="true" IsChild="false" GenFullBitstream="true" AutoIncrementalDir="$PSRCDIR/utils_1/imports/impl_1" LaunchOptions="-jobs 17 " AutoRQSDir="$PSRCDIR/utils_1/imports/impl_1" ParallelReportGen="true">
       <Strategy Version="1" Minor="2">
         <StratHandle Name="Vivado Implementation Defaults" Flow="Vivado Implementation 2025"/>
         <Step Id="init_design"/>

--- a/src/mc68881_alu.vhd
+++ b/src/mc68881_alu.vhd
@@ -177,7 +177,7 @@ architecture rtl of mc68881_alu is
   signal simple_op_reg : fpu_op_t := FPU_OP_NOP;
   signal simple_rm_reg : fp_round_mode_t := FP_RND_NEAREST;
   signal simple_rp_reg : fp_round_prec_t := FP_PREC_EXTENDED;
-  signal simple_hold_count_reg : integer range 0 to 3 := 0;  -- multi-cycle hold for FP settle
+  signal simple_hold_count_reg : integer range 0 to 4 := 0;  -- multi-cycle hold for FP settle
 
 begin
   trig_inst : entity work.mc68881_trig_unit
@@ -391,7 +391,7 @@ begin
           end if;
         else
           -- Simple ops path: compute heavy ops from registered operands
-          -- Multi-cycle hold: skip 1 cycle to let combinational FP settle.
+          -- Multi-cycle hold: wait configured cycles to let combinational FP settle.
           if simple_compute_pending_reg = '1' then
             if simple_hold_count_reg > 0 then
               simple_hold_count_reg <= simple_hold_count_reg - 1;
@@ -437,7 +437,7 @@ begin
           simple_rm_reg <= round_mode;
           simple_rp_reg <= round_prec;
           simple_compute_pending_reg <= '1';
-          simple_hold_count_reg <= 3;  -- 3 skip cycles + compute = MCP 4 (budget 400ns)
+          simple_hold_count_reg <= 4;  -- 4 skip cycles + compute = MCP 5 (budget 500ns)
           busy_reg <= '1';
           if op_alu_latency(op_sel) <= 1 then
             latency_count_reg <= 1;

--- a/src/mc68881_divrem_unit.vhd
+++ b/src/mc68881_divrem_unit.vhd
@@ -251,6 +251,16 @@ architecture rtl of mc68881_divrem_unit is
     return pack_fp80(res);
   end function;
 
+  function highest_one_index(value : unsigned(FP_MANT_WIDTH-1 downto 0)) return natural is
+  begin
+    for idx in value'high downto value'low loop
+      if value(idx) = '1' then
+        return idx;
+      end if;
+    end loop;
+    return 0;
+  end function;
+
   function fp80_trunc_toward_zero_local(value : fp80_t) return fp80_t is
     variable value_u : fp_unpacked_t := unpack_fp80(value);
     variable exp_i : integer := 0;
@@ -391,6 +401,7 @@ begin
     variable div_round_mode : fp_round_mode_t := FP_RND_NEAREST;
     variable div_round_prec : fp_round_prec_t := FP_PREC_EXTENDED;
     variable mantissa_even : unsigned(SQRT_MANT_EVEN_WIDTH-1 downto 0) := (others => '0');
+    variable sqrt_norm_shift : natural := 0;
   begin
     if reset_n = '0' then
       state_reg <= ST_IDLE;
@@ -500,13 +511,12 @@ begin
               state_reg <= ST_DONE;
             else
               if a_u.exp = 0 then
-                exp_unbiased := 1 - FP_EXP_BIAS;
-                mantissa_even := resize(a_u.mant, SQRT_MANT_EVEN_WIDTH);
-                for idx in 0 to FP_MANT_WIDTH-1 loop
-                  exit when mantissa_even(mantissa_even'left) = '1';
-                  mantissa_even := shift_left(mantissa_even, 1);
-                  exp_unbiased := exp_unbiased - 1;
-                end loop;
+                -- Subnormal normalization: replace iterative shift loop with
+                -- direct leading-one index decode to shorten this timing cone.
+                lead_idx := highest_one_index(a_u.mant);
+                sqrt_norm_shift := natural(SQRT_MANT_EVEN_WIDTH - 1 - lead_idx);
+                exp_unbiased := (1 - FP_EXP_BIAS) - integer(sqrt_norm_shift);
+                mantissa_even := shift_left(resize(a_u.mant, SQRT_MANT_EVEN_WIDTH), sqrt_norm_shift);
               else
                 exp_unbiased := to_integer(a_u.exp) - FP_EXP_BIAS;
                 mantissa_even := resize(a_u.mant, SQRT_MANT_EVEN_WIDTH);

--- a/src/mc68881_divrem_unit.vhd
+++ b/src/mc68881_divrem_unit.vhd
@@ -515,6 +515,11 @@ begin
                 -- direct leading-one index decode to shorten this timing cone.
                 lead_idx := highest_one_index(a_u.mant);
                 sqrt_norm_shift := natural(SQRT_MANT_EVEN_WIDTH - 1 - lead_idx);
+                -- Match legacy bounded-loop behavior (max FP_MANT_WIDTH shifts)
+                -- so the smallest subnormal does not over-shift to zero.
+                if sqrt_norm_shift > FP_MANT_WIDTH then
+                  sqrt_norm_shift := FP_MANT_WIDTH;
+                end if;
                 exp_unbiased := (1 - FP_EXP_BIAS) - integer(sqrt_norm_shift);
                 mantissa_even := shift_left(resize(a_u.mant, SQRT_MANT_EVEN_WIDTH), sqrt_norm_shift);
               else

--- a/src/mc68881_modrem_post_unit.vhd
+++ b/src/mc68881_modrem_post_unit.vhd
@@ -248,11 +248,11 @@ begin
             state_reg <= ST_FP_ADD;
           end if;
 
-        -- Registered FP add: 1 load + 2 hold + 1 compute = MCP 4 (400ns budget)
+        -- Registered FP add: 1 load + 3 hold + 1 compute = MCP 5 (500ns budget)
         when ST_FP_ADD =>
           if fp_hold_loaded_reg = '0' then
             fp_hold_loaded_reg <= '1';
-            mod_fp_wait_count_reg <= 2;
+            mod_fp_wait_count_reg <= 3;
           elsif mod_fp_wait_count_reg = 0 then
             mod_add_result_reg <= add_sub_fp80(mod_fp_add_a, mod_fp_add_b,
                                                mod_fp_add_is_sub, mod_fp_add_rm, mod_fp_add_rp);

--- a/src/mc68881_pkg.vhd
+++ b/src/mc68881_pkg.vhd
@@ -70,6 +70,9 @@ package mc68881_pkg is
     FPU_OP_TST,
     FPU_OP_MOVE,
     FPU_OP_MOVEM,
+    FPU_OP_FSCC,
+    FPU_OP_FBCC,
+    FPU_OP_FDBCC,
     FPU_OP_FNOP,
     FPU_OP_FSAVE,
     FPU_OP_FRESTORE
@@ -861,6 +864,27 @@ package body mc68881_pkg is
         FPU_SRC_FPM => 16, FPU_SRC_MEM_INTEGER => 20, FPU_SRC_MEM_SINGLE => 20,
         FPU_SRC_MEM_DOUBLE => 22, FPU_SRC_MEM_EXTENDED => 24, FPU_SRC_MEM_PACKED => 20
       )
+    ),
+    FPU_OP_FSCC => (
+      legacy_decode_id_valid => false, legacy_decode_id => 0,
+      core_v1_decode_id_valid => true, core_v1_decode_id => x"21",
+      op_class => OP_CLASS_PROG_CTRL, alu_latency => 0, cycle_model => OP_CYCLE_ZERO,
+      exception_policy => EXC_POLICY_NONE,
+      arith_cycles => SRC_CYCLES_ZERO, move_cycles => SRC_CYCLES_ZERO
+    ),
+    FPU_OP_FBCC => (
+      legacy_decode_id_valid => false, legacy_decode_id => 0,
+      core_v1_decode_id_valid => true, core_v1_decode_id => x"22",
+      op_class => OP_CLASS_PROG_CTRL, alu_latency => 0, cycle_model => OP_CYCLE_ZERO,
+      exception_policy => EXC_POLICY_NONE,
+      arith_cycles => SRC_CYCLES_ZERO, move_cycles => SRC_CYCLES_ZERO
+    ),
+    FPU_OP_FDBCC => (
+      legacy_decode_id_valid => false, legacy_decode_id => 0,
+      core_v1_decode_id_valid => true, core_v1_decode_id => x"23",
+      op_class => OP_CLASS_PROG_CTRL, alu_latency => 0, cycle_model => OP_CYCLE_ZERO,
+      exception_policy => EXC_POLICY_NONE,
+      arith_cycles => SRC_CYCLES_ZERO, move_cycles => SRC_CYCLES_ZERO
     ),
     FPU_OP_FNOP => (
       legacy_decode_id_valid => false, legacy_decode_id => 0,

--- a/src/mc68881_pkg.vhd
+++ b/src/mc68881_pkg.vhd
@@ -505,7 +505,7 @@ package body mc68881_pkg is
     FPU_OP_MOD => (
       legacy_decode_id_valid => true, legacy_decode_id => 8,
       core_v1_decode_id_valid => true, core_v1_decode_id => x"08",
-      op_class => OP_CLASS_ARITH, alu_latency => 84, cycle_model => OP_CYCLE_ARITH,
+      op_class => OP_CLASS_ARITH, alu_latency => 85, cycle_model => OP_CYCLE_ARITH,
       exception_policy => EXC_POLICY_MOD_REM,
       arith_cycles => (
         FPU_SRC_FPM => 109, FPU_SRC_MEM_INTEGER => 138, FPU_SRC_MEM_SINGLE => 130,
@@ -516,7 +516,7 @@ package body mc68881_pkg is
     FPU_OP_REM => (
       legacy_decode_id_valid => true, legacy_decode_id => 9,
       core_v1_decode_id_valid => true, core_v1_decode_id => x"09",
-      op_class => OP_CLASS_ARITH, alu_latency => 94, cycle_model => OP_CYCLE_ARITH,
+      op_class => OP_CLASS_ARITH, alu_latency => 97, cycle_model => OP_CYCLE_ARITH,
       exception_policy => EXC_POLICY_MOD_REM,
       arith_cycles => (
         FPU_SRC_FPM => 109, FPU_SRC_MEM_INTEGER => 138, FPU_SRC_MEM_SINGLE => 130,

--- a/src/mc68881_top.vhd
+++ b/src/mc68881_top.vhd
@@ -558,6 +558,8 @@ architecture rtl of mc68881_top is
     variable greater_than : boolean := false;
     variable less_than : boolean := false;
     variable equal_to : boolean := false;
+    -- Mirror upper 32 condition codes to lower 32 per MC68881 architecture
+    variable sel : std_logic_vector(5 downto 0);
   begin
     nan_set := cc_bits(0) = '1';
     inf_set := cc_bits(1) = '1';
@@ -567,9 +569,10 @@ architecture rtl of mc68881_top is
     ordered := not unordered;
     equal_to := ordered and zero_set;
     greater_than := ordered and (not zero_set) and (not neg_set);
-    less_than := ordered and neg_set;
+    less_than := ordered and neg_set and (not zero_set);
 
-    case condition_sel is
+    sel := '0' & condition_sel(4 downto 0);
+    case sel is
       when "000000" => return '0'; -- F
       when "000001" => if equal_to then return '1'; else return '0'; end if; -- EQ
       when "000010" => if greater_than then return '1'; else return '0'; end if; -- OGT
@@ -1156,6 +1159,9 @@ begin
             end if;
           when OP_CLASS_PROG_CTRL =>
             -- Program-control opcodes complete without ALU launch.
+            result_lo_reg <= (others => '0');
+            result_hi_reg <= (others => '0');
+            result_ex_reg <= (others => '0');
             if op_sel_write_decoded = FPU_OP_FSCC then
               cc_field := fpsr_reg(FPSR_CC_NEG downto FPSR_CC_NAN);
               cond_true := eval_fcc_condition(operand_reg(0)(5 downto 0), cc_field);
@@ -1164,8 +1170,6 @@ begin
                 prog_result(7 downto 0) := x"FF";
               end if;
               result_lo_reg <= prog_result;
-              result_hi_reg <= (others => '0');
-              result_ex_reg <= (others => '0');
             end if;
             result_ready_reg <= '1';
           when OP_CLASS_SYS_CTRL =>

--- a/src/mc68881_top.vhd
+++ b/src/mc68881_top.vhd
@@ -545,6 +545,66 @@ architecture rtl of mc68881_top is
     return cc_bits;
   end function;
 
+  function eval_fcc_condition(
+    condition_sel : std_logic_vector(5 downto 0);
+    cc_bits : std_logic_vector(3 downto 0)
+  ) return std_logic is
+    variable nan_set : boolean := false;
+    variable inf_set : boolean := false;
+    variable zero_set : boolean := false;
+    variable neg_set : boolean := false;
+    variable unordered : boolean := false;
+    variable ordered : boolean := false;
+    variable greater_than : boolean := false;
+    variable less_than : boolean := false;
+    variable equal_to : boolean := false;
+  begin
+    nan_set := cc_bits(0) = '1';
+    inf_set := cc_bits(1) = '1';
+    zero_set := cc_bits(2) = '1';
+    neg_set := cc_bits(3) = '1';
+    unordered := nan_set;
+    ordered := not unordered;
+    equal_to := ordered and zero_set;
+    greater_than := ordered and (not zero_set) and (not neg_set);
+    less_than := ordered and neg_set;
+
+    case condition_sel is
+      when "000000" => return '0'; -- F
+      when "000001" => if equal_to then return '1'; else return '0'; end if; -- EQ
+      when "000010" => if greater_than then return '1'; else return '0'; end if; -- OGT
+      when "000011" => if greater_than or equal_to then return '1'; else return '0'; end if; -- OGE
+      when "000100" => if less_than then return '1'; else return '0'; end if; -- OLT
+      when "000101" => if less_than or equal_to then return '1'; else return '0'; end if; -- OLE
+      when "000110" => if greater_than or less_than then return '1'; else return '0'; end if; -- OGL
+      when "000111" => if ordered then return '1'; else return '0'; end if; -- OR
+      when "001000" => if unordered then return '1'; else return '0'; end if; -- UN
+      when "001001" => if unordered or equal_to then return '1'; else return '0'; end if; -- UEQ
+      when "001010" => if unordered or greater_than then return '1'; else return '0'; end if; -- UGT
+      when "001011" => if unordered or greater_than or equal_to then return '1'; else return '0'; end if; -- UGE
+      when "001100" => if unordered or less_than then return '1'; else return '0'; end if; -- ULT
+      when "001101" => if unordered or less_than or equal_to then return '1'; else return '0'; end if; -- ULE
+      when "001110" => if not equal_to then return '1'; else return '0'; end if; -- NE
+      when "001111" => return '1'; -- T
+      when "010000" => return '0'; -- SF
+      when "010001" => if equal_to then return '1'; else return '0'; end if; -- SEQ
+      when "010010" => if greater_than then return '1'; else return '0'; end if; -- GT
+      when "010011" => if greater_than or equal_to then return '1'; else return '0'; end if; -- GE
+      when "010100" => if less_than then return '1'; else return '0'; end if; -- LT
+      when "010101" => if less_than or equal_to then return '1'; else return '0'; end if; -- LE
+      when "010110" => if greater_than or less_than then return '1'; else return '0'; end if; -- GL
+      when "010111" => if greater_than or less_than or equal_to then return '1'; else return '0'; end if; -- GLE
+      when "011000" => if unordered then return '1'; else return '0'; end if; -- NGLE
+      when "011001" => if unordered or equal_to then return '1'; else return '0'; end if; -- NGL
+      when "011010" => if unordered or greater_than then return '1'; else return '0'; end if; -- NLE
+      when "011011" => if unordered or greater_than or equal_to then return '1'; else return '0'; end if; -- NLT
+      when "011100" => if unordered or less_than then return '1'; else return '0'; end if; -- NGE
+      when "011101" => if unordered or less_than or equal_to then return '1'; else return '0'; end if; -- NGT
+      when "011110" => if not equal_to then return '1'; else return '0'; end if; -- SNE
+      when others   => return '1'; -- ST
+    end case;
+  end function;
+
 begin
   addr      <= unsigned(a_in);
   bus_write <= '1' when (cs_n = '0' and as_n = '0' and ds_n = '0' and rw = '0') else '0';
@@ -906,6 +966,9 @@ begin
     variable int_value : integer := 0;
     variable packed_k : integer := 0;
     variable move_cfg : move_cfg_t := move_cfg_default;
+    variable prog_result : std_logic_vector(31 downto 0) := (others => '0');
+    variable cc_field : std_logic_vector(3 downto 0) := (others => '0');
+    variable cond_true : std_logic := '0';
   begin
     if reset_n = '0' then
       result_lo_reg <= (others => '0');
@@ -1092,7 +1155,18 @@ begin
               result_ready_reg <= '1';
             end if;
           when OP_CLASS_PROG_CTRL =>
-            -- Program-control opcodes (e.g. FNOP) currently complete immediately.
+            -- Program-control opcodes complete without ALU launch.
+            if op_sel_write_decoded = FPU_OP_FSCC then
+              cc_field := fpsr_reg(FPSR_CC_NEG downto FPSR_CC_NAN);
+              cond_true := eval_fcc_condition(operand_reg(0)(5 downto 0), cc_field);
+              prog_result := (others => '0');
+              if cond_true = '1' then
+                prog_result(7 downto 0) := x"FF";
+              end if;
+              result_lo_reg <= prog_result;
+              result_hi_reg <= (others => '0');
+              result_ex_reg <= (others => '0');
+            end if;
             result_ready_reg <= '1';
           when OP_CLASS_SYS_CTRL =>
             -- System-control opcodes are class-routed here for future FSAVE/FRESTORE plumbing.

--- a/src/mc68881_top.xdc
+++ b/src/mc68881_top.xdc
@@ -32,7 +32,7 @@ set_property IOSTANDARD LVCMOS33 [get_ports sense_n]
 # Multi-Cycle Path Constraints
 # ======================================================
 
-# --- Trig a_reg -> log_exp_term (2-cycle MCP = 200ns) ---
+# --- Trig a_reg -> log_exp_term / log_unbiased_exp / log_exp_term_zero (2-cycle MCP = 200ns) ---
 set_multicycle_path -setup 2 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *trig_inst/a_reg_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *trig_inst/log_exp_term_reg_reg*/D}]
 set_multicycle_path -hold 1 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *trig_inst/a_reg_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *trig_inst/log_exp_term_reg_reg*/D}]
 set_multicycle_path -setup 2 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *trig_inst/a_reg_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *trig_inst/log_unbiased_exp_reg_reg*/D}]

--- a/src/mc68881_top.xdc
+++ b/src/mc68881_top.xdc
@@ -35,8 +35,10 @@ set_property IOSTANDARD LVCMOS33 [get_ports sense_n]
 # --- Trig a_reg -> log_exp_term (2-cycle MCP = 200ns) ---
 set_multicycle_path -setup 2 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *trig_inst/a_reg_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *trig_inst/log_exp_term_reg_reg*/D}]
 set_multicycle_path -hold 1 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *trig_inst/a_reg_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *trig_inst/log_exp_term_reg_reg*/D}]
-set_multicycle_path -setup 2 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *trig_inst/a_reg_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *trig_inst/log_exp_reg_reg*/D}]
-set_multicycle_path -hold 1 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *trig_inst/a_reg_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *trig_inst/log_exp_reg_reg*/D}]
+set_multicycle_path -setup 2 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *trig_inst/a_reg_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *trig_inst/log_unbiased_exp_reg_reg*/D}]
+set_multicycle_path -hold 1 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *trig_inst/a_reg_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *trig_inst/log_unbiased_exp_reg_reg*/D}]
+set_multicycle_path -setup 2 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *trig_inst/a_reg_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *trig_inst/log_exp_term_zero_reg_reg*/D}]
+set_multicycle_path -hold 1 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *trig_inst/a_reg_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *trig_inst/log_exp_term_zero_reg_reg*/D}]
 
 # --- Trig a_reg -> x_reg (2-cycle) ---
 set_multicycle_path -setup 2 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *trig_inst/a_reg_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *trig_inst/x_reg_reg*/D}]
@@ -68,22 +70,22 @@ set_multicycle_path -hold 3 -from [get_pins -hier -filter {REF_PIN_NAME == C && 
 # ST_FP_DIV now uses sequential mc68881_divrem_unit in trig_inst,
 # so no direct div_*_reg -> tmp_reg MCP is required here.
 
-# --- Simple ALU ops -> result (4-cycle MCP = 400ns) ---
-set_multicycle_path -setup 4 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *simple_a_reg_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *result_reg_reg*/D}]
-set_multicycle_path -hold 3 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *simple_a_reg_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *result_reg_reg*/D}]
-set_multicycle_path -setup 4 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *simple_b_reg_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *result_reg_reg*/D}]
-set_multicycle_path -hold 3 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *simple_b_reg_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *result_reg_reg*/D}]
-set_multicycle_path -setup 4 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *simple_op_reg_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *result_reg_reg*/D}]
-set_multicycle_path -hold 3 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *simple_op_reg_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *result_reg_reg*/D}]
+# --- Simple ALU ops -> result (5-cycle MCP = 500ns) ---
+set_multicycle_path -setup 5 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *simple_a_reg_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *result_reg_reg*/D}]
+set_multicycle_path -hold 4 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *simple_a_reg_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *result_reg_reg*/D}]
+set_multicycle_path -setup 5 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *simple_b_reg_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *result_reg_reg*/D}]
+set_multicycle_path -hold 4 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *simple_b_reg_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *result_reg_reg*/D}]
+set_multicycle_path -setup 5 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *simple_op_reg_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *result_reg_reg*/D}]
+set_multicycle_path -hold 4 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *simple_op_reg_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *result_reg_reg*/D}]
 
 # --- operand_reg -> result (4-cycle MCP = 400ns) ---
 set_multicycle_path -setup 4 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *operand_reg_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *result_reg_reg*/D}]
 set_multicycle_path -hold 3 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *operand_reg_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *result_reg_reg*/D}]
 
-# --- Modpost paths (4-cycle MCP = 400ns) ---
+# --- Modpost paths (5-cycle MCP = 500ns) ---
 # Scope only the ALU divrem modpost instance. Avoid constraining similarly named
 # internals in other units (e.g. trig-local divider helpers).
-set_multicycle_path -setup 4 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *alu_inst/divrem_inst/gen_modpost_on.modpost_inst/mod_fp_add_a_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *alu_inst/divrem_inst/gen_modpost_on.modpost_inst/mod_add_result_reg_reg*/D}]
-set_multicycle_path -hold 3 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *alu_inst/divrem_inst/gen_modpost_on.modpost_inst/mod_fp_add_a_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *alu_inst/divrem_inst/gen_modpost_on.modpost_inst/mod_add_result_reg_reg*/D}]
-set_multicycle_path -setup 4 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *alu_inst/divrem_inst/gen_modpost_on.modpost_inst/mod_fp_add_b_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *alu_inst/divrem_inst/gen_modpost_on.modpost_inst/mod_add_result_reg_reg*/D}]
-set_multicycle_path -hold 3 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *alu_inst/divrem_inst/gen_modpost_on.modpost_inst/mod_fp_add_b_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *alu_inst/divrem_inst/gen_modpost_on.modpost_inst/mod_add_result_reg_reg*/D}]
+set_multicycle_path -setup 5 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *alu_inst/divrem_inst/gen_modpost_on.modpost_inst/mod_fp_add_a_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *alu_inst/divrem_inst/gen_modpost_on.modpost_inst/mod_add_result_reg_reg*/D}]
+set_multicycle_path -hold 4 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *alu_inst/divrem_inst/gen_modpost_on.modpost_inst/mod_fp_add_a_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *alu_inst/divrem_inst/gen_modpost_on.modpost_inst/mod_add_result_reg_reg*/D}]
+set_multicycle_path -setup 5 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *alu_inst/divrem_inst/gen_modpost_on.modpost_inst/mod_fp_add_b_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *alu_inst/divrem_inst/gen_modpost_on.modpost_inst/mod_add_result_reg_reg*/D}]
+set_multicycle_path -hold 4 -from [get_pins -hier -filter {REF_PIN_NAME == C && NAME =~ *alu_inst/divrem_inst/gen_modpost_on.modpost_inst/mod_fp_add_b_reg*/C}] -to [get_pins -hier -filter {REF_PIN_NAME == D && NAME =~ *alu_inst/divrem_inst/gen_modpost_on.modpost_inst/mod_add_result_reg_reg*/D}]

--- a/src/mc68881_trig_unit.vhd
+++ b/src/mc68881_trig_unit.vhd
@@ -85,9 +85,11 @@ architecture rtl of mc68881_trig_unit is
     ST_LOG_GETEXP,
     ST_LOG_GETEXP_POST,
     ST_LOGNP1_Z_POST,
+    ST_LOGNP1_META_POST,
     ST_LOGNP1_GETEXP_POST,
     ST_ATAN_INV_POST,
     ST_TRANS_PREP,
+    ST_TRANS_ADD_PREP,
     ST_TRANS_INPUT_ADJUST_POST,
     ST_TRANS_PRE_MUL_POST,
     ST_TRANS_POLY_INIT,
@@ -1705,11 +1707,6 @@ begin
           x_local := fgetman_fp80(z_local);
           unbiased_exp_local := fgetexp_unbiased_int(z_local);
           log_unbiased_exp_reg <= unbiased_exp_local;
-          if unbiased_exp_local = 0 then
-            log_exp_term_zero_reg <= '1';
-          else
-            log_exp_term_zero_reg <= '0';
-          end if;
           log_scale_reg <= FP80_LN2;
           log_exp_add_en_reg <= '1';
           coeff0_reg <= FP80_ZERO;
@@ -1727,6 +1724,15 @@ begin
           seed_idx_reg <= 0;
           seed_return_state_reg <= ST_TRANS_PREP;
           x_reg <= x_local;
+          state_reg <= ST_LOGNP1_META_POST;
+
+        when ST_LOGNP1_META_POST =>
+          -- Isolate metadata/branching from z decode to shorten this timing cone.
+          if log_unbiased_exp_reg = 0 then
+            log_exp_term_zero_reg <= '1';
+          else
+            log_exp_term_zero_reg <= '0';
+          end if;
           state_reg <= ST_LOGNP1_GETEXP_POST;
 
         when ST_LOGNP1_GETEXP_POST =>
@@ -1761,7 +1767,7 @@ begin
             add_rm_reg <= FP_RND_NEAREST;
             add_rp_reg <= FP_PREC_EXTENDED;
             cont_state_reg <= ST_TRANS_INPUT_ADJUST_POST;
-            state_reg <= ST_FP_ADD;
+            state_reg <= ST_TRANS_ADD_PREP;
           elsif trans_pre_mul_en_reg = '1' then
             mul_a_reg <= x_reg;
             if seed_domain_reg = SEED_DOMAIN_EXP then
@@ -1783,6 +1789,10 @@ begin
           else
             state_reg <= ST_TRANS_POLY_INIT;
           end if;
+
+        when ST_TRANS_ADD_PREP =>
+          -- One-cycle launch stage to decouple add operand muxing from ST_FP_ADD.
+          state_reg <= ST_FP_ADD;
 
         when ST_TRANS_INPUT_ADJUST_POST =>
           x_reg <= tmp_reg;
@@ -1821,7 +1831,7 @@ begin
           add_rm_reg <= FP_RND_NEAREST;
           add_rp_reg <= FP_PREC_EXTENDED;
           cont_state_reg <= ST_TRANS_POLY_ADD_POST;
-          state_reg <= ST_FP_ADD;
+          state_reg <= ST_TRANS_ADD_PREP;
 
         when ST_TRANS_POLY_ADD_POST =>
           poly_reg <= tmp_reg;
@@ -1865,7 +1875,7 @@ begin
             add_rm_reg <= rm_reg;
             add_rp_reg <= rp_reg;
             cont_state_reg <= ST_TRANS_POST_ADD_POST;
-            state_reg <= ST_FP_ADD;
+            state_reg <= ST_TRANS_ADD_PREP;
           else
             add_a_reg <= result_reg;
             add_b_reg <= FP80_ZERO;
@@ -1873,7 +1883,7 @@ begin
             add_rm_reg <= rm_reg;
             add_rp_reg <= rp_reg;
             cont_state_reg <= ST_TRANS_FINAL_ROUND_POST;
-            state_reg <= ST_FP_ADD;
+            state_reg <= ST_TRANS_ADD_PREP;
           end if;
 
         when ST_TRANS_POST_ADD_POST =>

--- a/tb/mc68881_microseq_tb.vhd
+++ b/tb/mc68881_microseq_tb.vhd
@@ -38,6 +38,12 @@ begin
       report "decode_op_sel_word core-v1 SQRT mapping failed." severity failure;
     assert decode_op_sel_word(x"01000020") = FPU_OP_FNOP
       report "decode_op_sel_word core-v1 FNOP mapping failed." severity failure;
+    assert decode_op_sel_word(x"01000021") = FPU_OP_FSCC
+      report "decode_op_sel_word core-v1 FScc mapping failed." severity failure;
+    assert decode_op_sel_word(x"01000022") = FPU_OP_FBCC
+      report "decode_op_sel_word core-v1 FBcc mapping failed." severity failure;
+    assert decode_op_sel_word(x"01000023") = FPU_OP_FDBCC
+      report "decode_op_sel_word core-v1 FDBcc mapping failed." severity failure;
     assert decode_op_sel_word(x"01000030") = FPU_OP_FSAVE
       report "decode_op_sel_word core-v1 FSAVE mapping failed." severity failure;
     assert decode_op_sel_word(x"01000031") = FPU_OP_FRESTORE
@@ -115,6 +121,12 @@ begin
       report "op_class FTST mapping failed." severity failure;
     assert op_class(FPU_OP_FNOP) = OP_CLASS_PROG_CTRL
       report "op_class FNOP mapping failed." severity failure;
+    assert op_class(FPU_OP_FSCC) = OP_CLASS_PROG_CTRL
+      report "op_class FScc mapping failed." severity failure;
+    assert op_class(FPU_OP_FBCC) = OP_CLASS_PROG_CTRL
+      report "op_class FBcc mapping failed." severity failure;
+    assert op_class(FPU_OP_FDBCC) = OP_CLASS_PROG_CTRL
+      report "op_class FDBcc mapping failed." severity failure;
     assert op_class(FPU_OP_FSAVE) = OP_CLASS_SYS_CTRL
       report "op_class FSAVE mapping failed." severity failure;
     assert op_class(FPU_OP_FRESTORE) = OP_CLASS_SYS_CTRL
@@ -221,6 +233,18 @@ begin
     );
     assert cycles = 0
       report "op_cycle_count FNOP should be zero." severity failure;
+
+    cycles := op_cycle_count(
+      FPU_OP_FSCC,
+      FPU_SRC_FPM,
+      EA_MODE_DN_AN,
+      EA_CYCLE_BEST,
+      false,
+      false,
+      false
+    );
+    assert cycles = 0
+      report "op_cycle_count FScc should be zero." severity failure;
 
     cycles := op_cycle_count(
       FPU_OP_FSAVE,

--- a/tb/tb_mc68881_op_class_dispatch.vhd
+++ b/tb/tb_mc68881_op_class_dispatch.vhd
@@ -172,6 +172,16 @@ begin
       report "FNOP should execute through program-control class with zero modeled cycles."
       severity failure;
 
+    -- Program-control class dispatch (FScc).
+    report "Issuing FScc opcode through OPSEL." severity note;
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, x"01000021");
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word, "FScc");
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, cycle_total_word, ADDR_CYCLE_TOTAL);
+    report "FScc cycle_total=" & integer'image(to_integer(unsigned(cycle_total_word))) severity note;
+    assert to_integer(unsigned(cycle_total_word)) = 0
+      report "FScc should execute through program-control class with zero modeled cycles."
+      severity failure;
+
     -- System-control class dispatch (FSAVE placeholder opcode).
     report "Issuing FSAVE opcode through OPSEL." severity note;
     bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, x"01000030");

--- a/tb/tb_mc68881_top.vhd
+++ b/tb/tb_mc68881_top.vhd
@@ -1018,6 +1018,37 @@ begin
       report "FASIN(|x|>1) should set CC NAN"
       severity failure;
 
+    -- B6 slice: FScc uses FPSR condition code bits and writes byte result.
+    report "FScc EQ test with Z=1." severity note;
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPSR, x"04000000"); -- Z set
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(1, 5), x"00000001"); -- condition: EQ
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(0, 5), x"01000021"); -- FScc
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_lo, to_unsigned(7, 5));
+    assert rd_lo(7 downto 0) = x"FF"
+      report "FScc EQ should return 0xFF when Z=1"
+      severity failure;
+
+    report "FScc EQ test with N=1 and Z=0." severity note;
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPSR, x"08000000"); -- N set
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(1, 5), x"00000001"); -- condition: EQ
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(0, 5), x"01000021"); -- FScc
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_lo, to_unsigned(7, 5));
+    assert rd_lo(7 downto 0) = x"00"
+      report "FScc EQ should return 0x00 when Z=0"
+      severity failure;
+
+    report "FScc UN test with NAN=1." severity note;
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPSR, x"01000000"); -- NAN set
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(1, 5), x"00000008"); -- condition: UN
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, to_unsigned(0, 5), x"01000021"); -- FScc
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_lo, to_unsigned(7, 5));
+    assert rd_lo(7 downto 0) = x"FF"
+      report "FScc UN should return 0xFF when NAN=1"
+      severity failure;
+
     -- DSACK behavior coverage
     size_n <= "11";
     a_in   <= "10000";


### PR DESCRIPTION
## Summary
This PR advances **B6 (program-control instructions)** and includes timing-focused RTL/constraint changes needed to keep the branch usable while we continue closure work.

### Functional updates (B6)
- Added opcode metadata entries for:
  - `FPU_OP_FSCC`
  - `FPU_OP_FBCC`
  - `FPU_OP_FDBCC`
- Implemented `FScc` condition evaluation from FPSR CC flags in top-level dispatch.
  - `FScc` now returns byte-true/byte-false in result low byte.
- Updated B6 status to **in progress** in checklist documentation.
- Added/extended coverage in:
  - `tb/mc68881_microseq_tb.vhd`
  - `tb/tb_mc68881_op_class_dispatch.vhd`
  - `tb/tb_mc68881_top.vhd`

### FScc correctness fixes (from PR review)
- Fixed `less_than` predicate in `eval_fcc_condition`: added `(not zero_set)` guard so negative zero no longer satisfies OLT/OGL/GL and their signaling variants (MC68881 Table 3-23: LT = N AND NOT(NAN OR Z)).
- Fixed condition code mirroring: codes 32-63 now correctly mirror 0-31 by masking bit 5, instead of returning TRUE via `when others`.
- Zeroed result registers for all `OP_CLASS_PROG_CTRL` ops before the FScc-specific branch, preventing stale data leakage for FBcc/FDBcc placeholders.
- Updated XDC section header to list all three constrained trig log-exp registers.

## Timing/closure work included
### 1) Modpost FP add path (previously very deep)
- Increased modpost FP-add hold schedule in `mc68881_modrem_post_unit`.
- Updated matching MCP constraints in `mc68881_top.xdc` for modpost add paths.

### 2) Trig log-exp metadata path
- Added/adjusted MCP coverage for trig exponent metadata registers, including `log_exp_term_zero_reg` path.
- Added staging states in trig flow to decouple heavy metadata/launch cones.

### 3) Divrem SQRT classify critical path
- Refactored subnormal normalization in `mc68881_divrem_unit`:
  - replaced iterative shift loop with direct leading-one index decode,
  - added shift bound to preserve legacy loop-equivalent behavior.
- This also fixed the SQRT subnormal flush-to-zero regression seen in test.

## Latency contract alignment
Because modpost timing-safe staging added cycle depth, fixed-latency metadata needed alignment:
- `FPU_OP_MOD` `alu_latency`: `84 -> 85`
- `FPU_OP_REM` `alu_latency`: `94 -> 97`

This keeps ALU latency assertions and metadata-driven checks consistent with observed completion timing.

## Validation
- Full regression run:
  - `powershell -ExecutionPolicy Bypass -File scripts/run_tests.ps1`
  - **Result: pass**
- Notable checked outcomes from logs:
  - `MOD latency cycles: 85`
  - `REM latency cycles: 97`
  - SQRT subnormal checks pass again.

## Current timing status / follow-up
- Prior run in this series reported setup miss around `-2.998 ns` on:
  - `alu_inst/divrem_inst/a_reg_reg[63] -> sqrt_exp_out_reg_reg[*]`
- The divrem classify refactor in this PR is intended to reduce that cone.
- Routed implementation rerun should be used as the next checkpoint for updated WNS/TNS after these commits.