### PR TITLE
Fix DEF-DIVREM-001: gradual underflow for DIV/SQRT

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -35,7 +35,15 @@
       "Bash(powershell.exe -NoProfile -Command:*)",
       "Bash(cmd //c \"C:\\\\amddesigntools\\\\2025.2\\\\Vivado\\\\bin\\\\vivado.bat -mode batch -source C:/code/68881-fpga/scripts/run_impl.tcl\")",
       "Bash(cd:*)",
-      "WebFetch(domain:)"
+      "WebFetch(domain:)",
+      "WebSearch",
+      "WebFetch(domain:www.manualslib.com)",
+      "WebFetch(domain:en.wikipedia.org)",
+      "Bash(git push:*)",
+      "Bash(gh pr:*)",
+      "Bash(\"C:\\\\code\\\\ghdl-mcode-5.1.1-mingw64\\\\bin\\\\ghdl.exe\":*)",
+      "Bash(powershell:*)",
+      "Bash($GHDL:*)"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ __synthesis_is_complete__
 .claude/settings.local.json
 /.claude
 project/fpga68881/utilization_report.txt
+/validation
+/build

--- a/README.md
+++ b/README.md
@@ -86,9 +86,8 @@ covering:
 - Current status:
   - Open:
     - `DEF-TIMING-001`
-    - `DEF-DIVREM-001`
     - `DEF-DIVREM-002`
-  - `DEF-TRIG-001` and `DEF-PACKED-001` are closed; see `docs/fpu-progress-checklist.md` for closure notes.
+  - Closed: `DEF-TRIG-001`, `DEF-PACKED-001`, `DEF-DIVREM-001`; see `docs/fpu-progress-checklist.md` for closure notes.
 
 ## Running simulations
 Use a VHDL-2008 capable simulator (such as GHDL or ModelSim). The repo includes a test

--- a/docs/fpu-progress-checklist.md
+++ b/docs/fpu-progress-checklist.md
@@ -359,18 +359,6 @@ Keep this list short, actionable, and updated whenever a defect is fixed or newl
     iterative arithmetic stages, remove remaining trig MCP dependence, and close routed setup timing
     on those paths with single-cycle constraints at target frequency.
 
-### DEF-DIVREM-001: DIV/SQRT Underflow Flushes Tiny Results To Zero
-- Status: Open
-- File: `src/mc68881_divrem_unit.vhd`
-- Evidence:
-  - Underflow paths in post-round stages force zero when `exp_res_i <= 0`:
-    - `ST_SQRT_POST` (`src/mc68881_divrem_unit.vhd:604` vicinity)
-    - `ST_POST_DIV` (`src/mc68881_divrem_unit.vhd:670` vicinity)
-- Impact:
-  - Tiny finite results are flushed instead of emitting gradual-underflow subnormals.
-- Planned fix:
-  - Implement subnormal packing/rounding path for `exp_res_i <= 0` rather than hard zero.
-
 ### DEF-DIVREM-002: DIV NaN Policy Marks All NaN Inputs Invalid
 - Status: Open
 - File: `src/mc68881_divrem_unit.vhd`
@@ -382,6 +370,19 @@ Keep this list short, actionable, and updated whenever a defect is fixed or newl
   - Distinguish signaling-NaN vs quiet-NaN handling and raise invalid only where required by policy.
 
 ## Closed Defects
+
+### DEF-DIVREM-001: DIV/SQRT Underflow Flushes Tiny Results To Zero
+- Status: Closed (2026-03-02)
+- File: `src/mc68881_divrem_unit.vhd`
+- Resolution summary:
+  - Implemented IEEE 754 gradual underflow for DIV and SQRT paths.
+  - When `exp_res_i <= 0`, mantissa is right-shifted by `1 - exp_res_i` via
+    `shift_right_with_sticky` before rounding, preserving precision in the sticky bit.
+  - Post-rounding `exp_res_i <= 0` branch now packs subnormal (exp=0, mant=mant_main)
+    instead of flushing to zero.
+  - Fixed sign-clearing bug in ST_POST_DIV that discarded the correct sign for
+    negative underflow results (`div_res_u.sign := '0'` removed).
+  - Added DIV subnormal regression test (min_normal / 2.0 → subnormal).
 
 ### DEF-PACKED-002: Full Packed-Decimal Default QoR Still Above Release Gate
 - Status: Closed (2026-03-02)

--- a/project/fpga68881/fpga68881.xpr
+++ b/project/fpga68881/fpga68881.xpr
@@ -304,7 +304,7 @@
       <Report Name="ROUTE_DESIGN.REPORT_METHODOLOGY" Enabled="1"/>
       <RQSFiles/>
     </Run>
-    <Run Id="impl_1" Type="Ft2:EntireDesign" Part="xc7a200tfbg676-1" ConstrsSet="constrs_1" Description="Default settings for Implementation." AutoIncrementalCheckpoint="false" WriteIncrSynthDcp="false" State="current" SynthRun="synth_1" IncludeInArchive="true" IsChild="false" GenFullBitstream="true" AutoIncrementalDir="$PSRCDIR/utils_1/imports/impl_1" LaunchOptions="-jobs 17 " AutoRQSDir="$PSRCDIR/utils_1/imports/impl_1" ParallelReportGen="true">
+    <Run Id="impl_1" Type="Ft2:EntireDesign" Part="xc7a200tfbg676-1" ConstrsSet="constrs_1" Description="Default settings for Implementation." AutoIncrementalCheckpoint="false" WriteIncrSynthDcp="false" State="current" Dir="$PRUNDIR/impl_1" SynthRun="synth_1" IncludeInArchive="true" IsChild="false" GenFullBitstream="true" AutoIncrementalDir="$PSRCDIR/utils_1/imports/impl_1" LaunchOptions="-jobs 17 " AutoRQSDir="$PSRCDIR/utils_1/imports/impl_1" ParallelReportGen="true">
       <Strategy Version="1" Minor="2">
         <StratHandle Name="Vivado Implementation Defaults" Flow="Vivado Implementation 2025"/>
         <Step Id="init_design"/>
@@ -321,6 +321,7 @@
         </Step>
         <Step Id="write_bitstream"/>
       </Strategy>
+      <GeneratedRun Dir="$PRUNDIR" File="gen_run.xml"/>
       <ReportStrategy Name="Vivado Implementation Default Reports" Flow="Vivado Implementation 2025"/>
       <Report Name="ROUTE_DESIGN.REPORT_METHODOLOGY" Enabled="1"/>
       <RQSFiles/>

--- a/project/fpga68881/fpga68881.xpr
+++ b/project/fpga68881/fpga68881.xpr
@@ -304,7 +304,7 @@
       <Report Name="ROUTE_DESIGN.REPORT_METHODOLOGY" Enabled="1"/>
       <RQSFiles/>
     </Run>
-    <Run Id="impl_1" Type="Ft2:EntireDesign" Part="xc7a200tfbg676-1" ConstrsSet="constrs_1" Description="Default settings for Implementation." AutoIncrementalCheckpoint="false" WriteIncrSynthDcp="false" State="current" Dir="$PRUNDIR/impl_1" SynthRun="synth_1" IncludeInArchive="true" IsChild="false" GenFullBitstream="true" AutoIncrementalDir="$PSRCDIR/utils_1/imports/impl_1" LaunchOptions="-jobs 17 " AutoRQSDir="$PSRCDIR/utils_1/imports/impl_1" ParallelReportGen="true">
+    <Run Id="impl_1" Type="Ft2:EntireDesign" Part="xc7a200tfbg676-1" ConstrsSet="constrs_1" Description="Default settings for Implementation." AutoIncrementalCheckpoint="false" WriteIncrSynthDcp="false" State="current" SynthRun="synth_1" IncludeInArchive="true" IsChild="false" GenFullBitstream="true" AutoIncrementalDir="$PSRCDIR/utils_1/imports/impl_1" LaunchOptions="-jobs 17 " AutoRQSDir="$PSRCDIR/utils_1/imports/impl_1" ParallelReportGen="true">
       <Strategy Version="1" Minor="2">
         <StratHandle Name="Vivado Implementation Defaults" Flow="Vivado Implementation 2025"/>
         <Step Id="init_design"/>
@@ -321,7 +321,6 @@
         </Step>
         <Step Id="write_bitstream"/>
       </Strategy>
-      <GeneratedRun Dir="$PRUNDIR" File="gen_run.xml"/>
       <ReportStrategy Name="Vivado Implementation Default Reports" Flow="Vivado Implementation 2025"/>
       <Report Name="ROUTE_DESIGN.REPORT_METHODOLOGY" Enabled="1"/>
       <RQSFiles/>

--- a/src/mc68881_divrem_unit.vhd
+++ b/src/mc68881_divrem_unit.vhd
@@ -642,7 +642,6 @@ begin
           if exp_res_i <= 0 then
             mant_ext := shift_right_with_sticky(mant_ext, 1 - exp_res_i);
             exp_res_i := 0;
-            flag_underflow_reg <= '1';
           end if;
 
           apply_rounding('0', mant_ext, exp_res_i, rm_reg, rp_reg, mant_main, exp_res_i, inexact_local);
@@ -719,7 +718,6 @@ begin
           if exp_res_i <= 0 then
             mant_ext := shift_right_with_sticky(mant_ext, 1 - exp_res_i);
             exp_res_i := 0;
-            flag_underflow_reg <= '1';
           end if;
 
           apply_rounding(div_sign_reg, mant_ext, exp_res_i, div_round_mode, div_round_prec, mant_main, exp_res_i, inexact_local);

--- a/src/mc68881_divrem_unit.vhd
+++ b/src/mc68881_divrem_unit.vhd
@@ -647,6 +647,11 @@ begin
 
           apply_rounding('0', mant_ext, exp_res_i, rm_reg, rp_reg, mant_main, exp_res_i, inexact_local);
 
+          -- Promote to minimum normal if rounding set the integer bit
+          if exp_res_i = 0 and mant_main(mant_main'left) = '1' then
+            exp_res_i := 1;
+          end if;
+
           div_res_u.sign := '0';
           if mant_main = 0 then
             div_res_u.exp := (others => '0');
@@ -718,6 +723,11 @@ begin
           end if;
 
           apply_rounding(div_sign_reg, mant_ext, exp_res_i, div_round_mode, div_round_prec, mant_main, exp_res_i, inexact_local);
+
+          -- Promote to minimum normal if rounding set the integer bit
+          if exp_res_i = 0 and mant_main(mant_main'left) = '1' then
+            exp_res_i := 1;
+          end if;
 
           div_res_u.sign := div_sign_reg;
           if mant_main = 0 then

--- a/src/mc68881_divrem_unit.vhd
+++ b/src/mc68881_divrem_unit.vhd
@@ -638,6 +638,13 @@ begin
             inexact_local := '1';
           end if;
 
+          -- Gradual underflow: shift mantissa right to form subnormal
+          if exp_res_i <= 0 then
+            mant_ext := shift_right_with_sticky(mant_ext, 1 - exp_res_i);
+            exp_res_i := 0;
+            flag_underflow_reg <= '1';
+          end if;
+
           apply_rounding('0', mant_ext, exp_res_i, rm_reg, rp_reg, mant_main, exp_res_i, inexact_local);
 
           div_res_u.sign := '0';
@@ -647,7 +654,7 @@ begin
             div_final_result := pack_fp80(div_res_u);
           elsif exp_res_i <= 0 then
             div_res_u.exp := (others => '0');
-            div_res_u.mant := (others => '0');
+            div_res_u.mant := mant_main;
             div_final_result := pack_fp80(div_res_u);
             flag_underflow_reg <= '1';
           elsif exp_res_i >= FP_EXP_MAX then
@@ -703,6 +710,13 @@ begin
             div_round_prec := FP_PREC_EXTENDED;
           end if;
 
+          -- Gradual underflow: shift mantissa right to form subnormal
+          if exp_res_i <= 0 then
+            mant_ext := shift_right_with_sticky(mant_ext, 1 - exp_res_i);
+            exp_res_i := 0;
+            flag_underflow_reg <= '1';
+          end if;
+
           apply_rounding(div_sign_reg, mant_ext, exp_res_i, div_round_mode, div_round_prec, mant_main, exp_res_i, inexact_local);
 
           div_res_u.sign := div_sign_reg;
@@ -712,9 +726,8 @@ begin
             div_res_u.mant := (others => '0');
             div_final_result := pack_fp80(div_res_u);
           elsif exp_res_i <= 0 then
-            div_res_u.sign := '0';
             div_res_u.exp := (others => '0');
-            div_res_u.mant := (others => '0');
+            div_res_u.mant := mant_main;
             div_final_result := pack_fp80(div_res_u);
             flag_underflow_reg <= '1';
           elsif exp_res_i >= FP_EXP_MAX then

--- a/tb/tb_mc68881_alu.vhd
+++ b/tb/tb_mc68881_alu.vhd
@@ -171,6 +171,12 @@ architecture sim of tb_mc68881_alu is
   -- DIV subnormal-to-normal promotion: largest exp=1 value / 2.0
   -- Exact quotient is 0.5 ULP below min_normal; rounds up to min_normal
   constant FP80_MAX_MANT_EXP1 : fp80_t := x"0001FFFFFFFFFFFFFFFF"; -- exp=1, mant=all-ones
+  -- Negative subnormal: -min_normal / 2.0 — tests sign preservation
+  constant FP80_NEG_MIN_NORMAL : fp80_t := x"80018000000000000000"; -- sign=1, exp=1, mant=1.0
+  constant DIV_NEG_SUBNORMAL_EXPECTED : fp80_t := x"80004000000000000000"; -- sign=1, exp=0, mant=0.5
+  -- Deeply subnormal: min_normal / 2^32 — shift amount = 32
+  constant FP80_TWO_POW32 : fp80_t := x"401F8000000000000000"; -- 2^32 (exp=16415)
+  constant DIV_DEEP_SUBNORMAL_EXPECTED : fp80_t := x"00000000000080000000"; -- exp=0, mant=2^31
   constant LARGE_MOD_A : fp80_t := x"40278000000001800000"; -- 2^40 + 3
   constant LARGE_MOD_B : fp80_t := x"40008000000000000000"; -- 2
   constant FREM_BOUNDARY_A : fp80_t := x"401DFFFFFFFF80000000"; -- (integer'high + 0.75) for 32-bit integer
@@ -659,6 +665,48 @@ begin
     report "DIV subnormal promotion result: " & to_hstring(result)
       severity note;
     check_result(FP80_MIN_NORMAL, "DIV subnormal promotion");
+
+    -- DIV negative subnormal: tests sign preservation (ST_POST_DIV sign bug fix)
+    round_prec <= FP_PREC_EXTENDED;
+    round_mode <= FP_RND_NEAREST;
+    op_sel <= FPU_OP_DIV;
+    a_in   <= FP80_NEG_MIN_NORMAL;
+    b_in   <= FP80_TWO;
+    report "DIV neg subnormal expected: " & to_hstring(DIV_NEG_SUBNORMAL_EXPECTED)
+      severity note;
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    start_cycle := cycle_cnt;
+    wait until valid = '1';
+    wait for 0 ns;
+    report "DIV neg subnormal latency cycles: " & integer'image(cycle_cnt - start_cycle)
+      severity note;
+    report "DIV neg subnormal result: " & to_hstring(result)
+      severity note;
+    check_result(DIV_NEG_SUBNORMAL_EXPECTED, "DIV neg subnormal");
+
+    -- DIV deeply subnormal: min_normal / 2^32, shift amount = 32
+    round_prec <= FP_PREC_EXTENDED;
+    round_mode <= FP_RND_NEAREST;
+    op_sel <= FPU_OP_DIV;
+    a_in   <= FP80_MIN_NORMAL;
+    b_in   <= FP80_TWO_POW32;
+    report "DIV deep subnormal expected: " & to_hstring(DIV_DEEP_SUBNORMAL_EXPECTED)
+      severity note;
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    start_cycle := cycle_cnt;
+    wait until valid = '1';
+    wait for 0 ns;
+    report "DIV deep subnormal latency cycles: " & integer'image(cycle_cnt - start_cycle)
+      severity note;
+    report "DIV deep subnormal result: " & to_hstring(result)
+      severity note;
+    check_result(DIV_DEEP_SUBNORMAL_EXPECTED, "DIV deep subnormal");
 
     -- Arithmetic sweeps across non-trivial operands.
     run_binary_close(

--- a/tb/tb_mc68881_alu.vhd
+++ b/tb/tb_mc68881_alu.vhd
@@ -164,6 +164,10 @@ architecture sim of tb_mc68881_alu is
   constant DIV_1_10_MANT_DOUBLE : unsigned(FP_MANT_WIDTH-1 downto 0) := x"CCCCCCCCCCCCD000";
   constant DIV_1_10_SINGLE_EXPECTED : fp80_t := make_fp80('0', DIV_1_10_EXP, DIV_1_10_MANT_SINGLE);
   constant DIV_1_10_DOUBLE_EXPECTED : fp80_t := make_fp80('0', DIV_1_10_EXP, DIV_1_10_MANT_DOUBLE);
+  -- DIV subnormal: min_normal / 2.0 = subnormal (exp=0, mant=0.5)
+  constant FP80_MIN_NORMAL : fp80_t := x"00018000000000000000"; -- exp=1, mant=1.0
+  constant FP80_TWO : fp80_t := x"40008000000000000000"; -- 2.0
+  constant DIV_SUBNORMAL_EXPECTED : fp80_t := x"00004000000000000000"; -- exp=0, mant=0.5
   constant LARGE_MOD_A : fp80_t := x"40278000000001800000"; -- 2^40 + 3
   constant LARGE_MOD_B : fp80_t := x"40008000000000000000"; -- 2
   constant FREM_BOUNDARY_A : fp80_t := x"401DFFFFFFFF80000000"; -- (integer'high + 0.75) for 32-bit integer
@@ -607,6 +611,27 @@ begin
     report "DIV 1/10 double result: " & to_hstring(result)
       severity note;
     check_result(DIV_1_10_DOUBLE_EXPECTED, "DIV 1/10 double");
+
+    -- DIV subnormal: min_normal / 2.0 should produce subnormal result
+    round_prec <= FP_PREC_EXTENDED;
+    round_mode <= FP_RND_NEAREST;
+    op_sel <= FPU_OP_DIV;
+    a_in   <= FP80_MIN_NORMAL;
+    b_in   <= FP80_TWO;
+    report "DIV subnormal expected: " & to_hstring(DIV_SUBNORMAL_EXPECTED)
+      severity note;
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    start_cycle := cycle_cnt;
+    wait until valid = '1';
+    wait for 0 ns;
+    report "DIV subnormal latency cycles: " & integer'image(cycle_cnt - start_cycle)
+      severity note;
+    report "DIV subnormal result: " & to_hstring(result)
+      severity note;
+    check_result(DIV_SUBNORMAL_EXPECTED, "DIV subnormal");
 
     -- Arithmetic sweeps across non-trivial operands.
     run_binary_close(

--- a/tb/tb_mc68881_alu.vhd
+++ b/tb/tb_mc68881_alu.vhd
@@ -168,6 +168,9 @@ architecture sim of tb_mc68881_alu is
   constant FP80_MIN_NORMAL : fp80_t := x"00018000000000000000"; -- exp=1, mant=1.0
   constant FP80_TWO : fp80_t := x"40008000000000000000"; -- 2.0
   constant DIV_SUBNORMAL_EXPECTED : fp80_t := x"00004000000000000000"; -- exp=0, mant=0.5
+  -- DIV subnormal-to-normal promotion: largest exp=1 value / 2.0
+  -- Exact quotient is 0.5 ULP below min_normal; rounds up to min_normal
+  constant FP80_MAX_MANT_EXP1 : fp80_t := x"0001FFFFFFFFFFFFFFFF"; -- exp=1, mant=all-ones
   constant LARGE_MOD_A : fp80_t := x"40278000000001800000"; -- 2^40 + 3
   constant LARGE_MOD_B : fp80_t := x"40008000000000000000"; -- 2
   constant FREM_BOUNDARY_A : fp80_t := x"401DFFFFFFFF80000000"; -- (integer'high + 0.75) for 32-bit integer
@@ -632,6 +635,30 @@ begin
     report "DIV subnormal result: " & to_hstring(result)
       severity note;
     check_result(DIV_SUBNORMAL_EXPECTED, "DIV subnormal");
+
+    -- DIV subnormal boundary: rounding promotes max subnormal to min normal.
+    -- Exact quotient is (2^63 - 0.5) subnormal ULPs; nonzero remainder
+    -- sets sticky, so round-to-nearest rounds up. Without promotion fix,
+    -- result would be unnormal (exp=0, MSB=1).
+    round_prec <= FP_PREC_EXTENDED;
+    round_mode <= FP_RND_NEAREST;
+    op_sel <= FPU_OP_DIV;
+    a_in   <= FP80_MAX_MANT_EXP1;
+    b_in   <= FP80_TWO;
+    report "DIV subnormal promotion expected: " & to_hstring(FP80_MIN_NORMAL)
+      severity note;
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    start_cycle := cycle_cnt;
+    wait until valid = '1';
+    wait for 0 ns;
+    report "DIV subnormal promotion latency cycles: " & integer'image(cycle_cnt - start_cycle)
+      severity note;
+    report "DIV subnormal promotion result: " & to_hstring(result)
+      severity note;
+    check_result(FP80_MIN_NORMAL, "DIV subnormal promotion");
 
     -- Arithmetic sweeps across non-trivial operands.
     run_binary_close(


### PR DESCRIPTION
## Summary
- Implement IEEE 754 gradual underflow in `ST_SQRT_POST` and `ST_POST_DIV` paths: right-shift mantissa by `1 - exp_res_i` via `shift_right_with_sticky` before rounding when exponent underflows, preserving precision in the sticky bit
- Fix sign-clearing bug in `ST_POST_DIV` that discarded the correct sign for negative underflow results (`div_res_u.sign := '0'` removed)
- Add DIV subnormal regression test (min_normal / 2.0 → `x"00004000000000000000"`)

## Test plan
- [x] New DIV subnormal test produces exact expected result
- [x] Full GHDL test suite passes (pre-push hook verified)
- [ ] Vivado synthesis to check LUT impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)