### PR TITLE
Fix FMOVE exception flow and FP format conversion semantics

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -33,7 +33,8 @@
       "Bash(powershell.exe -NoProfile -Command 'Get-ChildItem \"\"C:\\\\amddesigntools\\\\Vivado\\\\2025.2\\\\bin\\\\vivado*\"\" -ErrorAction SilentlyContinue | Select-Object -Property Name,FullName')",
       "Bash(powershell.exe -NoProfile -Command 'Get-ChildItem \"\"C:\\\\amddesigntools\\\\2025.2\\\\bin\\\\vivado*\"\" -ErrorAction SilentlyContinue | Select-Object -Property Name,FullName')",
       "Bash(powershell.exe -NoProfile -Command:*)",
-      "Bash(cmd //c \"C:\\\\amddesigntools\\\\2025.2\\\\Vivado\\\\bin\\\\vivado.bat -mode batch -source C:/code/68881-fpga/scripts/run_impl.tcl\")"
+      "Bash(cmd //c \"C:\\\\amddesigntools\\\\2025.2\\\\Vivado\\\\bin\\\\vivado.bat -mode batch -source C:/code/68881-fpga/scripts/run_impl.tcl\")",
+      "Bash(cd:*)"
     ]
   }
 }

--- a/docs/fpu-progress-checklist.md
+++ b/docs/fpu-progress-checklist.md
@@ -217,8 +217,12 @@ F) Datasheet Conformance (MC68881UM Review Findings)
       mode semantics (RN -> infinity; RZ/RM/RP -> directed finite/infinity result).
     - FIXED: underflow conversion path now emits gradual-underflow subnormals
       instead of unconditional zero flush.
+    - FIXED: FMOVE reg->mem exception classification preserves destination-format
+      range status so directed overflow-to-max-finite and non-zero subnormal
+      results still assert FPSR EXC/AEXC overflow/underflow.
     - Regression coverage: `tb/tb_mc68881_fmove_fmovem.vhd` now checks single
-      and double minimum-subnormal conversion and single overflow mode behavior.
+      and double minimum-subnormal conversion, single overflow mode behavior,
+      and EXC/AEXC overflow/underflow signaling for those conversions.
 
 [x] F5. Fix FGETEXP(infinity) and FGETMAN(infinity).
     - FIXED: Both now return NaN (all-ones mantissa) for infinity input per datasheet.

--- a/docs/fpu-progress-checklist.md
+++ b/docs/fpu-progress-checklist.md
@@ -193,31 +193,29 @@ F) Datasheet Conformance (MC68881UM Review Findings)
     - FIXED: fp80_from_single and fp80_from_double now copy source fraction bits
       into extended mantissa, left-justified, preserving NaN payloads.
 
-[ ] F2. Fix format conversion rounding (fp80_to_single / fp80_to_double).
-    - fp80_to_single (line 376) and fp80_to_double (line 405) truncate mantissa
-      bits with no rounding. Datasheet Section 3.5.2 requires rounding using
-      current FPCR rounding mode (guard/round/sticky bit evaluation).
-    - Severity: high. Affects all FMOVE.S and FMOVE.D to memory.
+[x] F2. Fix format conversion rounding (fp80_to_single / fp80_to_double).
+    - FIXED: `fp80_to_single` and `fp80_to_double` now apply guard/round/sticky
+      rounding using the active FPCR rounding mode (RN/RZ/RM/RP).
+    - FIXED: tie-to-even behavior is implemented for round-to-nearest mode.
+    - Regression coverage: `tb/tb_mc68881_fmove_fmovem.vhd` now checks single
+      and double halfway cases across rounding modes.
 
-[~] F3. Add exception handling to FMOVE operations.
-    - FPU_OP_MOVE uses EXC_POLICY_NONE (mc68881_pkg.vhd:823), disabling all
-      exception classification. Datasheet states FMOVE is an arithmetic operation
-      that must signal OVFL, UNFL, INEX, SNAN during format conversion.
-    - Severity: high. Even if conversion functions are fixed, no exceptions
-      would be recorded.
-    - FIXED (partial): FPU_OP_MOVE policy changed from EXC_POLICY_NONE to
-      EXC_POLICY_ARITH. Policy metadata is correct; however, the FMOVE execution
-      path bypasses the ALU (no valid pulse), so the exception classification
-      block does not run for FMOVE ops. Full fix requires routing FMOVE
-      completion through the exception classification path.
+[x] F3. Add exception handling to FMOVE operations.
+    - FIXED: FPU_OP_MOVE now routes conversion-complete events through the same
+      exception-classification path used by ALU-valid completions.
+    - FMOVE conversion paths now drive EXC/AEXC/CC/FPIAR side effects via
+      op-policy metadata (`EXC_POLICY_ARITH`) instead of bypassing classification.
+    - Regression coverage: `tb/tb_mc68881_fmove_fmovem.vhd` now includes a
+      FMOVE single-qNaN mem->reg case that asserts FPSR invalid/AEXC invalid
+      and exception-time FPIAR capture.
 
-[ ] F4. Fix format conversion overflow/underflow behavior.
-    - fp80_to_single/double overflow: always saturates to infinity. Per datasheet
-      Section 6.1.4, in RZ/RM/RP modes the result should be the largest
-      representable normalized number, not infinity.
-    - fp80_to_single/double underflow: flushes to zero. Per IEEE 754 and datasheet,
-      gradual underflow (denormalized result) is required.
-    - Severity: high.
+[x] F4. Fix format conversion overflow/underflow behavior.
+    - FIXED: overflow handling in `fp80_to_single/double` now follows rounding
+      mode semantics (RN -> infinity; RZ/RM/RP -> directed finite/infinity result).
+    - FIXED: underflow conversion path now emits gradual-underflow subnormals
+      instead of unconditional zero flush.
+    - Regression coverage: `tb/tb_mc68881_fmove_fmovem.vhd` now checks single
+      and double minimum-subnormal conversion and single overflow mode behavior.
 
 [x] F5. Fix FGETEXP(infinity) and FGETMAN(infinity).
     - FIXED: Both now return NaN (all-ones mantissa) for infinity input per datasheet.

--- a/project/fpga68881/fpga68881.xpr
+++ b/project/fpga68881/fpga68881.xpr
@@ -298,7 +298,7 @@
       <Report Name="ROUTE_DESIGN.REPORT_METHODOLOGY" Enabled="1"/>
       <RQSFiles/>
     </Run>
-    <Run Id="impl_1" Type="Ft2:EntireDesign" Part="xc7a200tfbg676-1" ConstrsSet="constrs_1" Description="Default settings for Implementation." AutoIncrementalCheckpoint="false" WriteIncrSynthDcp="false" State="current" Dir="$PRUNDIR/impl_1" SynthRun="synth_1" IncludeInArchive="true" IsChild="false" GenFullBitstream="true" AutoIncrementalDir="$PSRCDIR/utils_1/imports/impl_1" LaunchOptions="-jobs 1 " AutoRQSDir="$PSRCDIR/utils_1/imports/impl_1" ParallelReportGen="true">
+    <Run Id="impl_1" Type="Ft2:EntireDesign" Part="xc7a200tfbg676-1" ConstrsSet="constrs_1" Description="Default settings for Implementation." AutoIncrementalCheckpoint="false" WriteIncrSynthDcp="false" State="current" Dir="$PRUNDIR/impl_1" SynthRun="synth_1" IncludeInArchive="true" IsChild="false" GenFullBitstream="true" AutoIncrementalDir="$PSRCDIR/utils_1/imports/impl_1" LaunchOptions="-jobs 17 " AutoRQSDir="$PSRCDIR/utils_1/imports/impl_1" ParallelReportGen="true">
       <Strategy Version="1" Minor="2">
         <StratHandle Name="Vivado Implementation Defaults" Flow="Vivado Implementation 2025"/>
         <Step Id="init_design"/>

--- a/src/mc68881_top.vhd
+++ b/src/mc68881_top.vhd
@@ -145,6 +145,7 @@ architecture rtl of mc68881_top is
   signal exc_event_divzero_reg : std_logic := '0';
   signal exc_event_force_overflow_reg : std_logic := '0';
   signal exc_event_force_underflow_reg : std_logic := '0';
+  signal exc_event_force_inexact_reg : std_logic := '0';
 
   constant FRAME_LATENCY : natural := 6;
   constant FP_EXP_ALL_ONES : unsigned(FP_EXP_WIDTH-1 downto 0) := (others => '1');
@@ -408,6 +409,14 @@ architecture rtl of mc68881_top is
     exp80_i := to_integer(exp80_u);
 
     if exp80_u = 0 then
+      -- fp80 subnormal: magnitude far below single range.
+      -- Directed rounding away from zero produces minimum subnormal.
+      if mant80 /= 0 then
+        if (mode = FP_RND_PLUS_INF and value(FP_WIDTH-1) = '0') or
+           (mode = FP_RND_MINUS_INF and value(FP_WIDTH-1) = '1') then
+          bits32(0) := '1';
+        end if;
+      end if;
       return bits32;
     elsif exp80_u = FP_EXP_ALL_ONES then
       bits32(30 downto 23) := (others => '1');
@@ -534,6 +543,14 @@ architecture rtl of mc68881_top is
     exp80_i := to_integer(exp80_u);
 
     if exp80_u = 0 then
+      -- fp80 subnormal: magnitude far below double range.
+      -- Directed rounding away from zero produces minimum subnormal.
+      if mant80 /= 0 then
+        if (mode = FP_RND_PLUS_INF and value(FP_WIDTH-1) = '0') or
+           (mode = FP_RND_MINUS_INF and value(FP_WIDTH-1) = '1') then
+          bits64(0) := '1';
+        end if;
+      end if;
       return bits64;
     elsif exp80_u = FP_EXP_ALL_ONES then
       bits64(62 downto 52) := (others => '1');
@@ -939,6 +956,7 @@ begin
     variable class_divzero : std_logic := '0';
     variable class_force_overflow : std_logic := '0';
     variable class_force_underflow : std_logic := '0';
+    variable class_force_inexact : std_logic := '0';
   begin
     if reset_n = '0' then
       op_sel_reg <= FPU_OP_NOP;
@@ -1049,6 +1067,7 @@ begin
           class_divzero := alu_flag_divzero;
           class_force_overflow := '0';
           class_force_underflow := '0';
+          class_force_inexact := '0';
         else
           class_opa := exc_event_opa_reg;
           class_opb := exc_event_opb_reg;
@@ -1056,6 +1075,7 @@ begin
           class_divzero := exc_event_divzero_reg;
           class_force_overflow := exc_event_force_overflow_reg;
           class_force_underflow := exc_event_force_underflow_reg;
+          class_force_inexact := exc_event_force_inexact_reg;
         end if;
         a_zero := fp80_is_zero(class_opa);
         b_zero := fp80_is_zero(class_opb);
@@ -1124,7 +1144,8 @@ begin
             exc_flags(FPSR_EXC_UNDERFLOW) := '1';
           end if;
 
-          if exc_flags(FPSR_EXC_OVERFLOW) = '1' or exc_flags(FPSR_EXC_UNDERFLOW) = '1' then
+          if exc_flags(FPSR_EXC_OVERFLOW) = '1' or exc_flags(FPSR_EXC_UNDERFLOW) = '1'
+             or class_force_inexact = '1' then
             exc_flags(FPSR_EXC_INEXACT) := '1';
           end if;
         end if;
@@ -1235,6 +1256,7 @@ begin
     variable move_exc_enable : std_logic := '0';
     variable move_exc_force_overflow : std_logic := '0';
     variable move_exc_force_underflow : std_logic := '0';
+    variable move_exc_force_inexact : std_logic := '0';
     variable move_src_abs : fp80_t := (others => '0');
     variable single_max_abs : fp80_t := (others => '0');
     variable double_max_abs : fp80_t := (others => '0');
@@ -1316,14 +1338,21 @@ begin
               move_exc_enable := '0';
               move_exc_force_overflow := '0';
               move_exc_force_underflow := '0';
+              move_exc_force_inexact := '0';
 
               if move_cfg.fmovecr_enable = '1' then
                 move_result := fmovecr_constant(operand_reg(0)(6 downto 0));
+                move_exc_enable := '1';
+                move_exc_result := move_result;
+                move_exc_opa := move_result;
                 fp_reg_file_reg(dst_idx) <= move_result;
               else
                 case mode is
                   when MOVE_CFG_MODE_REG_TO_REG =>
                     move_result := fp_reg_file_reg(src_idx);
+                    move_exc_enable := '1';
+                    move_exc_result := move_result;
+                    move_exc_opa := move_result;
                     fp_reg_file_reg(dst_idx) <= move_result;
                   when MOVE_CFG_MODE_MEM_TO_REG =>
                     if move_cfg.mem_to_reg_integer = '1' then
@@ -1353,6 +1382,9 @@ begin
                           move_exc_opa := move_result;
                         when others =>
                           move_result := operand_reg(0);
+                          move_exc_enable := '1';
+                          move_exc_result := move_result;
+                          move_exc_opa := move_result;
                       end case;
                     end if;
                     fp_reg_file_reg(dst_idx) <= move_result;
@@ -1378,6 +1410,9 @@ begin
                           move_exc_enable := '1';
                           move_exc_result := fp80_from_single(single_bits);
                           if not fp80_is_nan(move_result) and not fp80_is_inf(move_result) and not fp80_is_zero(move_result) then
+                            if move_exc_result /= move_result then
+                              move_exc_force_inexact := '1';
+                            end if;
                             if single_bits(30 downto 23) = x"00" then
                               move_exc_force_underflow := '1';
                             end if;
@@ -1396,6 +1431,9 @@ begin
                           move_exc_enable := '1';
                           move_exc_result := fp80_from_double(double_bits);
                           if not fp80_is_nan(move_result) and not fp80_is_inf(move_result) and not fp80_is_zero(move_result) then
+                            if move_exc_result /= move_result then
+                              move_exc_force_inexact := '1';
+                            end if;
                             if double_bits(62 downto 52) = std_logic_vector(to_unsigned(0, 11)) then
                               move_exc_force_underflow := '1';
                             end if;
@@ -1446,6 +1484,7 @@ begin
                 exc_event_opb_reg <= move_exc_opb;
                 exc_event_force_overflow_reg <= move_exc_force_overflow;
                 exc_event_force_underflow_reg <= move_exc_force_underflow;
+                exc_event_force_inexact_reg <= move_exc_force_inexact;
               end if;
               result_ready_reg <= '1';
             elsif op_sel_write_decoded = FPU_OP_MOVEM then

--- a/src/mc68881_top.vhd
+++ b/src/mc68881_top.vhd
@@ -143,6 +143,8 @@ architecture rtl of mc68881_top is
   signal exc_event_opa_reg : fp80_t := (others => '0');
   signal exc_event_opb_reg : fp80_t := x"3FFF8000000000000000";
   signal exc_event_divzero_reg : std_logic := '0';
+  signal exc_event_force_overflow_reg : std_logic := '0';
+  signal exc_event_force_underflow_reg : std_logic := '0';
 
   constant FRAME_LATENCY : natural := 6;
   constant FP_EXP_ALL_ONES : unsigned(FP_EXP_WIDTH-1 downto 0) := (others => '1');
@@ -935,6 +937,8 @@ begin
     variable class_opb : fp80_t := FP80_CLASSIFY_ONE;
     variable class_result : fp80_t := (others => '0');
     variable class_divzero : std_logic := '0';
+    variable class_force_overflow : std_logic := '0';
+    variable class_force_underflow : std_logic := '0';
   begin
     if reset_n = '0' then
       op_sel_reg <= FPU_OP_NOP;
@@ -1043,11 +1047,15 @@ begin
           class_opb := operand_reg(1);
           class_result := result;
           class_divzero := alu_flag_divzero;
+          class_force_overflow := '0';
+          class_force_underflow := '0';
         else
           class_opa := exc_event_opa_reg;
           class_opb := exc_event_opb_reg;
           class_result := exc_event_result_reg;
           class_divzero := exc_event_divzero_reg;
+          class_force_overflow := exc_event_force_overflow_reg;
+          class_force_underflow := exc_event_force_underflow_reg;
         end if;
         a_zero := fp80_is_zero(class_opa);
         b_zero := fp80_is_zero(class_opb);
@@ -1099,6 +1107,14 @@ begin
         end if;
 
         if exc_policy.classify_overflow_underflow then
+          if class_force_overflow = '1' then
+            exc_flags(FPSR_EXC_OVERFLOW) := '1';
+          end if;
+
+          if class_force_underflow = '1' then
+            exc_flags(FPSR_EXC_UNDERFLOW) := '1';
+          end if;
+
           if res_inf and not a_inf and not b_inf and not res_nan and
              exc_flags(FPSR_EXC_DIVZERO) = '0' then
             exc_flags(FPSR_EXC_OVERFLOW) := '1';
@@ -1217,6 +1233,11 @@ begin
     variable move_exc_opa : fp80_t := (others => '0');
     variable move_exc_opb : fp80_t := FP80_CLASSIFY_ONE;
     variable move_exc_enable : std_logic := '0';
+    variable move_exc_force_overflow : std_logic := '0';
+    variable move_exc_force_underflow : std_logic := '0';
+    variable move_src_abs : fp80_t := (others => '0');
+    variable single_max_abs : fp80_t := (others => '0');
+    variable double_max_abs : fp80_t := (others => '0');
     variable prog_result : std_logic_vector(31 downto 0) := (others => '0');
     variable cc_field : std_logic_vector(3 downto 0) := (others => '0');
     variable cond_true : std_logic := '0';
@@ -1245,11 +1266,15 @@ begin
       exc_event_opa_reg <= (others => '0');
       exc_event_opb_reg <= FP80_CLASSIFY_ONE;
       exc_event_divzero_reg <= '0';
+      exc_event_force_overflow_reg <= '0';
+      exc_event_force_underflow_reg <= '0';
     elsif rising_edge(clk) then
       op_start_reg <= '0';
       ctrl_move_write_req_reg <= '0';
       exc_event_valid_reg <= '0';
       exc_event_divzero_reg <= '0';
+      exc_event_force_overflow_reg <= '0';
+      exc_event_force_underflow_reg <= '0';
 
       if op_issue_pulse = '1' then
         result_ready_reg <= '0';
@@ -1289,6 +1314,8 @@ begin
               move_exc_opa := (others => '0');
               move_exc_opb := FP80_CLASSIFY_ONE;
               move_exc_enable := '0';
+              move_exc_force_overflow := '0';
+              move_exc_force_underflow := '0';
 
               if move_cfg.fmovecr_enable = '1' then
                 move_result := fmovecr_constant(operand_reg(0)(6 downto 0));
@@ -1350,6 +1377,17 @@ begin
                           single_bits := fp80_to_single(move_result, round_mode);
                           move_exc_enable := '1';
                           move_exc_result := fp80_from_single(single_bits);
+                          if not fp80_is_nan(move_result) and not fp80_is_inf(move_result) and not fp80_is_zero(move_result) then
+                            if single_bits(30 downto 23) = x"00" then
+                              move_exc_force_underflow := '1';
+                            end if;
+                            move_src_abs := move_result;
+                            move_src_abs(FP_WIDTH-1) := '0';
+                            single_max_abs := fp80_from_single(x"7F7FFFFF");
+                            if compare_fp80_ordered(move_src_abs, single_max_abs) > 0 then
+                              move_exc_force_overflow := '1';
+                            end if;
+                          end if;
                           result_lo_reg <= single_bits;
                           result_hi_reg <= (others => '0');
                           result_ex_reg <= (others => '0');
@@ -1357,6 +1395,17 @@ begin
                           double_bits := fp80_to_double(move_result, round_mode);
                           move_exc_enable := '1';
                           move_exc_result := fp80_from_double(double_bits);
+                          if not fp80_is_nan(move_result) and not fp80_is_inf(move_result) and not fp80_is_zero(move_result) then
+                            if double_bits(62 downto 52) = std_logic_vector(to_unsigned(0, 11)) then
+                              move_exc_force_underflow := '1';
+                            end if;
+                            move_src_abs := move_result;
+                            move_src_abs(FP_WIDTH-1) := '0';
+                            double_max_abs := fp80_from_double(x"7FEFFFFFFFFFFFFF");
+                            if compare_fp80_ordered(move_src_abs, double_max_abs) > 0 then
+                              move_exc_force_overflow := '1';
+                            end if;
+                          end if;
                           result_lo_reg <= double_bits(31 downto 0);
                           result_hi_reg <= double_bits(63 downto 32);
                           result_ex_reg <= (others => '0');
@@ -1395,6 +1444,8 @@ begin
                 exc_event_result_reg <= move_exc_result;
                 exc_event_opa_reg <= move_exc_opa;
                 exc_event_opb_reg <= move_exc_opb;
+                exc_event_force_overflow_reg <= move_exc_force_overflow;
+                exc_event_force_underflow_reg <= move_exc_force_underflow;
               end if;
               result_ready_reg <= '1';
             elsif op_sel_write_decoded = FPU_OP_MOVEM then

--- a/src/mc68881_top.vhd
+++ b/src/mc68881_top.vhd
@@ -138,9 +138,15 @@ architecture rtl of mc68881_top is
   signal ctrl_move_write_req_reg : std_logic := '0';
   signal ctrl_move_sel_reg : std_logic_vector(1 downto 0) := (others => '0');
   signal ctrl_move_data_reg : std_logic_vector(31 downto 0) := (others => '0');
+  signal exc_event_valid_reg : std_logic := '0';
+  signal exc_event_result_reg : fp80_t := (others => '0');
+  signal exc_event_opa_reg : fp80_t := (others => '0');
+  signal exc_event_opb_reg : fp80_t := x"3FFF8000000000000000";
+  signal exc_event_divzero_reg : std_logic := '0';
 
   constant FRAME_LATENCY : natural := 6;
   constant FP_EXP_ALL_ONES : unsigned(FP_EXP_WIDTH-1 downto 0) := (others => '1');
+  constant FP80_CLASSIFY_ONE : fp80_t := x"3FFF8000000000000000";
 
   constant FPSR_CC_NAN      : natural := 24;
   constant FPSR_CC_INF      : natural := 25;
@@ -352,61 +358,283 @@ architecture rtl of mc68881_top is
     end if;
   end function;
 
-  function fp80_to_single(value : fp80_t) return std_logic_vector is
+  function should_round_up(
+    sign_bit : std_logic;
+    lsb_bit : std_logic;
+    guard_bit : std_logic;
+    sticky_bit : std_logic;
+    mode : fp_round_mode_t
+  ) return std_logic is
+    variable remainder_nonzero : std_logic := '0';
+  begin
+    remainder_nonzero := guard_bit or sticky_bit;
+    case mode is
+      when FP_RND_NEAREST =>
+        if guard_bit = '1' and (sticky_bit = '1' or lsb_bit = '1') then
+          return '1';
+        end if;
+      when FP_RND_ZERO =>
+        null;
+      when FP_RND_MINUS_INF =>
+        if sign_bit = '1' and remainder_nonzero = '1' then
+          return '1';
+        end if;
+      when FP_RND_PLUS_INF =>
+        if sign_bit = '0' and remainder_nonzero = '1' then
+          return '1';
+        end if;
+    end case;
+    return '0';
+  end function;
+
+  function fp80_to_single(value : fp80_t; mode : fp_round_mode_t) return std_logic_vector is
     variable bits32 : std_logic_vector(31 downto 0) := (others => '0');
-    variable exp80 : unsigned(FP_EXP_WIDTH-1 downto 0) := unsigned(value(FP_WIDTH-2 downto FP_WIDTH-1-FP_EXP_WIDTH));
+    variable exp80_u : unsigned(FP_EXP_WIDTH-1 downto 0) := unsigned(value(FP_WIDTH-2 downto FP_WIDTH-1-FP_EXP_WIDTH));
     variable frac80 : unsigned(FP_MANT_WIDTH-2 downto 0) := unsigned(value(FP_MANT_WIDTH-2 downto 0));
+    variable mant80 : unsigned(FP_MANT_WIDTH-1 downto 0) := unsigned(value(FP_MANT_WIDTH-1 downto 0));
+    variable exp80_i : integer := 0;
     variable exp32 : integer := 0;
+    variable sig_base : unsigned(23 downto 0) := (others => '0');
+    variable sig_round : unsigned(24 downto 0) := (others => '0');
+    variable guard_bit : std_logic := '0';
+    variable sticky_bit : std_logic := '0';
+    variable round_up : std_logic := '0';
+    variable shift_total : integer := 0;
+    variable sticky_hi : integer := -1;
   begin
     bits32(31) := value(FP_WIDTH-1);
-    if exp80 = 0 then
+    exp80_i := to_integer(exp80_u);
+
+    if exp80_u = 0 then
       return bits32;
-    elsif exp80 = FP_EXP_ALL_ONES then
+    elsif exp80_u = FP_EXP_ALL_ONES then
       bits32(30 downto 23) := (others => '1');
       if frac80 /= 0 then
-        bits32(22) := '1';
+        bits32(22 downto 0) := value(FP_MANT_WIDTH-2 downto FP_MANT_WIDTH-24);
+        if bits32(22 downto 0) = std_logic_vector(to_unsigned(0, 23)) then
+          bits32(22) := '1';
+        end if;
       end if;
       return bits32;
     else
-      exp32 := to_integer(exp80) - FP_EXP_BIAS + 127;
-      if exp32 <= 0 then
+      exp32 := exp80_i - FP_EXP_BIAS + 127;
+      if exp32 > 0 then
+        sig_base := mant80(FP_MANT_WIDTH-1 downto FP_MANT_WIDTH-24);
+        guard_bit := mant80(FP_MANT_WIDTH-25);
+        sticky_bit := '0';
+        for idx in 0 to FP_MANT_WIDTH-26 loop
+          if mant80(idx) = '1' then
+            sticky_bit := '1';
+          end if;
+        end loop;
+        round_up := should_round_up(value(FP_WIDTH-1), sig_base(0), guard_bit, sticky_bit, mode);
+        sig_round := resize(sig_base, sig_round'length);
+        if round_up = '1' then
+          sig_round := sig_round + 1;
+        end if;
+        if sig_round(sig_round'left) = '1' then
+          exp32 := exp32 + 1;
+          sig_base := sig_round(sig_round'left downto 1);
+        else
+          sig_base := sig_round(sig_base'range);
+        end if;
+
+        if exp32 >= 255 then
+          case mode is
+            when FP_RND_NEAREST =>
+              bits32(30 downto 23) := (others => '1');
+              bits32(22 downto 0) := (others => '0');
+            when FP_RND_ZERO =>
+              bits32(30 downto 23) := std_logic_vector(to_unsigned(254, 8));
+              bits32(22 downto 0) := (others => '1');
+            when FP_RND_MINUS_INF =>
+              if value(FP_WIDTH-1) = '1' then
+                bits32(30 downto 23) := (others => '1');
+                bits32(22 downto 0) := (others => '0');
+              else
+                bits32(30 downto 23) := std_logic_vector(to_unsigned(254, 8));
+                bits32(22 downto 0) := (others => '1');
+              end if;
+            when FP_RND_PLUS_INF =>
+              if value(FP_WIDTH-1) = '0' then
+                bits32(30 downto 23) := (others => '1');
+                bits32(22 downto 0) := (others => '0');
+              else
+                bits32(30 downto 23) := std_logic_vector(to_unsigned(254, 8));
+                bits32(22 downto 0) := (others => '1');
+              end if;
+          end case;
+          return bits32;
+        end if;
+
+        bits32(30 downto 23) := std_logic_vector(to_unsigned(exp32, 8));
+        bits32(22 downto 0) := std_logic_vector(sig_base(22 downto 0));
         return bits32;
-      elsif exp32 >= 255 then
-        bits32(30 downto 23) := (others => '1');
+      else
+        -- Gradual underflow: right-shift significand into subnormal range.
+        shift_total := 40 + (1 - exp32);
+        sig_base := (others => '0');
+        guard_bit := '0';
+        sticky_bit := '0';
+        if shift_total < FP_MANT_WIDTH then
+          sig_base := shift_right(mant80, shift_total)(23 downto 0);
+        end if;
+
+        if shift_total > 0 and shift_total - 1 < FP_MANT_WIDTH then
+          guard_bit := mant80(shift_total - 1);
+        end if;
+        sticky_hi := shift_total - 2;
+        if sticky_hi > FP_MANT_WIDTH-1 then
+          sticky_hi := FP_MANT_WIDTH-1;
+        end if;
+        if sticky_hi >= 0 then
+          for idx in 0 to sticky_hi loop
+            if mant80(idx) = '1' then
+              sticky_bit := '1';
+            end if;
+          end loop;
+        end if;
+
+        round_up := should_round_up(value(FP_WIDTH-1), sig_base(0), guard_bit, sticky_bit, mode);
+        sig_round := resize(sig_base, sig_round'length);
+        if round_up = '1' then
+          sig_round := sig_round + 1;
+        end if;
+
+        if sig_round(23) = '1' then
+          bits32(30 downto 23) := std_logic_vector(to_unsigned(1, 8));
+          bits32(22 downto 0) := (others => '0');
+        else
+          bits32(30 downto 23) := (others => '0');
+          bits32(22 downto 0) := std_logic_vector(sig_round(22 downto 0));
+        end if;
         return bits32;
       end if;
-      bits32(30 downto 23) := std_logic_vector(to_unsigned(exp32, 8));
-      bits32(22 downto 0) := value(FP_MANT_WIDTH-2 downto FP_MANT_WIDTH-24);
-      return bits32;
     end if;
   end function;
 
-  function fp80_to_double(value : fp80_t) return std_logic_vector is
+  function fp80_to_double(value : fp80_t; mode : fp_round_mode_t) return std_logic_vector is
     variable bits64 : std_logic_vector(63 downto 0) := (others => '0');
-    variable exp80 : unsigned(FP_EXP_WIDTH-1 downto 0) := unsigned(value(FP_WIDTH-2 downto FP_WIDTH-1-FP_EXP_WIDTH));
+    variable exp80_u : unsigned(FP_EXP_WIDTH-1 downto 0) := unsigned(value(FP_WIDTH-2 downto FP_WIDTH-1-FP_EXP_WIDTH));
     variable frac80 : unsigned(FP_MANT_WIDTH-2 downto 0) := unsigned(value(FP_MANT_WIDTH-2 downto 0));
+    variable mant80 : unsigned(FP_MANT_WIDTH-1 downto 0) := unsigned(value(FP_MANT_WIDTH-1 downto 0));
+    variable exp80_i : integer := 0;
     variable exp64 : integer := 0;
+    variable sig_base : unsigned(52 downto 0) := (others => '0');
+    variable sig_round : unsigned(53 downto 0) := (others => '0');
+    variable guard_bit : std_logic := '0';
+    variable sticky_bit : std_logic := '0';
+    variable round_up : std_logic := '0';
+    variable shift_total : integer := 0;
+    variable sticky_hi : integer := -1;
   begin
     bits64(63) := value(FP_WIDTH-1);
-    if exp80 = 0 then
+    exp80_i := to_integer(exp80_u);
+
+    if exp80_u = 0 then
       return bits64;
-    elsif exp80 = FP_EXP_ALL_ONES then
+    elsif exp80_u = FP_EXP_ALL_ONES then
       bits64(62 downto 52) := (others => '1');
       if frac80 /= 0 then
-        bits64(51) := '1';
+        bits64(51 downto 0) := value(FP_MANT_WIDTH-2 downto FP_MANT_WIDTH-53);
+        if bits64(51 downto 0) = std_logic_vector(to_unsigned(0, 52)) then
+          bits64(51) := '1';
+        end if;
       end if;
       return bits64;
     else
-      exp64 := to_integer(exp80) - FP_EXP_BIAS + 1023;
-      if exp64 <= 0 then
+      exp64 := exp80_i - FP_EXP_BIAS + 1023;
+      if exp64 > 0 then
+        sig_base := mant80(FP_MANT_WIDTH-1 downto FP_MANT_WIDTH-53);
+        guard_bit := mant80(FP_MANT_WIDTH-54);
+        sticky_bit := '0';
+        for idx in 0 to FP_MANT_WIDTH-55 loop
+          if mant80(idx) = '1' then
+            sticky_bit := '1';
+          end if;
+        end loop;
+        round_up := should_round_up(value(FP_WIDTH-1), sig_base(0), guard_bit, sticky_bit, mode);
+        sig_round := resize(sig_base, sig_round'length);
+        if round_up = '1' then
+          sig_round := sig_round + 1;
+        end if;
+        if sig_round(sig_round'left) = '1' then
+          exp64 := exp64 + 1;
+          sig_base := sig_round(sig_round'left downto 1);
+        else
+          sig_base := sig_round(sig_base'range);
+        end if;
+
+        if exp64 >= 2047 then
+          case mode is
+            when FP_RND_NEAREST =>
+              bits64(62 downto 52) := (others => '1');
+              bits64(51 downto 0) := (others => '0');
+            when FP_RND_ZERO =>
+              bits64(62 downto 52) := std_logic_vector(to_unsigned(2046, 11));
+              bits64(51 downto 0) := (others => '1');
+            when FP_RND_MINUS_INF =>
+              if value(FP_WIDTH-1) = '1' then
+                bits64(62 downto 52) := (others => '1');
+                bits64(51 downto 0) := (others => '0');
+              else
+                bits64(62 downto 52) := std_logic_vector(to_unsigned(2046, 11));
+                bits64(51 downto 0) := (others => '1');
+              end if;
+            when FP_RND_PLUS_INF =>
+              if value(FP_WIDTH-1) = '0' then
+                bits64(62 downto 52) := (others => '1');
+                bits64(51 downto 0) := (others => '0');
+              else
+                bits64(62 downto 52) := std_logic_vector(to_unsigned(2046, 11));
+                bits64(51 downto 0) := (others => '1');
+              end if;
+          end case;
+          return bits64;
+        end if;
+
+        bits64(62 downto 52) := std_logic_vector(to_unsigned(exp64, 11));
+        bits64(51 downto 0) := std_logic_vector(sig_base(51 downto 0));
         return bits64;
-      elsif exp64 >= 2047 then
-        bits64(62 downto 52) := (others => '1');
+      else
+        shift_total := 11 + (1 - exp64);
+        sig_base := (others => '0');
+        guard_bit := '0';
+        sticky_bit := '0';
+        if shift_total < FP_MANT_WIDTH then
+          sig_base := shift_right(mant80, shift_total)(52 downto 0);
+        end if;
+
+        if shift_total > 0 and shift_total - 1 < FP_MANT_WIDTH then
+          guard_bit := mant80(shift_total - 1);
+        end if;
+        sticky_hi := shift_total - 2;
+        if sticky_hi > FP_MANT_WIDTH-1 then
+          sticky_hi := FP_MANT_WIDTH-1;
+        end if;
+        if sticky_hi >= 0 then
+          for idx in 0 to sticky_hi loop
+            if mant80(idx) = '1' then
+              sticky_bit := '1';
+            end if;
+          end loop;
+        end if;
+
+        round_up := should_round_up(value(FP_WIDTH-1), sig_base(0), guard_bit, sticky_bit, mode);
+        sig_round := resize(sig_base, sig_round'length);
+        if round_up = '1' then
+          sig_round := sig_round + 1;
+        end if;
+
+        if sig_round(52) = '1' then
+          bits64(62 downto 52) := std_logic_vector(to_unsigned(1, 11));
+          bits64(51 downto 0) := (others => '0');
+        else
+          bits64(62 downto 52) := (others => '0');
+          bits64(51 downto 0) := std_logic_vector(sig_round(51 downto 0));
+        end if;
         return bits64;
       end if;
-      bits64(62 downto 52) := std_logic_vector(to_unsigned(exp64, 11));
-      bits64(51 downto 0) := value(FP_MANT_WIDTH-2 downto FP_MANT_WIDTH-53);
-      return bits64;
     end if;
   end function;
 
@@ -640,6 +868,10 @@ begin
     variable res_nan  : boolean;
     variable res_subnormal : boolean;
     variable aexc_combined : std_logic_vector(4 downto 0);
+    variable class_opa : fp80_t := (others => '0');
+    variable class_opb : fp80_t := FP80_CLASSIFY_ONE;
+    variable class_result : fp80_t := (others => '0');
+    variable class_divzero : std_logic := '0';
   begin
     if reset_n = '0' then
       op_sel_reg <= FPU_OP_NOP;
@@ -738,20 +970,32 @@ begin
         end case;
       end if;
 
-      -- Exception classification is performed at result-valid boundary.
-      if valid = '1' then
+      -- Exception classification is performed at operation-complete boundary
+      -- (ALU valid or FMOVE conversion completion event).
+      if valid = '1' or exc_event_valid_reg = '1' then
         exc_flags := (others => '0');
         exc_policy := op_exception_policy(last_op_sel_reg);
-        a_zero := fp80_is_zero(operand_reg(0));
-        b_zero := fp80_is_zero(operand_reg(1));
-        a_inf := fp80_is_inf(operand_reg(0));
-        b_inf := fp80_is_inf(operand_reg(1));
-        a_nan := fp80_is_nan(operand_reg(0));
-        b_nan := fp80_is_nan(operand_reg(1));
-        res_zero := fp80_is_zero(result);
-        res_inf := fp80_is_inf(result);
-        res_nan := fp80_is_nan(result);
-        res_subnormal := fp80_exp_is_zero_nonzero_mant(result);
+        if valid = '1' then
+          class_opa := operand_reg(0);
+          class_opb := operand_reg(1);
+          class_result := result;
+          class_divzero := alu_flag_divzero;
+        else
+          class_opa := exc_event_opa_reg;
+          class_opb := exc_event_opb_reg;
+          class_result := exc_event_result_reg;
+          class_divzero := exc_event_divzero_reg;
+        end if;
+        a_zero := fp80_is_zero(class_opa);
+        b_zero := fp80_is_zero(class_opb);
+        a_inf := fp80_is_inf(class_opa);
+        b_inf := fp80_is_inf(class_opb);
+        a_nan := fp80_is_nan(class_opa);
+        b_nan := fp80_is_nan(class_opb);
+        res_zero := fp80_is_zero(class_result);
+        res_inf := fp80_is_inf(class_result);
+        res_nan := fp80_is_nan(class_result);
+        res_subnormal := fp80_exp_is_zero_nonzero_mant(class_result);
 
         if exc_policy.invalid_on_nan_inputs and (a_nan or b_nan) then
           exc_flags(FPSR_EXC_INVALID) := '1';
@@ -773,7 +1017,7 @@ begin
         end if;
 
         -- Trig/divrem unit explicit DZ flag (FLOGNP1(-1), FATANH(±1), etc.)
-        if alu_flag_divzero = '1' then
+        if class_divzero = '1' then
           exc_flags(FPSR_EXC_DIVZERO) := '1';
         end if;
 
@@ -828,14 +1072,14 @@ begin
         end if;
 
         if exc_policy.update_cc_from_compare then
-          cc_bits := fpsr_cc_from_compare(operand_reg(0), operand_reg(1));
+          cc_bits := fpsr_cc_from_compare(class_opa, class_opb);
           fpsr_reg(FPSR_CC_NEG downto FPSR_CC_NAN) <= cc_bits;
         elsif exc_policy.update_cc_from_result then
           if exc_flags(FPSR_EXC_INVALID) = '1' then
             cc_bits := (others => '0');
             cc_bits(0) := '1';
           else
-            cc_bits := fpsr_cc_from_result(result);
+            cc_bits := fpsr_cc_from_result(class_result);
           end if;
           fpsr_reg(FPSR_CC_NEG downto FPSR_CC_NAN) <= cc_bits;
         end if;
@@ -844,7 +1088,7 @@ begin
           fpiar_reg <= fpiar_issue_snapshot_reg;
         end if;
 
-        if quotient_valid = '1' then
+        if valid = '1' and quotient_valid = '1' then
           fpsr_reg(FPSR_QUOT_MSB downto FPSR_QUOT_LSB) <= quotient_byte;
         end if;
       end if;
@@ -906,6 +1150,13 @@ begin
     variable int_value : integer := 0;
     variable packed_k : integer := 0;
     variable move_cfg : move_cfg_t := move_cfg_default;
+    variable move_exc_result : fp80_t := (others => '0');
+    variable move_exc_opa : fp80_t := (others => '0');
+    variable move_exc_opb : fp80_t := FP80_CLASSIFY_ONE;
+    variable move_exc_enable : std_logic := '0';
+    variable prog_result : std_logic_vector(31 downto 0) := (others => '0');
+    variable cc_field : std_logic_vector(3 downto 0) := (others => '0');
+    variable cond_true : std_logic := '0';
   begin
     if reset_n = '0' then
       result_lo_reg <= (others => '0');
@@ -926,9 +1177,16 @@ begin
       ctrl_move_write_req_reg <= '0';
       ctrl_move_sel_reg <= (others => '0');
       ctrl_move_data_reg <= (others => '0');
+      exc_event_valid_reg <= '0';
+      exc_event_result_reg <= (others => '0');
+      exc_event_opa_reg <= (others => '0');
+      exc_event_opb_reg <= FP80_CLASSIFY_ONE;
+      exc_event_divzero_reg <= '0';
     elsif rising_edge(clk) then
       op_start_reg <= '0';
       ctrl_move_write_req_reg <= '0';
+      exc_event_valid_reg <= '0';
+      exc_event_divzero_reg <= '0';
 
       if op_issue_pulse = '1' then
         result_ready_reg <= '0';
@@ -964,6 +1222,10 @@ begin
               dst_idx := move_cfg.dst_idx;
               ctrl_sel := move_cfg.ctrl_sel;
               move_result := (others => '0');
+              move_exc_result := (others => '0');
+              move_exc_opa := (others => '0');
+              move_exc_opb := FP80_CLASSIFY_ONE;
+              move_exc_enable := '0';
 
               if move_cfg.fmovecr_enable = '1' then
                 move_result := fmovecr_constant(operand_reg(0)(6 downto 0));
@@ -984,12 +1246,21 @@ begin
                           int_value := signed32_to_integer(operand_reg(0)(31 downto 0));
                       end case;
                       move_result := fp80_from_int(int_value);
+                      move_exc_enable := '1';
+                      move_exc_result := move_result;
+                      move_exc_opa := move_result;
                     else
                       case mem_fmt is
                         when "01" =>
                           move_result := fp80_from_single(operand_reg(0)(31 downto 0));
+                          move_exc_enable := '1';
+                          move_exc_result := move_result;
+                          move_exc_opa := move_result;
                         when "10" =>
                           move_result := fp80_from_double(operand_reg(0)(63 downto 0));
+                          move_exc_enable := '1';
+                          move_exc_result := move_result;
+                          move_exc_opa := move_result;
                         when others =>
                           move_result := operand_reg(0);
                       end case;
@@ -997,6 +1268,7 @@ begin
                     fp_reg_file_reg(dst_idx) <= move_result;
                   when MOVE_CFG_MODE_REG_TO_MEM =>
                     move_result := fp_reg_file_reg(src_idx);
+                    move_exc_opa := move_result;
                     if move_cfg.reg_to_mem_packed = '1' then
                       if move_cfg.packed_k_from_opa = '1' then
                         packed_k := signed8_to_integer(operand_reg(0)(7 downto 0));
@@ -1004,18 +1276,24 @@ begin
                         packed_k := signed8_to_integer(operand_reg(1)(7 downto 0));
                       end if;
                       move_result := apply_packed_k_factor(move_result, packed_k);
+                      move_exc_enable := '1';
+                      move_exc_result := move_result;
                       result_lo_reg <= move_result(FP80_RESULT_LO_WIDTH-1 downto 0);
                       result_hi_reg <= move_result(FP80_RESULT_LO_WIDTH+FP80_RESULT_HI_WIDTH-1 downto FP80_RESULT_LO_WIDTH);
                       result_ex_reg <= move_result(FP_WIDTH-1 downto FP_WIDTH-FP80_RESULT_EX_WIDTH);
                     else
                       case mem_fmt is
                         when "01" =>
-                          single_bits := fp80_to_single(move_result);
+                          single_bits := fp80_to_single(move_result, round_mode);
+                          move_exc_enable := '1';
+                          move_exc_result := fp80_from_single(single_bits);
                           result_lo_reg <= single_bits;
                           result_hi_reg <= (others => '0');
                           result_ex_reg <= (others => '0');
                         when "10" =>
-                          double_bits := fp80_to_double(move_result);
+                          double_bits := fp80_to_double(move_result, round_mode);
+                          move_exc_enable := '1';
+                          move_exc_result := fp80_from_double(double_bits);
                           result_lo_reg <= double_bits(31 downto 0);
                           result_hi_reg <= double_bits(63 downto 32);
                           result_ex_reg <= (others => '0');
@@ -1048,6 +1326,12 @@ begin
                 result_lo_reg <= move_result(FP80_RESULT_LO_WIDTH-1 downto 0);
                 result_hi_reg <= move_result(FP80_RESULT_LO_WIDTH+FP80_RESULT_HI_WIDTH-1 downto FP80_RESULT_LO_WIDTH);
                 result_ex_reg <= move_result(FP_WIDTH-1 downto FP_WIDTH-FP80_RESULT_EX_WIDTH);
+              end if;
+              if move_exc_enable = '1' then
+                exc_event_valid_reg <= '1';
+                exc_event_result_reg <= move_exc_result;
+                exc_event_opa_reg <= move_exc_opa;
+                exc_event_opb_reg <= move_exc_opb;
               end if;
               result_ready_reg <= '1';
             elsif op_sel_write_decoded = FPU_OP_MOVEM then

--- a/tb/tb_mc68881_fmove_fmovem.vhd
+++ b/tb/tb_mc68881_fmove_fmovem.vhd
@@ -63,6 +63,10 @@ architecture sim of tb_mc68881_fmove_fmovem is
   constant FP80_SINGLE_OVERFLOW : fp80_t := x"407F8000000000000000";
   constant FP80_DOUBLE_HALF_ULP : fp80_t := x"3FFF8000000000000400";
   constant FP80_DOUBLE_MIN_SUBNORMAL : fp80_t := x"3BCD8000000000000000";
+  constant FP80_DOUBLE_OVERFLOW : fp80_t := x"43FF8000000000000000";
+  constant FP80_SINGLE_OVERFLOW_NEG : fp80_t := x"C07F8000000000000000";
+  constant FP80_SINGLE_HALF_ULP_NEG : fp80_t := x"BFFF8000008000000000";
+  constant FPSR_CC_NAN : natural := 24;
 
   procedure split_fp80(
     constant value : fp80_t;
@@ -447,6 +451,112 @@ begin
     assert rd_ex(FPSR_AEXC_BASE + FPSR_EXC_UNDERFLOW) = '1'
       report "FMOVE double gradual underflow should set FPSR AEXC underflow"
       severity failure;
+    assert rd_ex(FPSR_EXC_BASE + FPSR_EXC_INEXACT) = '1'
+      report "FMOVE double gradual underflow should set FPSR EXC inexact"
+      severity failure;
+
+    report "FMOVE double overflow checks" severity note;
+    -- Load double-overflow source (2^1024, above double max ~1.8e308)
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_L, FP80_DOUBLE_OVERFLOW(31 downto 0));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_H, FP80_DOUBLE_OVERFLOW(63 downto 32));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_E, x"0000" & FP80_DOUBLE_OVERFLOW(79 downto 64));
+    cfg_word := make_move_cfg("01", 0, 7, "00", '0', "00", (others => '0'), '0');
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_MOVE_CFG, cfg_word);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
+    -- Double overflow RZ: should saturate to max finite (7FEFFFFF_FFFFFFFF)
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPCR, x"00000010");
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPSR, (others => '0'));
+    cfg_word := make_move_cfg("10", 7, 0, "10", '0', "00", (others => '0'), '0');
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_MOVE_CFG, cfg_word);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_lo, ADDR_RES_L);
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_hi, ADDR_RES_H);
+    report "FMOVE double overflow RZ observed hi=" & to_hstring(rd_hi) &
+           " lo=" & to_hstring(rd_lo) severity note;
+    assert rd_hi = x"7FEFFFFF" and rd_lo = x"FFFFFFFF"
+      report "FMOVE double overflow in RZ should saturate to max finite"
+      severity failure;
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_ex, ADDR_FPSR);
+    report "FMOVE double overflow RZ FPSR=" & to_hstring(rd_ex) severity note;
+    assert rd_ex(FPSR_EXC_BASE + FPSR_EXC_OVERFLOW) = '1'
+      report "FMOVE double overflow in RZ should set FPSR EXC overflow"
+      severity failure;
+    assert rd_ex(FPSR_EXC_BASE + FPSR_EXC_INEXACT) = '1'
+      report "FMOVE double overflow in RZ should set FPSR EXC inexact"
+      severity failure;
+    -- Double overflow RP: should produce +infinity (7FF00000_00000000)
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPCR, x"00000030");
+    cfg_word := make_move_cfg("10", 7, 0, "10", '0', "00", (others => '0'), '0');
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_MOVE_CFG, cfg_word);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_lo, ADDR_RES_L);
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_hi, ADDR_RES_H);
+    report "FMOVE double overflow RP observed hi=" & to_hstring(rd_hi) &
+           " lo=" & to_hstring(rd_lo) severity note;
+    assert rd_hi = x"7FF00000" and rd_lo = x"00000000"
+      report "FMOVE double overflow in RP should produce +infinity"
+      severity failure;
+
+    report "FMOVE negative overflow and RM rounding checks" severity note;
+    -- Load negative single overflow source
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_L, FP80_SINGLE_OVERFLOW_NEG(31 downto 0));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_H, FP80_SINGLE_OVERFLOW_NEG(63 downto 32));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_E, x"0000" & FP80_SINGLE_OVERFLOW_NEG(79 downto 64));
+    cfg_word := make_move_cfg("01", 0, 7, "00", '0', "00", (others => '0'), '0');
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_MOVE_CFG, cfg_word);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
+    -- Negative overflow RP: negative rounds toward +inf = truncate = -max-finite (FF7FFFFF)
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPCR, x"00000030");
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPSR, (others => '0'));
+    cfg_word := make_move_cfg("10", 7, 0, "01", '0', "00", (others => '0'), '0');
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_MOVE_CFG, cfg_word);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_lo, ADDR_RES_L);
+    report "FMOVE single neg overflow RP observed=" & to_hstring(rd_lo) severity note;
+    assert rd_lo = x"FF7FFFFF"
+      report "FMOVE single neg overflow in RP should saturate to -max-finite"
+      severity failure;
+    -- Negative overflow RM: negative rounds toward -inf = away from zero = -inf (FF800000)
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPCR, x"00000020");
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPSR, (others => '0'));
+    cfg_word := make_move_cfg("10", 7, 0, "01", '0', "00", (others => '0'), '0');
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_MOVE_CFG, cfg_word);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_lo, ADDR_RES_L);
+    report "FMOVE single neg overflow RM observed=" & to_hstring(rd_lo) severity note;
+    assert rd_lo = x"FF800000"
+      report "FMOVE single neg overflow in RM should produce -infinity"
+      severity failure;
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_hi, ADDR_FPSR);
+    report "FMOVE single neg overflow RM FPSR=" & to_hstring(rd_hi) severity note;
+    assert rd_hi(FPSR_EXC_BASE + FPSR_EXC_OVERFLOW) = '1'
+      report "FMOVE single neg overflow in RM should set FPSR EXC overflow"
+      severity failure;
+
+    -- RM rounding: negative half-ULP tie should round away from zero
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_L, FP80_SINGLE_HALF_ULP_NEG(31 downto 0));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_H, FP80_SINGLE_HALF_ULP_NEG(63 downto 32));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_E, x"0000" & FP80_SINGLE_HALF_ULP_NEG(79 downto 64));
+    cfg_word := make_move_cfg("01", 0, 7, "00", '0', "00", (others => '0'), '0');
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_MOVE_CFG, cfg_word);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPCR, x"00000020");
+    cfg_word := make_move_cfg("10", 7, 0, "01", '0', "00", (others => '0'), '0');
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_MOVE_CFG, cfg_word);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_lo, ADDR_RES_L);
+    report "FMOVE single neg tie RM observed=" & to_hstring(rd_lo) severity note;
+    assert rd_lo = x"BF800001"
+      report "FMOVE single neg tie in RM should round away from zero (-1.0 - 1ULP)"
+      severity failure;
 
     report "FMOVE subnormal single/double source checks" severity note;
 
@@ -671,6 +781,9 @@ begin
       severity failure;
     assert rd_lo(FPSR_AEXC_BASE + FPSR_EXC_INVALID) = '1'
       report "FMOVE qNaN should set FPSR AEXC invalid"
+      severity failure;
+    assert rd_lo(FPSR_CC_NAN) = '1'
+      report "FMOVE qNaN should set FPSR CC NAN bit"
       severity failure;
     bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, fpiar_word, ADDR_FPIAR);
     report "FMOVE qNaN FPIAR=" & to_hstring(fpiar_word) severity note;

--- a/tb/tb_mc68881_fmove_fmovem.vhd
+++ b/tb/tb_mc68881_fmove_fmovem.vhd
@@ -40,6 +40,9 @@ architecture sim of tb_mc68881_fmove_fmovem is
   constant FPSR_AEXC_BASE : natural := 0;
   constant FPSR_EXC_BASE : natural := 8;
   constant FPSR_EXC_INVALID : natural := 4;
+  constant FPSR_EXC_OVERFLOW : natural := 2;
+  constant FPSR_EXC_UNDERFLOW : natural := 1;
+  constant FPSR_EXC_INEXACT : natural := 0;
 
   constant OP_FMOVE : std_logic_vector(31 downto 0) := x"00000005";
   constant OP_FMOVEM : std_logic_vector(31 downto 0) := x"00000006";
@@ -322,6 +325,7 @@ begin
     bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
     wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
     bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPCR, x"00000010");
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPSR, (others => '0'));
     cfg_word := make_move_cfg("10", 7, 0, "01", '0', "00", (others => '0'), '0');
     bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_MOVE_CFG, cfg_word);
     bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
@@ -330,6 +334,17 @@ begin
     report "FMOVE single min-subnormal observed=" & to_hstring(rd_lo) severity note;
     assert rd_lo = x"00000001"
       report "FMOVE single gradual underflow should keep min subnormal"
+      severity failure;
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_hi, ADDR_FPSR);
+    report "FMOVE single min-subnormal FPSR=" & to_hstring(rd_hi) severity note;
+    assert rd_hi(FPSR_EXC_BASE + FPSR_EXC_UNDERFLOW) = '1'
+      report "FMOVE single gradual underflow should set FPSR EXC underflow"
+      severity failure;
+    assert rd_hi(FPSR_AEXC_BASE + FPSR_EXC_UNDERFLOW) = '1'
+      report "FMOVE single gradual underflow should set FPSR AEXC underflow"
+      severity failure;
+    assert rd_hi(FPSR_EXC_BASE + FPSR_EXC_INEXACT) = '1'
+      report "FMOVE single gradual underflow should set FPSR EXC inexact"
       severity failure;
 
     bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_L, FP80_SINGLE_OVERFLOW(31 downto 0));
@@ -340,6 +355,7 @@ begin
     bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
     wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
     bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPCR, x"00000010");
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPSR, (others => '0'));
     cfg_word := make_move_cfg("10", 7, 0, "01", '0', "00", (others => '0'), '0');
     bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_MOVE_CFG, cfg_word);
     bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
@@ -348,6 +364,17 @@ begin
     report "FMOVE single overflow RZ observed=" & to_hstring(rd_lo) severity note;
     assert rd_lo = x"7F7FFFFF"
       report "FMOVE single overflow in RZ should saturate to max finite"
+      severity failure;
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_hi, ADDR_FPSR);
+    report "FMOVE single overflow RZ FPSR=" & to_hstring(rd_hi) severity note;
+    assert rd_hi(FPSR_EXC_BASE + FPSR_EXC_OVERFLOW) = '1'
+      report "FMOVE single overflow in RZ should set FPSR EXC overflow"
+      severity failure;
+    assert rd_hi(FPSR_AEXC_BASE + FPSR_EXC_OVERFLOW) = '1'
+      report "FMOVE single overflow in RZ should set FPSR AEXC overflow"
+      severity failure;
+    assert rd_hi(FPSR_EXC_BASE + FPSR_EXC_INEXACT) = '1'
+      report "FMOVE single overflow in RZ should set FPSR EXC inexact"
       severity failure;
     bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPCR, x"00000030");
     cfg_word := make_move_cfg("10", 7, 0, "01", '0', "00", (others => '0'), '0');
@@ -400,6 +427,7 @@ begin
     bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
     wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
     bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPCR, x"00000010");
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPSR, (others => '0'));
     cfg_word := make_move_cfg("10", 7, 0, "10", '0', "00", (others => '0'), '0');
     bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_MOVE_CFG, cfg_word);
     bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
@@ -410,6 +438,14 @@ begin
            " lo=" & to_hstring(rd_lo) severity note;
     assert rd_hi = x"00000000" and rd_lo = x"00000001"
       report "FMOVE double gradual underflow should keep min subnormal"
+      severity failure;
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_ex, ADDR_FPSR);
+    report "FMOVE double min-subnormal FPSR=" & to_hstring(rd_ex) severity note;
+    assert rd_ex(FPSR_EXC_BASE + FPSR_EXC_UNDERFLOW) = '1'
+      report "FMOVE double gradual underflow should set FPSR EXC underflow"
+      severity failure;
+    assert rd_ex(FPSR_AEXC_BASE + FPSR_EXC_UNDERFLOW) = '1'
+      report "FMOVE double gradual underflow should set FPSR AEXC underflow"
       severity failure;
 
     report "FMOVE subnormal single/double source checks" severity note;

--- a/tb/tb_mc68881_fmove_fmovem.vhd
+++ b/tb/tb_mc68881_fmove_fmovem.vhd
@@ -37,12 +37,16 @@ architecture sim of tb_mc68881_fmove_fmovem is
   constant ADDR_FPSR : unsigned(4 downto 0) := to_unsigned(14, 5);
   constant ADDR_MOVE_CFG : unsigned(4 downto 0) := to_unsigned(23, 5);
   constant ADDR_FPIAR : unsigned(4 downto 0) := to_unsigned(24, 5);
+  constant FPSR_AEXC_BASE : natural := 0;
+  constant FPSR_EXC_BASE : natural := 8;
+  constant FPSR_EXC_INVALID : natural := 4;
 
   constant OP_FMOVE : std_logic_vector(31 downto 0) := x"00000005";
   constant OP_FMOVEM : std_logic_vector(31 downto 0) := x"00000006";
   constant FMOVECR_PI : fp80_t := x"4000C90FDAA22168C235";
   constant FMOVE_SINGLE_SUBMIN_NEG : std_logic_vector(31 downto 0) := x"80000001";
   constant FMOVE_SINGLE_SUBMAX_POS : std_logic_vector(31 downto 0) := x"007FFFFF";
+  constant FMOVE_SINGLE_QNAN : std_logic_vector(31 downto 0) := x"7FC12345";
   constant FMOVE_DOUBLE_SUBMIN_POS_LO : std_logic_vector(31 downto 0) := x"00000001";
   constant FMOVE_DOUBLE_SUBMIN_POS_HI : std_logic_vector(31 downto 0) := x"00000000";
   constant FMOVE_DOUBLE_SUBMAX_POS_LO : std_logic_vector(31 downto 0) := x"FFFFFFFF";
@@ -51,6 +55,11 @@ architecture sim of tb_mc68881_fmove_fmovem is
   constant FMOVE_SINGLE_SUBMAX_POS_FP80 : fp80_t := x"3F80FFFFFE0000000000";
   constant FMOVE_DOUBLE_SUBMIN_POS_FP80 : fp80_t := x"3BCD8000000000000000";
   constant FMOVE_DOUBLE_SUBMAX_POS_FP80 : fp80_t := x"3C00FFFFFFFFFFFFF000";
+  constant FP80_SINGLE_HALF_ULP : fp80_t := x"3FFF8000008000000000";
+  constant FP80_SINGLE_MIN_SUBNORMAL : fp80_t := x"3F6A8000000000000000";
+  constant FP80_SINGLE_OVERFLOW : fp80_t := x"407F8000000000000000";
+  constant FP80_DOUBLE_HALF_ULP : fp80_t := x"3FFF8000000000000400";
+  constant FP80_DOUBLE_MIN_SUBNORMAL : fp80_t := x"3BCD8000000000000000";
 
   procedure split_fp80(
     constant value : fp80_t;
@@ -274,6 +283,135 @@ begin
       report "FMOVE single conversion mismatch expected=42280000 got=" & to_hstring(rd_lo)
       severity failure;
 
+    report "FMOVE single/double rounding and range conversion checks" severity note;
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_L, FP80_SINGLE_HALF_ULP(31 downto 0));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_H, FP80_SINGLE_HALF_ULP(63 downto 32));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_E, x"0000" & FP80_SINGLE_HALF_ULP(79 downto 64));
+    cfg_word := make_move_cfg("01", 0, 7, "00", '0', "00", (others => '0'), '0');
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_MOVE_CFG, cfg_word);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
+
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPCR, x"00000000");
+    cfg_word := make_move_cfg("10", 7, 0, "01", '0', "00", (others => '0'), '0');
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_MOVE_CFG, cfg_word);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_lo, ADDR_RES_L);
+    report "FMOVE single tie-nearest observed=" & to_hstring(rd_lo) severity note;
+    assert rd_lo = x"3F800000"
+      report "FMOVE single tie-nearest should round to even (1.0)"
+      severity failure;
+
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPCR, x"00000030");
+    cfg_word := make_move_cfg("10", 7, 0, "01", '0', "00", (others => '0'), '0');
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_MOVE_CFG, cfg_word);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_lo, ADDR_RES_L);
+    report "FMOVE single tie-plus-inf observed=" & to_hstring(rd_lo) severity note;
+    assert rd_lo = x"3F800001"
+      report "FMOVE single tie-plus-inf should round upward"
+      severity failure;
+
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_L, FP80_SINGLE_MIN_SUBNORMAL(31 downto 0));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_H, FP80_SINGLE_MIN_SUBNORMAL(63 downto 32));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_E, x"0000" & FP80_SINGLE_MIN_SUBNORMAL(79 downto 64));
+    cfg_word := make_move_cfg("01", 0, 7, "00", '0', "00", (others => '0'), '0');
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_MOVE_CFG, cfg_word);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPCR, x"00000010");
+    cfg_word := make_move_cfg("10", 7, 0, "01", '0', "00", (others => '0'), '0');
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_MOVE_CFG, cfg_word);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_lo, ADDR_RES_L);
+    report "FMOVE single min-subnormal observed=" & to_hstring(rd_lo) severity note;
+    assert rd_lo = x"00000001"
+      report "FMOVE single gradual underflow should keep min subnormal"
+      severity failure;
+
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_L, FP80_SINGLE_OVERFLOW(31 downto 0));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_H, FP80_SINGLE_OVERFLOW(63 downto 32));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_E, x"0000" & FP80_SINGLE_OVERFLOW(79 downto 64));
+    cfg_word := make_move_cfg("01", 0, 7, "00", '0', "00", (others => '0'), '0');
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_MOVE_CFG, cfg_word);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPCR, x"00000010");
+    cfg_word := make_move_cfg("10", 7, 0, "01", '0', "00", (others => '0'), '0');
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_MOVE_CFG, cfg_word);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_lo, ADDR_RES_L);
+    report "FMOVE single overflow RZ observed=" & to_hstring(rd_lo) severity note;
+    assert rd_lo = x"7F7FFFFF"
+      report "FMOVE single overflow in RZ should saturate to max finite"
+      severity failure;
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPCR, x"00000030");
+    cfg_word := make_move_cfg("10", 7, 0, "01", '0', "00", (others => '0'), '0');
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_MOVE_CFG, cfg_word);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_lo, ADDR_RES_L);
+    report "FMOVE single overflow RP observed=" & to_hstring(rd_lo) severity note;
+    assert rd_lo = x"7F800000"
+      report "FMOVE single overflow in RP should produce +infinity"
+      severity failure;
+
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_L, FP80_DOUBLE_HALF_ULP(31 downto 0));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_H, FP80_DOUBLE_HALF_ULP(63 downto 32));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_E, x"0000" & FP80_DOUBLE_HALF_ULP(79 downto 64));
+    cfg_word := make_move_cfg("01", 0, 7, "00", '0', "00", (others => '0'), '0');
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_MOVE_CFG, cfg_word);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPCR, x"00000000");
+    cfg_word := make_move_cfg("10", 7, 0, "10", '0', "00", (others => '0'), '0');
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_MOVE_CFG, cfg_word);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_lo, ADDR_RES_L);
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_hi, ADDR_RES_H);
+    report "FMOVE double tie-nearest observed hi=" & to_hstring(rd_hi) &
+           " lo=" & to_hstring(rd_lo) severity note;
+    assert rd_hi = x"3FF00000" and rd_lo = x"00000000"
+      report "FMOVE double tie-nearest should round to even (1.0)"
+      severity failure;
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPCR, x"00000030");
+    cfg_word := make_move_cfg("10", 7, 0, "10", '0', "00", (others => '0'), '0');
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_MOVE_CFG, cfg_word);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_lo, ADDR_RES_L);
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_hi, ADDR_RES_H);
+    report "FMOVE double tie-plus-inf observed hi=" & to_hstring(rd_hi) &
+           " lo=" & to_hstring(rd_lo) severity note;
+    assert rd_hi = x"3FF00000" and rd_lo = x"00000001"
+      report "FMOVE double tie-plus-inf should round upward"
+      severity failure;
+
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_L, FP80_DOUBLE_MIN_SUBNORMAL(31 downto 0));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_H, FP80_DOUBLE_MIN_SUBNORMAL(63 downto 32));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_E, x"0000" & FP80_DOUBLE_MIN_SUBNORMAL(79 downto 64));
+    cfg_word := make_move_cfg("01", 0, 7, "00", '0', "00", (others => '0'), '0');
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_MOVE_CFG, cfg_word);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPCR, x"00000010");
+    cfg_word := make_move_cfg("10", 7, 0, "10", '0', "00", (others => '0'), '0');
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_MOVE_CFG, cfg_word);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_lo, ADDR_RES_L);
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_hi, ADDR_RES_H);
+    report "FMOVE double min-subnormal observed hi=" & to_hstring(rd_hi) &
+           " lo=" & to_hstring(rd_lo) severity note;
+    assert rd_hi = x"00000000" and rd_lo = x"00000001"
+      report "FMOVE double gradual underflow should keep min subnormal"
+      severity failure;
+
     report "FMOVE subnormal single/double source checks" severity note;
 
     bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_L, FMOVE_SINGLE_SUBMIN_NEG);
@@ -479,6 +617,30 @@ begin
     rd_full := rd_ex(15 downto 0) & rd_hi & rd_lo;
     report "FMOVE.L min source observed=" & to_hstring(rd_full) severity note;
     check_fp80(rd_full, fp80_from_int(-2147483647), "FMOVE.L min source");
+
+    report "FMOVE conversion exception path check (single qNaN mem->reg)" severity note;
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPSR, (others => '0'));
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_FPIAR, x"CAFEBABE");
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_L, FMOVE_SINGLE_QNAN);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_H, x"00000000");
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPA_E, x"00000000");
+    cfg_word := make_move_cfg("01", 0, 7, "01", '0', "00", (others => '0'), '0');
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_MOVE_CFG, cfg_word);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n, ADDR_OPSEL, OP_FMOVE);
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, status_word);
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, rd_lo, ADDR_FPSR);
+    report "FMOVE qNaN FPSR=" & to_hstring(rd_lo) severity note;
+    assert rd_lo(FPSR_EXC_BASE + FPSR_EXC_INVALID) = '1'
+      report "FMOVE qNaN should set FPSR EXC invalid"
+      severity failure;
+    assert rd_lo(FPSR_AEXC_BASE + FPSR_EXC_INVALID) = '1'
+      report "FMOVE qNaN should set FPSR AEXC invalid"
+      severity failure;
+    bus_read(a_in, rw, cs_n, as_n, ds_n, dsack0_n, dsack1_n, d_out, fpiar_word, ADDR_FPIAR);
+    report "FMOVE qNaN FPIAR=" & to_hstring(fpiar_word) severity note;
+    assert fpiar_word = x"CAFEBABE"
+      report "FMOVE qNaN should capture FPIAR snapshot"
+      severity failure;
 
     report "FMOVE .P static/dynamic k-factor checks" severity note;
     fp_val_a := fp80_from_int(1234567);


### PR DESCRIPTION
## Summary
- Route FMOVE conversion completions through the exception-classification path so EXC/AEXC/CC/FPIAR updates are no longer bypassed
- Implement FPCR-mode-aware `fp80_to_single`/`fp80_to_double` rounding using guard/round/sticky behavior
- Fix format-conversion overflow/underflow behavior for FMOVE single/double outputs (directed overflow handling + gradual underflow)
- Extend FMOVE/FMOVEM testbench coverage for conversion rounding/range behavior and FMOVE qNaN exception/FPIAR checks
- Update progress checklist status for F2/F3/F4 to done

### Correctness fixes (from PR review)
- Fix fp80 subnormal early return in `fp80_to_single`/`fp80_to_double`: directed rounding away from zero (RP+positive, RM+negative) now produces minimum subnormal instead of silently flushing to zero
- Add INEXACT exception for normal-range precision loss in FMOVE reg-to-mem single/double conversions via `force_inexact` flag pipeline through `exc_event`
- Enable CC update for FMOVECR, REG_TO_REG, and extended MEM_TO_REG FMOVE sub-modes by setting `move_exc_enable` so `exc_event_valid_reg` fires the exception classifier

### Test coverage additions (from PR review)
- Double-precision overflow: RZ saturates to max-finite, RP produces +infinity
- Negative-sign overflow: RP -> -max-finite, RM -> -infinity (exercises sign-dependent directed overflow branches)
- RM rounding mode (FPCR=0x20): negative half-ULP tie rounds away from zero
- Missing FPSR EXC inexact assertion for double underflow
- FPSR CC NAN bit assertion in qNaN exception path test

## Validation
- Full regression: `powershell -ExecutionPolicy Bypass -File scripts/run_tests.ps1`
- **Result: pass**