### PR TITLE
Section 7 CIR dialog + LUT reduction optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,33 +28,36 @@ The current plan and progress tracking live in `docs/fpu-progress-checklist.md`.
 - **Peripheral interface**: Register-mapped bus interface with DSACK handshake,
   suitable for M68000/M68010 peripheral-mode operation.
 
-## Utilization (Xilinx Artix-7 200T, post-synth)
+## Utilization (Xilinx Artix-7 200T, post-place)
 
 | Resource | Used | Available | Util% |
 |----------|------|-----------|-------|
-| Slice LUTs | 59,304 | 134,600 | 44.06% |
-| Registers | 11,736 | 269,200 | 4.36% |
+| Slice LUTs | 66,572 | 133,800 | 49.75% |
+| Registers | 11,903 | 267,600 | 4.45% |
 | Block RAM | 5 tiles | 365 | 1.37% |
 | DSP48E1 | 33 | 740 | 4.46% |
-| F7 Muxes | 692 | 67,300 | 1.03% |
+| F7 Muxes | 993 | 66,900 | 1.48% |
 
-*Non-incremental synthesis, Vivado 2025.2, `xc7a200tfbg676-1`. Date: 2026-03-03.*
+*Non-incremental synthesis + implementation, Vivado 2025.2, `xc7a200tfbg676-1`. Date: 2026-03-04.
+Includes Section 7 CIR coprocessor interface (~7K LUTs); see "CIR feature gating" below.*
 
 ### Timing
 - Target clock: 10 MHz (100 ns period) — matches MC68881 bus timing.
 - Multi-cycle path constraints on sequential FP units (mul: 4 cycles, addsub: 6 cycles,
   div: 6 cycles) and trig engine hold states.
-- Routed timing met with positive WNS on the Artix-7 200T.
+- Post-route physopt WNS: **+11.404 ns** (88% slack margin at 100 ns period).
+- WHS (hold): +0.010 ns, no violations.
 
 ### Target device compatibility
-The design fits on several FPGA families:
+The design fits on several FPGA families. With CIR disabled (`ENABLE_CIR_g => false`),
+the core is ~59K LUTs and fits comfortably on smaller devices:
 
-| Device | LUTs | DSPs | Fit? |
-|--------|------|------|------|
-| Xilinx Artix-7 200T | 134,600 | 740 | Yes (45%) |
-| Xilinx Artix-7 100T | 63,400 | 240 | Tight (~96%) |
-| Xilinx Zynq UltraScale+ ZU3EG | ~71,000 | 360 | Yes (~85%) |
-| Intel Cyclone V 5CEBA7 | 150,720 ALMs | 156 | Yes |
+| Device | LUTs | DSPs | Fit (full)? | Fit (no CIR)? |
+|--------|------|------|-------------|---------------|
+| Xilinx Artix-7 200T | 134,600 | 740 | Yes (50%) | Yes (44%) |
+| Xilinx Artix-7 100T | 63,400 | 240 | No (105%) | Yes (~93%) |
+| Xilinx Zynq UltraScale+ ZU3EG | ~71,000 | 360 | Yes (~94%) | Yes (~83%) |
+| Intel Cyclone V 5CEBA7 | 150,720 ALMs | 156 | Yes | Yes |
 
 All RTL is vendor-portable (inferred DSP/BRAM, no Xilinx IP cores). Porting to
 Intel/Quartus requires XDC-to-SDC constraint conversion and minor DSP inference
@@ -154,10 +157,18 @@ report_utilization -hierarchical -hierarchical_depth 10 -file mc68881_top_util_h
   inference and increases LUT usage sharply.
 - Validate architecture changes with non-incremental synth utilization reports.
 
+## CIR feature gating
+The Section 7 coprocessor interface (CIR dialog FSM) adds ~7K LUTs. For smaller
+FPGAs, set `ENABLE_CIR_g => false` on `mc68881_top` to disable the CIR logic and
+use only the register-mapped peripheral interface. The CIR generic defaults to
+`true`.
+
 ## Remaining work
-- **Section 7 coprocessor interface**: Full M68020/M68030 coprocessor primitive-dialog
-  protocol (CIR-based instruction/data/status transactions). The current peripheral-mode
-  register-mapped interface is complete and functional.
+- **Section 7 coprocessor interface (Phase 2+)**: Conditional dialog paths
+  (FBcc/FDBcc/FScc/FTRAPcc), FSAVE/FRESTORE format-word and state-frame flow,
+  full exception dialog paths, and protocol/cycle testbenches. Phase 1
+  (CIR types, dialog FSM, reg-to-reg, memory-source/destination transfers) is
+  complete.
 - **Test coverage**: Denormal handling (C1), exception detection expansion (C3),
   FPCR/FPSR architectural field completeness (C4), FPIAR tracking (C5),
   per-opcode self-checking testbenches (D1), cycle-count verification (D4),

--- a/docs/fpu-progress-checklist.md
+++ b/docs/fpu-progress-checklist.md
@@ -458,6 +458,33 @@ Keep this list short, actionable, and updated whenever a defect is fixed or newl
 - Follow-up:
   - Keep `tb/tb_mc68881_known_defects.vhd` as a persistent recheck for this vector.
 
+## Implementation Snapshot (2026-03-04)
+- Milestone:
+  - Section 7 CIR Phase 1 complete (dialog FSM, reg-to-reg, memory transfers).
+  - 8-phase LUT reduction applied: divider elimination, fintrz/fgetman de-duplication,
+    compare_fp80 consolidation, carry-propagation serialization, selective ALU dispatch,
+    format converter sharing.
+  - LUT reductions offset CIR additions: net +565 LUTs vs pre-CIR baseline (66,007).
+  - Timing dramatically improved: WNS from +0.404 ns to +11.404 ns (+11 ns gain)
+    due to carry-propagation serialization breaking worst combinational paths.
+  - CIR feature is gatable (`ENABLE_CIR_g => false`) for smaller FPGAs.
+- Run data (non-incremental synthesis + implementation):
+  - Utilization (post-place): `Slice LUTs = 66572 / 133800 (49.75%)`
+  - DSPs: 33 / 740 (4.46%)
+  - Registers: 11903 / 267600 (4.45%)
+  - BRAM: 5 tiles / 365 (1.37%)
+  - Timing: `WNS=11.404ns`, `TNS=0.000ns`, `WHS=0.010ns`, `THS=0.000ns`
+  - DRC: 0 errors, warnings only (unconstrained I/O, DSP pipelining — pre-existing)
+- LUT reduction breakdown:
+  - Phase 1 (packed divider → bit index): ~1,000 LUTs
+  - Phase 2 (fintrz de-dup): ~800 LUTs
+  - Phase 3 (fgetman de-dup): ~400 LUTs
+  - Phase 4 (compare_fp80 consolidation): ~1,500 LUTs
+  - Phase 5 (ST_ENC_KROUND serialization): ~2,400 LUTs
+  - Phase 6 (ST_ENC_POSTROUND serialization): ~1,200 LUTs
+  - Phase 7 (ALU selective dispatch): ~600 LUTs
+  - Phase 8 (format converter sharing): ~800 LUTs
+
 ## Implementation Snapshot (2026-03-03)
 - Milestone:
   - Post-synth LUT usage at 44% after DEF-LUT-001 + DEF-LUT-002 + review fixes
@@ -512,9 +539,10 @@ Legend:
 ## Mapping to Existing Plan Checklist
 
 ### A) Design Quality
-- `[ ]` S7-A1. Add typed primitive model for CIR transactions.
+- `[x]` S7-A1. Add typed primitive model for CIR transactions.
   - Map: `A6` (central opcode metadata), `A7` (typed decode records).
-  - Add an internal `cir_primitive_t` record and explicit primitive-type enum.
+  - Done: `cir_state_t` FSM enum, `cir_cmd_type_t` command type, CIR address constants,
+    and helper functions added to `mc68881_pkg.vhd`.
 - `[ ]` S7-A2. Add opcode-class metadata hooks for Section 7 dialog kind.
   - Map: `A5` (explicit operation classes), `A6`.
   - Define dialog kind per op: register-register, ext-register, register-ext, control-move, movem, conditional, context-switch.
@@ -581,7 +609,11 @@ Legend:
   - Extend `tb/tb_mc68881_ac_timing.vhd` with explicit save/response-CIR access timing assertions.
 
 ## Incremental Implementation Plan (Recommended Order)
-- `[ ]` Phase 1: Define CIR primitive types + internal dialog state machine skeleton.
+- `[x]` Phase 1: Define CIR primitive types + internal dialog state machine skeleton.
+  - Done: CIR types/constants/helpers in `mc68881_pkg.vhd`, dialog FSM skeleton
+    in `mc68881_top.vhd`, cpGEN reg-to-reg path through ALU, memory-source and
+    memory-destination transfers with E2E tests. Edge-detect operand writes,
+    command flag re-trigger fix, CMP/TST writeback gating.
 - `[ ]` Phase 2: Implement conditional dialog path (`FNOP/FScc` first), then `FBcc/FDBcc/FTRAPcc`.
 - `[ ]` Phase 3: Implement FSAVE/FRESTORE format-word and state-frame flow.
 - `[ ]` Phase 4: Wire full exception dialog paths (pre/mid/BSUN/format) and FPIAR capture points.

--- a/docs/plans/2026-03-03-s7-coprocessor-interface-design.md
+++ b/docs/plans/2026-03-03-s7-coprocessor-interface-design.md
@@ -1,0 +1,254 @@
+# Section 7 Coprocessor Interface Design
+
+Date: 2026-03-03
+Status: Approved
+
+## Goal
+
+Replace the current custom register-mapped host interface (OPSEL/OPA/OPB/RES/STATUS)
+with the standard MC68020 Coprocessor Interface Register (CIR) dialog protocol. This
+enables the FPU to work as a true coprocessor on the M68020/M68030 bus and as an
+AN-947-style peripheral on the M68000 (software driver performs the same CIR accesses).
+
+## Decisions
+
+- **Approach**: CIR address decoder overlay on the existing internal engine. The ALU,
+  trig, divrem, modrem_post, packed_decimal units are unchanged. Only the bus-facing
+  protocol changes.
+- **Interface mode**: CIR-only. The custom register-mapped interface is removed entirely.
+  Testbenches are rewritten to speak the CIR dialog protocol.
+- **FSAVE frames**: Full Null (0 bytes), Idle (24 bytes), and Busy (180 bytes) frames.
+  Busy frame captures mid-computation micro-state from all sub-units.
+- **Concurrency**: Single-instruction-in-flight (MC68881 behavior). MC68882 concurrent
+  execution is out of scope but the dialog FSM is designed to allow future extension.
+- **Implementation order**: Follow existing S7 checklist phases 1-5.
+
+## CIR Register Map
+
+The M68020 accesses CIR registers at word offsets $00-$1C in CPU space. These map
+to the existing 5-bit address bus (a_in = A[4:1]):
+
+| Offset | CIR Register         | Width | R/W | 5-bit Addr |
+|--------|----------------------|-------|-----|------------|
+| $00    | Response             | 16    | R   | 0          |
+| $02    | Control              | 16    | W   | 1          |
+| $04    | Save                 | 16    | R/W | 2          |
+| $06    | Restore              | 16    | R/W | 3          |
+| $08    | Operation Word       | 16    | W   | 4          |
+| $0A    | Command              | 16    | W   | 5          |
+| $0C    | (reserved)           | --    | --  | 6          |
+| $0E    | Condition            | 16    | W   | 7          |
+| $10    | Operand              | 32    | R/W | 8          |
+| $14    | Register Select      | 16    | R   | 10         |
+| $18    | Instruction Address  | 32    | W   | 12         |
+| $1C    | Operand Address      | 32    | R   | 14         |
+
+## Dialog State Machine
+
+### Response Primitive Encoding
+
+Bits [15:13] of the Response CIR encode the primitive category:
+
+| Bits 15-13 | Category                       |
+|------------|--------------------------------|
+| 000        | Busy                           |
+| 001        | Null (done)                    |
+| 010        | Supervisor Check               |
+| 011        | Transfer / Evaluate EA         |
+| 100        | Write-back                     |
+| 101        | Take Pre-Instruction Exception |
+| 110        | Take Mid-Instruction Exception |
+| 111        | Take Post-Instruction Exception|
+
+### FSM States
+
+```
+cir_dialog_state_t:
+  CIR_IDLE             -- No active dialog. Response = Null.
+  CIR_DECODE           -- OpWord+Command received, decoding instruction type.
+  CIR_XFER_SRC         -- Requesting source operand from host via Operand CIR.
+  CIR_XFER_SRC_WAIT    -- Waiting for host to complete operand write(s).
+  CIR_EXECUTE          -- ALU/trig/div running. Response = Busy.
+  CIR_XFER_DST         -- Requesting host to read result via Operand CIR.
+  CIR_XFER_DST_WAIT    -- Waiting for host to complete result read(s).
+  CIR_COND_EVAL        -- Conditional instruction evaluated.
+  CIR_EXCEPT_PRE       -- Pre-instruction exception pending.
+  CIR_EXCEPT_MID       -- Mid-instruction exception pending.
+  CIR_EXCEPT_POST      -- Post-instruction exception pending.
+  CIR_SAVE_FORMAT      -- FSAVE: format word ready for host read.
+  CIR_SAVE_FRAME       -- FSAVE: streaming state frame via Operand CIR.
+  CIR_RESTORE_FORMAT   -- FRESTORE: waiting for format word from host.
+  CIR_RESTORE_FRAME    -- FRESTORE: receiving state frame via Operand CIR.
+```
+
+### Dialog Flows
+
+**cpGEN with memory source** (e.g. FADD.S <ea>,FP0):
+1. Host writes OpWord ($08), Command ($0A)
+2. FSM decodes: need N-word source operand
+3. Response = Transfer Operand primitive ($68xx, byte count)
+4. Host writes N longwords to Operand CIR ($10)
+5. FSM converts format, launches ALU. Response = Busy ($0000)
+6. ALU completes. Response = Null ($2001)
+
+**cpGEN register-to-register** (e.g. FADD FP1,FP0):
+1. Host writes OpWord ($08), Command ($0A)
+2. FSM decodes: source = FPn, no transfer needed
+3. FSM reads source from fp_reg_file, launches ALU. Response = Busy
+4. ALU completes. Response = Null
+
+**cpBcc/cpScc/cpDBcc/cpTRAPcc**:
+1. Host writes OpWord ($08), Condition ($0E)
+2. FSM evaluates FPSR CC bits via eval_fcc_condition
+3. Response = Null (condition false) or Post-Instruction Exception (branch/trap)
+
+**cpSAVE**:
+1. Host writes to Save CIR ($04)
+2. FPU freezes state, determines frame type (Null/Idle/Busy)
+3. Host reads Save CIR → gets format word ($0000/$0018/$00B4)
+4. Host reads N longwords from Operand CIR ($10) for frame body
+5. Response = Null when complete
+
+**cpRESTORE**:
+1. Host writes format word to Restore CIR ($06)
+2. FPU validates format word
+3. If valid: host writes N longwords to Operand CIR for frame body
+4. FPU commits restored state. Response = Null.
+5. If invalid: Response = Pre-Instruction Exception
+
+## Instruction Decode
+
+### Operation Word ($08) — Type Field [8:6]
+
+| Type | Instruction                  | Dialog Family   |
+|------|------------------------------|-----------------|
+| 000  | cpGEN (arithmetic/move)      | General         |
+| 001  | cpScc, cpDBcc, cpTRAPcc      | Conditional     |
+| 010  | cpBcc (.W displacement)      | Conditional     |
+| 011  | cpBcc (.L displacement)      | Conditional     |
+| 100  | cpSAVE                       | Context Save    |
+| 101  | cpRESTORE                    | Context Restore |
+
+### Command Word ($0A) — Source Format [12:10]
+
+| Src | Format         | Operand Words |
+|-----|----------------|---------------|
+| 000 | Long Integer   | 1             |
+| 001 | Single         | 1             |
+| 010 | Extended       | 3             |
+| 011 | Packed Decimal | 3             |
+| 100 | Word Integer   | 1             |
+| 101 | Double         | 2             |
+| 110 | Byte Integer   | 1             |
+| 111 | FPn (register) | 0             |
+
+Command word bits [6:0] map to the existing fpu_op_t enum.
+Bits [9:7] = destination FP register. Bit [14] = reg-to-reg vs memory-to-reg.
+
+## Operand Transfer Protocol
+
+Source operand transfer uses the "Evaluate EA and Transfer Data" response primitive:
+- Bits [15:13] = 011, bit [12] = 1 (to coprocessor), bits [7:0] = byte count
+- Internal xfer_word_index counter auto-increments on each Operand CIR write
+- Word packing follows M68020 memory order (MSW first)
+
+Destination operand transfer (FMOVE reg→mem) uses transfer-from-CP primitive:
+- Same encoding with bit [12] = 0 (from coprocessor)
+- Host reads N longwords from Operand CIR
+
+FMOVEM uses Register Select CIR ($14) to communicate the register list mask,
+then multiple 3-word transfers via Operand CIR for each FP register.
+
+## Exception Dialog Paths
+
+### Pre-Instruction (Response $Axxx)
+- Invalid OpWord type, unrecognized opcode, privilege violation
+- Detected during CIR_DECODE, no internal state modified
+- Vector encoded in bits [9:0]
+
+### Mid-Instruction (Response $Cxxx)
+- FPCR-enabled arithmetic exception during execution (OVFL, UNFL, DZ, etc.)
+- Internal state modified — host must FSAVE before handling
+- Detected when exc_status_proc fires and FPCR enable bit is set
+
+### Post-Instruction (Response $Exxx)
+- BSUN, FTRAPcc condition true, enabled INEX after completion
+- Result committed to FP register file
+- Uses existing cir_trap_pending_reg / exc_event_force_bsun_reg paths
+
+### Control CIR ($02)
+- Host writes exception-acknowledge bit after processing exception
+- Clears exception state, dialog returns to CIR_IDLE
+
+### FPIAR Capture
+- Pre-instruction: captured at Instruction Address CIR write
+- Mid/Post-instruction: captured at instruction start (fpiar_issue_snapshot_reg)
+
+## FSAVE/FRESTORE State Frames
+
+### Frame Types
+
+| FPU State | Format Word | Frame Size  |
+|-----------|-------------|-------------|
+| Null      | $0000       | 0 bytes     |
+| Idle      | $0018       | 24 bytes    |
+| Busy      | $00B4       | 180 bytes   |
+
+### Idle Frame (24 bytes = 6 longwords)
+Non-architectural internal state only (FPCR/FPSR/FPIAR are architectural,
+saved separately by FMOVEM.CR):
+- Frame version + internal flags
+- Last operation descriptor
+- Pending exception state
+- Microsequencer state
+- CIR dialog state
+- Reserved
+
+### Busy Frame (180 bytes = 45 longwords)
+Full mid-computation micro-state:
+- Words 0-5: Idle frame fields
+- Words 6-7: ALU control state (op_sel, staging)
+- Words 8-11: Operand A + B (80-bit each)
+- Words 12-20: Trig unit state (FSM enum, working regs, FP sub-unit pipeline)
+- Words 21-26: Divrem unit state (FSM enum, iteration, partial quotient, mantissa)
+- Words 27-29: Modrem post-unit state
+- Words 30-32: Packed decimal unit state
+- Words 33-37: Shared FP mul/add unit pipeline state
+- Words 38-44: Reserved / padding
+
+### Save/Restore Sub-Unit Interface
+Each computation unit gets:
+```vhdl
+save_req     : in  std_logic;
+save_data    : out std_logic_vector(31 downto 0);
+save_addr    : in  natural range 0 to N;
+save_busy    : out std_logic;
+restore_req  : in  std_logic;
+restore_data : in  std_logic_vector(31 downto 0);
+restore_addr : in  natural range 0 to N;
+restore_wr   : in  std_logic;
+```
+
+## Files Changed
+
+| File                              | Change Type                        |
+|-----------------------------------|------------------------------------|
+| src/mc68881_pkg.vhd               | Add CIR types, constants, frames   |
+| src/mc68881_top.vhd               | Replace bus interface with CIR FSM |
+| src/mc68881_alu.vhd               | Add save/restore ports             |
+| src/mc68881_trig_unit.vhd         | Add save/restore ports             |
+| src/mc68881_divrem_unit.vhd       | Add save/restore ports             |
+| src/mc68881_modrem_post_unit.vhd  | Add save/restore ports             |
+| src/mc68881_packed_decimal_unit.vhd | Add save/restore ports           |
+| tb/tb_mc68881_top.vhd             | Rewrite for CIR dialog protocol    |
+| tb/tb_mc68881_alu.vhd             | No change (direct ALU interface)   |
+
+## What Stays the Same
+
+- ALU entity and all computation sub-units (internal logic unchanged)
+- FP register file (8 x 80-bit)
+- FPCR/FPSR/FPIAR internal representation
+- Exception classification (exc_status_proc)
+- Microsequencer (cycle counting)
+- DSACK state machine (bus handshake)
+- mc68881_pkg.vhd op descriptors, exception policies, FP types

--- a/docs/plans/2026-03-03-s7-coprocessor-interface.md
+++ b/docs/plans/2026-03-03-s7-coprocessor-interface.md
@@ -1,0 +1,1024 @@
+# Section 7 Coprocessor Interface Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the custom register-mapped host interface with the standard MC68020 CIR dialog protocol, enabling true coprocessor operation on M68020/M68030 and AN-947 peripheral operation on M68000.
+
+**Architecture:** CIR address decoder overlay on the existing internal engine. A dialog FSM in `mc68881_top.vhd` drives the Response CIR based on instruction phase. Sub-units gain save/restore ports for FSAVE Busy frame serialization. The ALU, trig, divrem, and other computation units are internally unchanged.
+
+**Tech Stack:** VHDL-2008, GHDL for simulation (`C:\code\ghdl-mcode-5.1.1-mingw64\bin\ghdl.exe`), Vivado for synthesis (`C:\amddesigntools\2025.2\Vivado\bin\vivado.bat`), test suite via `scripts/run_tests.ps1`.
+
+**Design doc:** `docs/plans/2026-03-03-s7-coprocessor-interface-design.md`
+
+---
+
+## Phase 1: CIR Types + Dialog FSM Skeleton
+
+### Task 1: Add CIR types and constants to package
+
+**Files:**
+- Modify: `src/mc68881_pkg.vhd` (add after line ~313, after `op_descriptor_table_t`)
+
+**Step 1: Add CIR type definitions**
+
+Add the following types and constants after the existing `op_descriptor_table_t` definition (line 313):
+
+```vhdl
+  -- ===== Section 7 Coprocessor Interface Types =====
+
+  -- CIR register addresses (5-bit, maps to A[4:1] of CPU-space address).
+  -- MC68020 CIR offset $XX maps to addr = $XX / 2.
+  constant CIR_ADDR_RESPONSE     : unsigned(4 downto 0) := "00000";  -- $00
+  constant CIR_ADDR_CONTROL      : unsigned(4 downto 0) := "00001";  -- $02
+  constant CIR_ADDR_SAVE         : unsigned(4 downto 0) := "00010";  -- $04
+  constant CIR_ADDR_RESTORE      : unsigned(4 downto 0) := "00011";  -- $06
+  constant CIR_ADDR_OPWORD       : unsigned(4 downto 0) := "00100";  -- $08
+  constant CIR_ADDR_COMMAND      : unsigned(4 downto 0) := "00101";  -- $0A
+  constant CIR_ADDR_CONDITION    : unsigned(4 downto 0) := "00111";  -- $0E
+  constant CIR_ADDR_OPERAND      : unsigned(4 downto 0) := "01000";  -- $10
+  constant CIR_ADDR_REGSELECT    : unsigned(4 downto 0) := "01010";  -- $14
+  constant CIR_ADDR_INSTADDR     : unsigned(4 downto 0) := "01100";  -- $18
+  constant CIR_ADDR_OPADDR       : unsigned(4 downto 0) := "01110";  -- $1C
+
+  -- Dialog FSM states.
+  type cir_dialog_state_t is (
+    CIR_IDLE,
+    CIR_DECODE,
+    CIR_XFER_SRC,
+    CIR_XFER_SRC_WAIT,
+    CIR_EXECUTE,
+    CIR_XFER_DST,
+    CIR_XFER_DST_WAIT,
+    CIR_COND_EVAL,
+    CIR_EXCEPT_PRE,
+    CIR_EXCEPT_MID,
+    CIR_EXCEPT_POST,
+    CIR_SAVE_FORMAT,
+    CIR_SAVE_FRAME,
+    CIR_RESTORE_FORMAT,
+    CIR_RESTORE_FRAME
+  );
+
+  -- Response primitive categories (bits 15:13 of Response CIR).
+  constant CIR_RESP_BUSY         : std_logic_vector(2 downto 0) := "000";
+  constant CIR_RESP_NULL         : std_logic_vector(2 downto 0) := "001";
+  constant CIR_RESP_SUPERVISOR   : std_logic_vector(2 downto 0) := "010";
+  constant CIR_RESP_TRANSFER     : std_logic_vector(2 downto 0) := "011";
+  constant CIR_RESP_WRITEBACK    : std_logic_vector(2 downto 0) := "100";
+  constant CIR_RESP_EXCEPT_PRE   : std_logic_vector(2 downto 0) := "101";
+  constant CIR_RESP_EXCEPT_MID   : std_logic_vector(2 downto 0) := "110";
+  constant CIR_RESP_EXCEPT_POST  : std_logic_vector(2 downto 0) := "111";
+
+  -- Common response primitive words.
+  constant CIR_PRIM_BUSY         : std_logic_vector(15 downto 0) := x"0000";
+  constant CIR_PRIM_NULL         : std_logic_vector(15 downto 0) := x"2001";
+
+  -- Operation Word type field [8:6] — instruction family.
+  constant CIR_TYPE_CPGEN        : std_logic_vector(2 downto 0) := "000";
+  constant CIR_TYPE_CPCOND       : std_logic_vector(2 downto 0) := "001";
+  constant CIR_TYPE_CPBCC_W      : std_logic_vector(2 downto 0) := "010";
+  constant CIR_TYPE_CPBCC_L      : std_logic_vector(2 downto 0) := "011";
+  constant CIR_TYPE_CPSAVE       : std_logic_vector(2 downto 0) := "100";
+  constant CIR_TYPE_CPRESTORE    : std_logic_vector(2 downto 0) := "101";
+
+  -- Source format field [12:10] of cpGEN command word.
+  constant CIR_SRC_LONG          : std_logic_vector(2 downto 0) := "000";
+  constant CIR_SRC_SINGLE        : std_logic_vector(2 downto 0) := "001";
+  constant CIR_SRC_EXTENDED      : std_logic_vector(2 downto 0) := "010";
+  constant CIR_SRC_PACKED        : std_logic_vector(2 downto 0) := "011";
+  constant CIR_SRC_WORD          : std_logic_vector(2 downto 0) := "100";
+  constant CIR_SRC_DOUBLE        : std_logic_vector(2 downto 0) := "101";
+  constant CIR_SRC_BYTE          : std_logic_vector(2 downto 0) := "110";
+  constant CIR_SRC_FPN           : std_logic_vector(2 downto 0) := "111";
+
+  -- FSAVE frame format words.
+  constant CIR_FRAME_NULL_FW     : std_logic_vector(15 downto 0) := x"0000";
+  constant CIR_FRAME_IDLE_FW     : std_logic_vector(15 downto 0) := x"0018";
+  constant CIR_FRAME_BUSY_FW     : std_logic_vector(15 downto 0) := x"00B4";
+  constant CIR_FRAME_IDLE_WORDS  : natural := 6;   -- 24 bytes / 4
+  constant CIR_FRAME_BUSY_WORDS  : natural := 45;  -- 180 bytes / 4
+
+  -- Helper: number of 32-bit operand words for a given source format.
+  function cir_src_word_count(src_fmt : std_logic_vector(2 downto 0)) return natural;
+
+  -- Helper: decode command word bits [6:0] to fpu_op_t.
+  function cir_decode_cpgen_opcode(cmd_word : std_logic_vector(15 downto 0)) return fpu_op_t;
+```
+
+**Step 2: Add helper function bodies**
+
+In the package body (after line ~1133, after `decode_op_sel_word` body), add:
+
+```vhdl
+  function cir_src_word_count(src_fmt : std_logic_vector(2 downto 0)) return natural is
+  begin
+    case src_fmt is
+      when CIR_SRC_LONG | CIR_SRC_SINGLE | CIR_SRC_WORD | CIR_SRC_BYTE =>
+        return 1;
+      when CIR_SRC_DOUBLE =>
+        return 2;
+      when CIR_SRC_EXTENDED | CIR_SRC_PACKED =>
+        return 3;
+      when CIR_SRC_FPN =>
+        return 0;
+      when others =>
+        return 0;
+    end case;
+  end function;
+
+  function cir_decode_cpgen_opcode(cmd_word : std_logic_vector(15 downto 0)) return fpu_op_t is
+    variable opcode_bits : std_logic_vector(6 downto 0);
+    variable key : op_key_t;
+  begin
+    opcode_bits := cmd_word(6 downto 0);
+    -- Map MC68881 opcode encoding to core_v1 decode IDs.
+    -- The command word opcode field matches the MC68881 opcode table
+    -- (e.g. $22=FADD, $28=FSUB, $23=FMUL, $20=FDIV, etc.).
+    -- Build an op_key in OP_NS_CORE_V1 namespace and look up via descriptors.
+    key.namespace := OP_NS_CORE_V1;
+    key.opcode_id := '0' & opcode_bits;
+    for op in fpu_op_t loop
+      if OP_DESCRIPTORS(op).core_v1_decode_id_valid and
+         OP_DESCRIPTORS(op).core_v1_decode_id = key.opcode_id then
+        return op;
+      end if;
+    end loop;
+    return FPU_OP_NOP;
+  end function;
+```
+
+**Step 3: Verify GHDL analysis passes**
+
+Run: `cd /c/code/68881-fpga && C:/code/ghdl-mcode-5.1.1-mingw64/bin/ghdl.exe -a --std=08 src/mc68881_pkg.vhd`
+Expected: Clean compile, no errors.
+
+**Step 4: Commit**
+
+```
+git add src/mc68881_pkg.vhd
+git commit -m "Add CIR types, constants, and helper functions to package (S7 Phase 1)"
+```
+
+---
+
+### Task 2: Replace address decode and add CIR registers in top-level
+
+**Files:**
+- Modify: `src/mc68881_top.vhd`
+
+This task replaces the register-mapped address constants and access_class decode with the CIR register map, and adds the new CIR dialog signals. The internal engine (ALU dispatch, exception classification, microsequencer) is NOT changed yet — this task just lays the addressing foundation.
+
+**Step 1: Replace address constants (lines 84-111)**
+
+Remove the old `ADDR_OPSEL` through `ADDR_AUX_RES_E` constants. Replace with CIR addresses imported from the package (the constants added in Task 1 are in `mc68881_pkg`). Add local aliases if needed for readability.
+
+Add new CIR dialog signals in the signal declaration area (after line ~169):
+
+```vhdl
+  -- CIR dialog state machine signals.
+  signal cir_state_reg         : cir_dialog_state_t := CIR_IDLE;
+  signal cir_opword_reg        : std_logic_vector(15 downto 0) := (others => '0');
+  signal cir_command_reg       : std_logic_vector(15 downto 0) := (others => '0');
+  signal cir_condition_reg     : std_logic_vector(5 downto 0) := (others => '0');
+  signal cir_instr_type        : std_logic_vector(2 downto 0) := (others => '0');
+  signal cir_src_fmt           : std_logic_vector(2 downto 0) := (others => '0');
+  signal cir_dst_reg_idx       : natural range 0 to 7 := 0;
+  signal cir_src_reg_idx       : natural range 0 to 7 := 0;
+  signal cir_reg_to_reg        : std_logic := '0';
+  signal cir_xfer_word_idx     : natural range 0 to 44 := 0;
+  signal cir_xfer_word_count   : natural range 0 to 45 := 0;
+  signal cir_response_word     : std_logic_vector(15 downto 0) := CIR_PRIM_NULL;
+  signal cir_opword_written    : std_logic := '0';
+  signal cir_command_written   : std_logic := '0';
+  signal cir_exc_vector        : std_logic_vector(9 downto 0) := (others => '0');
+  signal cir_control_ack       : std_logic := '0';
+```
+
+**Step 2: Replace address decode process (lines 1599-1626)**
+
+Replace the `access_class` case statement to decode CIR addresses:
+
+```vhdl
+  process(addr)
+  begin
+    access_class <= ACCESS_NONE;
+    case addr is
+      when CIR_ADDR_RESPONSE =>
+        access_class <= ACCESS_CIR;
+      when CIR_ADDR_CONTROL =>
+        access_class <= ACCESS_CIR;
+      when CIR_ADDR_SAVE =>
+        access_class <= ACCESS_FRAME;
+      when CIR_ADDR_RESTORE =>
+        access_class <= ACCESS_FRAME;
+      when CIR_ADDR_OPWORD | CIR_ADDR_COMMAND =>
+        access_class <= ACCESS_OPERAND;
+      when CIR_ADDR_CONDITION =>
+        access_class <= ACCESS_CIR;
+      when CIR_ADDR_OPERAND =>
+        access_class <= ACCESS_OPERAND;
+      when CIR_ADDR_REGSELECT =>
+        access_class <= ACCESS_CIR;
+      when CIR_ADDR_INSTADDR =>
+        access_class <= ACCESS_FPIAR;
+      when CIR_ADDR_OPADDR =>
+        access_class <= ACCESS_CIR;
+      when others =>
+        access_class <= ACCESS_NONE;
+    end case;
+  end process;
+```
+
+**Step 3: Replace bus read mux (lines 2731-2831)**
+
+Replace the `d_out_comb` process to return CIR register values:
+
+```vhdl
+  process(addr, cir_response_word, cir_state_reg, ...)
+  begin
+    d_out_comb <= (others => '0');
+    case addr is
+      when CIR_ADDR_RESPONSE =>
+        d_out_comb(15 downto 0) <= cir_response_word;
+      when CIR_ADDR_SAVE =>
+        -- Format word (set by FSAVE dialog)
+        d_out_comb(15 downto 0) <= frame_format_word_reg;
+      when CIR_ADDR_OPERAND =>
+        -- Operand data (transfer direction depends on dialog state)
+        d_out_comb <= cir_operand_read_data;
+      when CIR_ADDR_REGSELECT =>
+        d_out_comb(15 downto 0) <= cir_regselect_word;
+      when CIR_ADDR_OPADDR =>
+        d_out_comb <= cir_operand_addr_reg;
+      when others =>
+        d_out_comb <= (others => '0');
+    end case;
+  end process;
+```
+
+**Step 4: Verify GHDL analysis passes**
+
+Run: `cd /c/code/68881-fpga && C:/code/ghdl-mcode-5.1.1-mingw64/bin/ghdl.exe -a --std=08 src/mc68881_pkg.vhd src/mc68881_top.vhd`
+Expected: Clean compile (testbenches will NOT compile yet — they still reference old addresses).
+
+**Step 5: Commit**
+
+```
+git add src/mc68881_top.vhd
+git commit -m "Replace register-mapped address decode with CIR register map (S7 Phase 1)"
+```
+
+---
+
+### Task 3: Implement dialog FSM skeleton
+
+**Files:**
+- Modify: `src/mc68881_top.vhd`
+
+This task adds the core dialog state machine process that drives `cir_response_word` based on `cir_state_reg`. Initially it handles only the CIR_IDLE → CIR_DECODE → CIR_EXECUTE → CIR_IDLE flow for register-to-register cpGEN ops. Other paths are stubbed.
+
+**Step 1: Add CIR register write handling**
+
+In the synchronous bus write process, add handlers for OpWord, Command, and Condition CIR writes:
+
+```vhdl
+  -- OpWord CIR write: latch F-line operation word, extract type field.
+  when CIR_ADDR_OPWORD =>
+    cir_opword_reg <= d_in(15 downto 0);
+    cir_instr_type <= d_in(8 downto 6);
+    cir_opword_written <= '1';
+
+  -- Command CIR write: latch command word, extract fields.
+  when CIR_ADDR_COMMAND =>
+    cir_command_reg <= d_in(15 downto 0);
+    cir_src_fmt <= d_in(12 downto 10);
+    cir_dst_reg_idx <= to_integer(unsigned(d_in(9 downto 7)));
+    cir_reg_to_reg <= d_in(14);
+    cir_command_written <= '1';
+
+  -- Condition CIR write: latch condition selector, trigger eval.
+  when CIR_ADDR_CONDITION =>
+    cir_condition_reg <= d_in(5 downto 0);
+
+  -- Instruction Address CIR write: capture FPIAR.
+  when CIR_ADDR_INSTADDR =>
+    fpiar_reg <= d_in;
+
+  -- Control CIR write: exception acknowledge.
+  when CIR_ADDR_CONTROL =>
+    cir_control_ack <= d_in(0);
+```
+
+**Step 2: Add dialog FSM process**
+
+New synchronous process `cir_dialog_proc` that manages state transitions:
+
+```vhdl
+  cir_dialog_proc : process(clk, reset_n)
+  begin
+    if reset_n = '0' then
+      cir_state_reg <= CIR_IDLE;
+      cir_opword_written <= '0';
+      cir_command_written <= '0';
+      cir_xfer_word_idx <= 0;
+      cir_xfer_word_count <= 0;
+    elsif rising_edge(clk) then
+      case cir_state_reg is
+
+        when CIR_IDLE =>
+          -- Wait for OpWord + Command (cpGEN) or OpWord + Condition (cpBcc/cpScc).
+          if cir_opword_written = '1' and cir_command_written = '1' then
+            cir_state_reg <= CIR_DECODE;
+            cir_opword_written <= '0';
+            cir_command_written <= '0';
+          end if;
+
+        when CIR_DECODE =>
+          case cir_instr_type is
+            when CIR_TYPE_CPGEN =>
+              if cir_src_fmt = CIR_SRC_FPN then
+                -- Register-to-register: launch ALU directly.
+                -- (op_issue wiring goes here — Task 4)
+                cir_state_reg <= CIR_EXECUTE;
+              else
+                -- Memory source: request operand transfer.
+                cir_xfer_word_count <= cir_src_word_count(cir_src_fmt);
+                cir_xfer_word_idx <= 0;
+                cir_state_reg <= CIR_XFER_SRC;
+              end if;
+            when CIR_TYPE_CPCOND | CIR_TYPE_CPBCC_W | CIR_TYPE_CPBCC_L =>
+              cir_state_reg <= CIR_COND_EVAL;
+            when CIR_TYPE_CPSAVE =>
+              cir_state_reg <= CIR_SAVE_FORMAT;
+            when CIR_TYPE_CPRESTORE =>
+              cir_state_reg <= CIR_RESTORE_FORMAT;
+            when others =>
+              cir_state_reg <= CIR_EXCEPT_PRE;  -- Unknown type
+          end case;
+
+        when CIR_EXECUTE =>
+          -- Wait for ALU completion.
+          if valid = '1' then
+            cir_state_reg <= CIR_IDLE;
+          end if;
+
+        when CIR_XFER_SRC =>
+          -- Present transfer-operand response. Wait for host writes.
+          null;  -- Operand CIR write handler increments xfer_word_idx.
+
+        when CIR_XFER_SRC_WAIT =>
+          if cir_xfer_word_idx >= cir_xfer_word_count then
+            cir_state_reg <= CIR_EXECUTE;
+          end if;
+
+        -- Stub remaining states for later phases:
+        when CIR_XFER_DST | CIR_XFER_DST_WAIT =>
+          null;
+        when CIR_COND_EVAL =>
+          cir_state_reg <= CIR_IDLE;  -- Phase 2 fills this in
+        when CIR_EXCEPT_PRE | CIR_EXCEPT_MID | CIR_EXCEPT_POST =>
+          if cir_control_ack = '1' then
+            cir_state_reg <= CIR_IDLE;
+            cir_control_ack <= '0';
+          end if;
+        when CIR_SAVE_FORMAT | CIR_SAVE_FRAME =>
+          null;  -- Phase 3
+        when CIR_RESTORE_FORMAT | CIR_RESTORE_FRAME =>
+          null;  -- Phase 3
+      end case;
+    end if;
+  end process;
+```
+
+**Step 3: Add combinational response word generation**
+
+```vhdl
+  process(cir_state_reg, cir_xfer_word_count)
+  begin
+    case cir_state_reg is
+      when CIR_IDLE =>
+        cir_response_word <= CIR_PRIM_NULL;
+      when CIR_EXECUTE =>
+        cir_response_word <= CIR_PRIM_BUSY;
+      when CIR_XFER_SRC =>
+        -- Transfer Operand to-CP: bits [15:13]=011, [12]=1, [7:0]=byte count
+        cir_response_word <= "011" & '1' & "0000" &
+          std_logic_vector(to_unsigned(cir_xfer_word_count * 4, 8));
+      when CIR_EXCEPT_PRE =>
+        cir_response_word <= CIR_RESP_EXCEPT_PRE & "0" & "000000000000";
+      when CIR_EXCEPT_MID =>
+        cir_response_word <= CIR_RESP_EXCEPT_MID & "0" & "000000000000";
+      when CIR_EXCEPT_POST =>
+        cir_response_word <= CIR_RESP_EXCEPT_POST & "0" & "000000000000";
+      when others =>
+        cir_response_word <= CIR_PRIM_NULL;
+    end case;
+  end process;
+```
+
+**Step 4: Verify GHDL analysis passes**
+
+Run: `cd /c/code/68881-fpga && C:/code/ghdl-mcode-5.1.1-mingw64/bin/ghdl.exe -a --std=08 src/mc68881_pkg.vhd src/mc68881_top.vhd`
+Expected: Clean compile.
+
+**Step 5: Commit**
+
+```
+git add src/mc68881_top.vhd
+git commit -m "Add CIR dialog FSM skeleton with cpGEN decode path (S7 Phase 1)"
+```
+
+---
+
+### Task 4: Wire cpGEN register-to-register through dialog FSM to ALU
+
+**Files:**
+- Modify: `src/mc68881_top.vhd`
+
+Connect the dialog FSM's CIR_DECODE → CIR_EXECUTE path to the existing ALU dispatch. When the FSM decodes a register-to-register cpGEN instruction:
+1. Decode command word opcode bits [6:0] to `fpu_op_t` via `cir_decode_cpgen_opcode`.
+2. Load source operand from `fp_reg_file_reg(cir_src_reg_idx)`.
+3. Load destination operand from `fp_reg_file_reg(cir_dst_reg_idx)` (for dyadic ops).
+4. Set `op_sel_reg` and pulse `op_start_reg`.
+5. On ALU `valid`, write result back to `fp_reg_file_reg(cir_dst_reg_idx)`.
+
+The existing `alu_control_proc` op_issue_pulse logic (line 1638) must be replaced: instead of triggering from an OPSEL address write, it triggers from the dialog FSM entering CIR_EXECUTE.
+
+**Step 1: Modify op_issue_pulse to trigger from FSM**
+
+Replace the combinational `op_issue_pulse` (lines 1638-1647) with a registered pulse driven by the FSM:
+
+```vhdl
+  -- op_issue_pulse is now driven by the dialog FSM, not by OPSEL write.
+  -- It fires for one cycle when the FSM transitions to CIR_EXECUTE.
+```
+
+In `cir_dialog_proc`, at the CIR_DECODE → CIR_EXECUTE transition:
+```vhdl
+  -- Decode opcode, stage operands, fire ALU.
+  op_sel_reg <= cir_decode_cpgen_opcode(cir_command_reg);
+  cir_src_reg_idx <= to_integer(unsigned(cir_command_reg(12 downto 10)))
+                     when cir_src_fmt = CIR_SRC_FPN else 0;
+  operand_reg(0) <= fp_reg_file_reg(cir_dst_reg_idx);  -- Destination = operand A
+  operand_reg(1) <= fp_reg_file_reg(cir_src_reg_idx);  -- Source = operand B
+  op_start_reg <= '1';
+  cir_state_reg <= CIR_EXECUTE;
+```
+
+Note: For the MC68881, dyadic ops use `FPn,FPm` where source is the second operand. The operand mapping (which goes to A vs B) must match the existing ALU convention. Check the existing `alu_control_proc` OP_CLASS_ARITH section to verify operand order.
+
+**Step 2: Add result writeback on ALU completion**
+
+In `cir_dialog_proc` CIR_EXECUTE state:
+```vhdl
+  when CIR_EXECUTE =>
+    op_start_reg <= '0';
+    if valid = '1' then
+      -- Write result to destination FP register.
+      fp_reg_file_reg(cir_dst_reg_idx) <= result;
+      -- Run exception classification (existing exc_status_proc).
+      -- Transition based on exception state.
+      cir_state_reg <= CIR_IDLE;
+    end if;
+```
+
+**Step 3: Verify GHDL analysis passes**
+
+Run: `cd /c/code/68881-fpga && C:/code/ghdl-mcode-5.1.1-mingw64/bin/ghdl.exe -a --std=08 src/mc68881_pkg.vhd src/mc68881_top.vhd`
+
+**Step 4: Commit**
+
+```
+git add src/mc68881_top.vhd
+git commit -m "Wire cpGEN reg-to-reg path through dialog FSM to ALU (S7 Phase 1)"
+```
+
+---
+
+### Task 5: Write CIR dialog testbench with first cpGEN reg-to-reg test
+
+**Files:**
+- Create: `tb/tb_mc68881_cir_dialog.vhd`
+- Modify: `scripts/run_tests.ps1` (add to compile/run list)
+
+**Step 1: Create CIR dialog testbench**
+
+Create `tb/tb_mc68881_cir_dialog.vhd` with:
+- DUT instantiation of `mc68881_top`
+- CIR-protocol bus procedures:
+  - `cir_write_opword(opword)` — write to CIR_ADDR_OPWORD
+  - `cir_write_command(cmd)` — write to CIR_ADDR_COMMAND
+  - `cir_write_condition(cond)` — write to CIR_ADDR_CONDITION
+  - `cir_write_operand(data)` — write to CIR_ADDR_OPERAND
+  - `cir_read_response() → 16-bit` — read CIR_ADDR_RESPONSE
+  - `cir_read_operand() → 32-bit` — read CIR_ADDR_OPERAND
+  - `cir_write_instaddr(addr)` — write to CIR_ADDR_INSTADDR
+  - `cir_poll_until_not_busy() → response` — loop read Response until not Busy
+- Higher-level dialog procedures:
+  - `cpgen_reg_to_reg(opcode, src_reg, dst_reg)` — full cpGEN dialog for FPn,FPm
+  - `cpgen_mem_source(opcode, src_fmt, dst_reg, operand_words)` — full dialog with operand transfer
+- First test case: `FADD FP1,FP0`
+  1. Pre-load FP0 with 1.0 via cpGEN FMOVE with memory source (or direct register init)
+  2. Pre-load FP1 with 2.0
+  3. Execute `cpgen_reg_to_reg(FADD, src=1, dst=0)`
+  4. Verify FP0 = 3.0 by reading back via FMOVE to memory dialog
+  5. Assert response was Busy then Null
+
+**Step 2: Add to compile/run list**
+
+Add `tb/tb_mc68881_cir_dialog.vhd` to the GHDL compile line in `scripts/run_tests.ps1` (line 28), and add elaborate+run lines.
+
+**Step 3: Run test**
+
+Run: `cd /c/code/68881-fpga && powershell -ExecutionPolicy Bypass -File scripts/run_tests.ps1`
+Expected: New CIR dialog test passes (other tests may need adjustment).
+
+**Step 4: Commit**
+
+```
+git add tb/tb_mc68881_cir_dialog.vhd scripts/run_tests.ps1
+git commit -m "Add CIR dialog testbench with cpGEN reg-to-reg FADD test (S7 Phase 1)"
+```
+
+---
+
+### Task 6: Implement cpGEN memory-source operand transfer
+
+**Files:**
+- Modify: `src/mc68881_top.vhd`
+- Modify: `tb/tb_mc68881_cir_dialog.vhd`
+
+**Step 1: Add Operand CIR write handler for source transfer**
+
+When `cir_state_reg = CIR_XFER_SRC` and host writes to CIR_ADDR_OPERAND:
+- Store the word into the appropriate slice of the operand staging register based on `cir_xfer_word_idx` and `cir_src_fmt`.
+- Increment `cir_xfer_word_idx`.
+- When `cir_xfer_word_idx = cir_xfer_word_count`, convert from source format to FP80 (using existing `fp80_from_single`, `fp80_from_double`, `fp80_from_integer` functions) and transition to CIR_EXECUTE.
+
+Word packing for each format:
+- **Long/Word/Byte**: 1 word → `operand_reg(1)(31 downto 0)`
+- **Single**: 1 word → pass to `fp80_from_single`
+- **Double**: word 0 = upper 32, word 1 = lower 32 → pass to `fp80_from_double`
+- **Extended**: word 0[31:16] = sign+exp, word 1 = mant high, word 2 = mant low → direct FP80 pack
+- **Packed**: word 0 = SE/YY/exp, word 1 = digits high, word 2 = digits low → packed decode path
+
+**Step 2: Add test for FADD.S with memory source**
+
+In `tb/tb_mc68881_cir_dialog.vhd`, add test:
+1. Write OpWord for cpGEN
+2. Write Command with src_fmt=Single, opcode=FADD, dst=FP0
+3. Read Response → expect Transfer Operand primitive ($6804)
+4. Write 1 longword to Operand CIR (single-precision 2.0 = $40000000)
+5. Poll Response until not Busy
+6. Verify FP0 contains expected result
+
+**Step 3: Run tests**
+
+Run: `cd /c/code/68881-fpga && powershell -ExecutionPolicy Bypass -File scripts/run_tests.ps1`
+
+**Step 4: Commit**
+
+```
+git add src/mc68881_top.vhd tb/tb_mc68881_cir_dialog.vhd
+git commit -m "Implement cpGEN memory-source operand transfer via Operand CIR (S7 Phase 1)"
+```
+
+---
+
+### Task 7: Implement cpGEN destination transfer (FMOVE reg→mem)
+
+**Files:**
+- Modify: `src/mc68881_top.vhd`
+- Modify: `tb/tb_mc68881_cir_dialog.vhd`
+
+**Step 1: Add CIR_XFER_DST path**
+
+When the dialog FSM decodes an FMOVE reg→mem (command word bit [13]=1 indicating direction, or however the existing move_cfg decode determines direction):
+- Transition to CIR_XFER_DST after ALU/conversion completes.
+- Present transfer-from-CP response primitive with byte count.
+- On each host read of CIR_ADDR_OPERAND, output the next result word and increment `cir_xfer_word_idx`.
+- When all words transferred, transition to CIR_IDLE.
+
+**Step 2: Add test for FMOVE FP0 to memory (single format)**
+
+Test: load FP0 with a known value, then execute FMOVE to memory dialog:
+1. Write OpWord for cpGEN
+2. Write Command for FMOVE with dst_fmt=Single, src=FP0
+3. Read Response → expect transfer-from-CP primitive ($6404)
+4. Read 1 longword from Operand CIR → verify single-precision encoding
+
+**Step 3: Run tests and commit**
+
+---
+
+### Task 8: Update existing testbenches for CIR protocol
+
+**Files:**
+- Modify: `tb/tb_mc68881_top.vhd`
+- Modify: `tb/tb_mc68881_fpcr_fpsr.vhd`
+- Modify: `tb/tb_mc68881_fmove_fmovem.vhd`
+- Modify: `tb/tb_mc68881_fmovecr.vhd`
+- Modify: `tb/tb_mc68881_ea_cycles.vhd`
+- Modify: `tb/tb_mc68881_cycle_counts.vhd`
+- Modify: `tb/tb_mc68881_cycle_counts_top.vhd`
+- Modify: `tb/tb_mc68881_ac_timing.vhd`
+- Modify: `tb/tb_mc68881_op_class_dispatch.vhd`
+- Modify: `tb/tb_mc68881_known_defects.vhd`
+
+Each testbench that talks to `mc68881_top` must be updated:
+1. Replace ADDR_OPSEL/OPA/OPB/RES/STATUS constants with CIR addresses.
+2. Replace `bus_write(ADDR_OPSEL, opcode)` pattern with cpGEN dialog sequence (write OpWord, write Command, poll Response).
+3. Replace `wait_for_valid` (STATUS polling) with `cir_poll_until_not_busy` (Response polling).
+4. Replace `bus_read(ADDR_RES_*)` with Operand CIR read sequence for FMOVE to memory.
+5. Replace direct FPCR/FPSR reads with FMOVE control register dialog (or keep direct if FPCR/FPSR remain readable).
+
+Note: FPCR/FPSR/FPIAR are now accessed through the CIR dialog (FMOVEM.CR). Consider whether to keep them as directly addressable registers during Phase 1 for easier migration, or convert them now. Decision: Keep direct FPCR/FPSR/FPIAR access as additional CIR addresses temporarily (addresses not used by the standard CIR map) for testbench convenience, and remove in Phase 5.
+
+**This is the largest task. Break it into sub-commits per testbench file.**
+
+Run full test suite after each file: `powershell -ExecutionPolicy Bypass -File scripts/run_tests.ps1`
+
+---
+
+## Phase 2: Conditional Dialog Paths
+
+### Task 9: Implement cpScc dialog (FScc)
+
+**Files:**
+- Modify: `src/mc68881_top.vhd`
+- Modify: `tb/tb_mc68881_cir_dialog.vhd`
+
+**Step 1: Fill in CIR_COND_EVAL state for cpScc**
+
+When `cir_instr_type = CIR_TYPE_CPCOND` and command word indicates FScc:
+1. Extract condition selector from Condition CIR (written via CIR_ADDR_CONDITION).
+2. Evaluate condition using existing `eval_fcc_condition(cir_condition_reg, fpsr_cc_bits)`.
+3. Check BSUN via `is_signaling_fcc_condition`.
+4. Set result byte (0xFF true, 0x00 false) — host reads via Operand CIR.
+5. If BSUN and FPCR BSUN enabled: transition to CIR_EXCEPT_POST.
+6. Otherwise: transition to CIR_IDLE with Null response.
+
+Reuse the existing conditional evaluation logic from lines 2561-2572 of the current `alu_control_proc`.
+
+**Step 2: Add FScc test cases**
+
+In `tb/tb_mc68881_cir_dialog.vhd`:
+- FScc with EQ condition, FPSR Z=1 → result = $FF
+- FScc with EQ condition, FPSR Z=0 → result = $00
+- FScc with signaling condition + NAN → BSUN exception
+
+**Step 3: Run tests and commit**
+
+---
+
+### Task 10: Implement cpBcc dialog (FBcc)
+
+**Files:**
+- Modify: `src/mc68881_top.vhd`
+- Modify: `tb/tb_mc68881_cir_dialog.vhd`
+
+FBcc evaluates condition. If true: response = Take Post-Instruction Exception (the M68020 takes this to mean "branch taken" — the CPU adds the displacement to PC). If false: response = Null (fall through).
+
+If BSUN: Take Post-Instruction Exception with BSUN vector.
+
+**Step 1: Add FBcc handling in CIR_COND_EVAL**
+
+Distinguish cpBcc from cpScc using `cir_instr_type` (CIR_TYPE_CPBCC_W or CIR_TYPE_CPBCC_L vs CIR_TYPE_CPCOND).
+
+**Step 2: Add FBcc test cases**
+
+- FBcc.W with condition true → Post-Instruction Exception (branch taken)
+- FBcc.W with condition false → Null
+- FBcc.L variant
+
+**Step 3: Run tests and commit**
+
+---
+
+### Task 11: Implement cpDBcc and cpTRAPcc dialogs
+
+**Files:**
+- Modify: `src/mc68881_top.vhd`
+- Modify: `tb/tb_mc68881_cir_dialog.vhd`
+
+**FDBcc**: Condition true → Null (skip). Condition false → decrement counter (host provides counter via Operand CIR), if counter != -1 → response encodes "branch taken", else → Null (expired).
+
+**FTRAPcc**: Condition true → Take Post-Instruction Exception (trap). Condition false → Null.
+
+These map closely to the existing logic at lines 2587-2629.
+
+**Step 1: Add FDBcc and FTRAPcc handling**
+
+FDBcc needs the host to write the counter value to the Operand CIR before the condition evaluation completes. The dialog flow:
+1. Host writes OpWord (type = CIR_TYPE_CPCOND with FDBcc sub-encoding)
+2. FPU requests operand transfer (counter word)
+3. Host writes counter to Operand CIR
+4. FPU evaluates condition, decrements if needed
+5. Response carries updated counter and branch decision
+
+FTRAPcc is simpler — just condition eval → trap or null.
+
+**Step 2: Add test cases for FDBcc loop and FTRAPcc**
+
+**Step 3: Run tests and commit**
+
+---
+
+## Phase 3: FSAVE/FRESTORE
+
+### Task 12: Implement Null and Idle FSAVE
+
+**Files:**
+- Modify: `src/mc68881_top.vhd`
+- Modify: `tb/tb_mc68881_cir_dialog.vhd`
+
+**Step 1: Add frame type determination**
+
+When the dialog FSM enters CIR_SAVE_FORMAT:
+- If FPU has never been initialized (no operation executed since reset): frame type = Null ($0000).
+- If FPU is idle (no operation in progress): frame type = Idle ($0018).
+- If FPU is busy (ALU/trig/div active): frame type = Busy ($00B4).
+
+Store determined format word in `frame_format_word_reg`.
+
+**Step 2: Implement Idle frame serialization**
+
+For Idle frame (6 longwords), the CIR_SAVE_FRAME state reads from:
+- Word 0: Frame version tag (constant) + internal flags
+- Word 1: `fpu_op_t'pos(last_op_sel_reg)` + op class encoding
+- Word 2: Exception event registers packed
+- Word 3: Microsequencer state
+- Word 4: CIR dialog flags
+- Word 5: Reserved (zero)
+
+Each host read of CIR_ADDR_OPERAND returns the next word and increments `cir_xfer_word_idx`. When all words transferred, transition to CIR_IDLE.
+
+**Step 3: Add FSAVE tests**
+
+- FSAVE after reset → Null frame ($0000), 0 data words
+- FSAVE after FADD completes → Idle frame ($0018), 6 data words
+
+**Step 4: Run tests and commit**
+
+---
+
+### Task 13: Implement Null and Idle FRESTORE
+
+**Files:**
+- Modify: `src/mc68881_top.vhd`
+- Modify: `tb/tb_mc68881_cir_dialog.vhd`
+
+**Step 1: Add FRESTORE format word validation**
+
+When host writes format word to CIR_ADDR_RESTORE:
+- $0000 (Null): Reset FPU to power-on state. No frame data. Respond Null.
+- $0018 (Idle): Expect 6 longwords of frame data via Operand CIR.
+- $00B4 (Busy): Expect 45 longwords (Task 15).
+- Anything else: Respond Pre-Instruction Exception (invalid format).
+
+**Step 2: Implement Idle frame deserialization**
+
+CIR_RESTORE_FRAME receives 6 longwords via Operand CIR writes, unpacking into the same internal signals that FSAVE serialized. After the last word, commit restored state.
+
+**Step 3: Add FRESTORE tests**
+
+- FRESTORE with Null format → FPU reset
+- FRESTORE with Idle frame → internal state restored
+- FRESTORE with invalid format word → Pre-Instruction Exception
+- Round-trip: FSAVE(idle) → FRESTORE(idle) → verify state matches
+
+**Step 4: Run tests and commit**
+
+---
+
+### Task 14: Add save/restore ports to sub-units
+
+**Files:**
+- Modify: `src/mc68881_trig_unit.vhd`
+- Modify: `src/mc68881_divrem_unit.vhd`
+- Modify: `src/mc68881_modrem_post_unit.vhd`
+- Modify: `src/mc68881_packed_decimal_unit.vhd`
+- Modify: `src/mc68881_alu.vhd`
+- Modify: `src/mc68881_top.vhd` (port map updates)
+
+Add the save/restore port interface to each computation unit:
+
+```vhdl
+  -- Save/restore interface for FSAVE/FRESTORE Busy frame.
+  save_req     : in  std_logic;
+  save_data    : out std_logic_vector(31 downto 0);
+  save_addr    : in  natural range 0 to UNIT_SAVE_WORDS-1;
+  save_busy    : out std_logic;
+  restore_req  : in  std_logic;
+  restore_data : in  std_logic_vector(31 downto 0);
+  restore_addr : in  natural range 0 to UNIT_SAVE_WORDS-1;
+  restore_wr   : in  std_logic;
+```
+
+Each unit implements save/restore by:
+- **Save**: On `save_req`, copy FSM state + working registers into shadow registers. `save_data` muxes shadow registers by `save_addr`.
+- **Restore**: On `restore_wr`, write `restore_data` into shadow register at `restore_addr`. On `restore_req`, commit shadow registers to working state.
+
+Word allocation per unit:
+- Trig unit: 9 words (FSM state, tmp_reg, x_reg, a_reg, poly index, iteration, quadrant, sub-unit state x2)
+- Divrem unit: 6 words (FSM state, iteration, mantissa x2, partial quotient, exponent)
+- Modrem post: 3 words (continuation state, working registers)
+- Packed decimal: 3 words (arith state, digit index, accumulator)
+- ALU: 5 words (simple_hold, shared FP unit pipeline state x4)
+
+Total sub-unit words: 26. Plus 6 idle frame + 2 ALU control + 4 operands + 7 padding = 45 words = 180 bytes.
+
+**Do each unit as a separate sub-commit. Verify GHDL compile after each.**
+
+---
+
+### Task 15: Implement Busy FSAVE/FRESTORE
+
+**Files:**
+- Modify: `src/mc68881_top.vhd`
+- Modify: `tb/tb_mc68881_cir_dialog.vhd`
+
+**Step 1: Extend FSAVE serializer for Busy frame**
+
+When frame type = Busy:
+- Words 0-5: Same as Idle frame
+- Words 6-7: op_sel_reg encoding, operand staging metadata
+- Words 8-11: operand_reg(0) and operand_reg(1) packed as 80-bit → 3 words each (but only 2.5 words each, pack into 2 words with upper bits)
+- Words 12-20: Trig unit save_data[0..8]
+- Words 21-26: Divrem unit save_data[0..5]
+- Words 27-29: Modrem post save_data[0..2]
+- Words 30-32: Packed decimal save_data[0..2]
+- Words 33-37: ALU save_data[0..4]
+- Words 38-44: Zero padding
+
+The top-level serializer steps through word addresses, routing to the appropriate sub-unit's `save_data` output based on address range.
+
+**Step 2: Extend FRESTORE deserializer for Busy frame**
+
+Inverse: route incoming words to sub-unit `restore_data`/`restore_wr` based on address, then pulse `restore_req` on all units after the last word.
+
+**Step 3: Add Busy frame test**
+
+- Start a long-running operation (e.g. FSIN)
+- While busy: issue FSAVE → get Busy format word ($00B4)
+- Read 45 longwords
+- Issue FRESTORE with the saved frame
+- Poll until operation completes
+- Verify result matches expected FSIN output
+
+**Step 4: Run tests and commit**
+
+---
+
+## Phase 4: Exception Paths
+
+### Task 16: Implement pre-instruction exception dialog
+
+**Files:**
+- Modify: `src/mc68881_top.vhd`
+- Modify: `tb/tb_mc68881_cir_dialog.vhd`
+
+**Step 1: Add pre-instruction exception detection**
+
+In CIR_DECODE: if opcode is unrecognized (cir_decode_cpgen_opcode returns FPU_OP_NOP for non-NOP command), transition to CIR_EXCEPT_PRE with F-line vector (11).
+
+**Step 2: Add Control CIR acknowledge handling**
+
+When host writes to CIR_ADDR_CONTROL with acknowledge bit: clear exception state, return to CIR_IDLE.
+
+**Step 3: Add tests**
+
+- Write invalid command word opcode → Pre-Instruction Exception response
+- Write Control CIR ack → returns to Idle
+
+**Step 4: Run tests and commit**
+
+---
+
+### Task 17: Implement mid-instruction exception dialog
+
+**Files:**
+- Modify: `src/mc68881_top.vhd`
+- Modify: `tb/tb_mc68881_cir_dialog.vhd`
+
+**Step 1: Check FPCR enables after ALU completion**
+
+In CIR_EXECUTE, when `valid = '1'`: before transitioning to CIR_IDLE, check if any exception bits in FPSR EXC byte have their corresponding FPCR enable bits set. If so, transition to CIR_EXCEPT_MID instead of CIR_IDLE.
+
+The existing `exc_status_proc` already computes exception flags. Add a combinational signal:
+```vhdl
+cir_mid_exception <= '1' when (fpsr_exc_byte AND fpcr_enable_byte) /= x"00" else '0';
+```
+
+**Step 2: Add tests**
+
+- FDIV by zero with FPCR DZ enabled → Mid-Instruction Exception
+- FADD overflow with FPCR OVFL enabled → Mid-Instruction Exception
+- Same operations with FPCR enables clear → Null (no exception)
+
+**Step 3: Run tests and commit**
+
+---
+
+### Task 18: Implement post-instruction exception dialog
+
+**Files:**
+- Modify: `src/mc68881_top.vhd`
+- Modify: `tb/tb_mc68881_cir_dialog.vhd`
+
+Post-instruction exceptions are primarily for conditional operations (BSUN, FTRAPcc). The result is committed but the host should take the exception.
+
+**Step 1: Wire BSUN and trap paths to CIR_EXCEPT_POST**
+
+In the conditional evaluation path (CIR_COND_EVAL), when BSUN is detected and FPCR BSUN enable is set, or when FTRAPcc condition is true: transition to CIR_EXCEPT_POST with appropriate vector.
+
+**Step 2: Add tests**
+
+- FBcc with signaling condition + NAN + BSUN enabled → Post-Instruction Exception
+- FTRAPcc with condition true → Post-Instruction Exception
+
+**Step 3: Run tests and commit**
+
+---
+
+## Phase 5: Timing, Integration, and Test Closure
+
+### Task 19: FPCR/FPSR/FPIAR access via FMOVEM dialog
+
+**Files:**
+- Modify: `src/mc68881_top.vhd`
+- Modify: `tb/tb_mc68881_cir_dialog.vhd`
+
+Implement FMOVEM for control registers (FPCR/FPSR/FPIAR) through the CIR dialog protocol. The command word register-list field identifies which control registers to transfer. The Register Select CIR ($14) communicates the register list.
+
+**Step 1: Implement FMOVEM.CR to/from memory**
+
+**Step 2: Remove temporary direct FPCR/FPSR/FPIAR access (if added in Task 8)**
+
+**Step 3: Update all testbenches to use FMOVEM.CR dialog for control register access**
+
+**Step 4: Run full test suite and commit**
+
+---
+
+### Task 20: FMOVEM.X register list transfer
+
+**Files:**
+- Modify: `src/mc68881_top.vhd`
+- Modify: `tb/tb_mc68881_cir_dialog.vhd`
+
+Implement FMOVEM for FP data registers (FP0-FP7). The register list mask determines which registers transfer. Each FP register is 3 longwords (80-bit extended + padding).
+
+**Step 1: Implement FMOVEM.X to/from memory via Operand CIR**
+
+**Step 2: Add test for FMOVEM with multiple registers**
+
+**Step 3: Run tests and commit**
+
+---
+
+### Task 21: Remove legacy testbench compatibility shims
+
+**Files:**
+- Modify: All testbench files
+
+Remove any temporary direct-access addresses or legacy compatibility code added in Task 8. All host communication now goes through the CIR dialog protocol exclusively.
+
+Run full test suite: `powershell -ExecutionPolicy Bypass -File scripts/run_tests.ps1`
+
+---
+
+### Task 22: Update S7 checklist and run synthesis
+
+**Files:**
+- Modify: `docs/fpu-progress-checklist.md`
+
+**Step 1: Mark S7 checklist items as done**
+
+Update all S7-* items that are now implemented to `[x]`.
+
+**Step 2: Run GHDL full regression**
+
+Run: `powershell -ExecutionPolicy Bypass -File scripts/run_tests.ps1`
+Expected: All tests pass.
+
+**Step 3: Run Vivado synthesis for LUT/timing check**
+
+Run non-incremental synthesis to verify the CIR FSM addition hasn't blown the LUT budget or broken timing.
+
+**Step 4: Commit and update implementation snapshot**
+
+---
+
+## Task Dependency Summary
+
+```
+Phase 1: Task 1 → Task 2 → Task 3 → Task 4 → Task 5 → Task 6 → Task 7 → Task 8
+Phase 2: Task 9 → Task 10 → Task 11
+Phase 3: Task 12 → Task 13 → Task 14 → Task 15
+Phase 4: Task 16 → Task 17 → Task 18
+Phase 5: Task 19 → Task 20 → Task 21 → Task 22
+```
+
+Phases 2, 3, 4 can proceed in any order after Phase 1 completes.
+Phase 5 requires all prior phases.

--- a/scripts/run_tests.ps1
+++ b/scripts/run_tests.ps1
@@ -25,7 +25,7 @@ function Invoke-Ghdl {
   }
 }
 
-Invoke-Ghdl @('-a', '--std=08', 'src/mc68881_pkg.vhd', 'src/mc68881_fp80_mul_unit.vhd', 'src/mc68881_fp80_addsub_unit.vhd', 'src/mc68881_modrem_post_unit.vhd', 'src/mc68881_divrem_unit.vhd', 'src/mc68881_trig_unit.vhd', 'src/mc68881_sgl_ops_unit.vhd', 'src/mc68881_alu.vhd', 'src/mc68881_packed_decimal_unit.vhd', 'src/mc68881_top.vhd', 'tb/mc68881_golden_vectors_pkg.vhd', 'tb/mc68881_microseq_tb.vhd', 'tb/tb_mc68881_alu.vhd', 'tb/tb_mc68881_top.vhd', 'tb/tb_mc68881_fpcr_fpsr.vhd', 'tb/tb_mc68881_ea_cycles.vhd', 'tb/tb_mc68881_cycle_counts.vhd', 'tb/tb_mc68881_cycle_counts_top.vhd', 'tb/tb_mc68881_fmove_fmovem.vhd', 'tb/tb_mc68881_fmovecr.vhd', 'tb/tb_mc68881_ac_timing.vhd', 'tb/tb_mc68881_op_class_dispatch.vhd', 'tb/tb_mc68881_known_defects.vhd')
+Invoke-Ghdl @('-a', '--std=08', 'src/mc68881_pkg.vhd', 'src/mc68881_fp80_mul_unit.vhd', 'src/mc68881_fp80_addsub_unit.vhd', 'src/mc68881_modrem_post_unit.vhd', 'src/mc68881_divrem_unit.vhd', 'src/mc68881_trig_unit.vhd', 'src/mc68881_sgl_ops_unit.vhd', 'src/mc68881_alu.vhd', 'src/mc68881_packed_decimal_unit.vhd', 'src/mc68881_top.vhd', 'tb/mc68881_golden_vectors_pkg.vhd', 'tb/mc68881_microseq_tb.vhd', 'tb/tb_mc68881_alu.vhd', 'tb/tb_mc68881_top.vhd', 'tb/tb_mc68881_fpcr_fpsr.vhd', 'tb/tb_mc68881_ea_cycles.vhd', 'tb/tb_mc68881_cycle_counts.vhd', 'tb/tb_mc68881_cycle_counts_top.vhd', 'tb/tb_mc68881_fmove_fmovem.vhd', 'tb/tb_mc68881_fmovecr.vhd', 'tb/tb_mc68881_ac_timing.vhd', 'tb/tb_mc68881_op_class_dispatch.vhd', 'tb/tb_mc68881_known_defects.vhd', 'tb/tb_mc68881_cir_dialog.vhd')
 Invoke-Ghdl @('-e', '--std=08', 'mc68881_microseq_tb')
 Invoke-Ghdl @('-r', '--std=08', 'mc68881_microseq_tb', '--assert-level=error')
 Invoke-Ghdl @('-e', '--std=08', 'tb_mc68881_alu')
@@ -50,5 +50,7 @@ Invoke-Ghdl @('-e', '--std=08', 'tb_mc68881_op_class_dispatch')
 Invoke-Ghdl @('-r', '--std=08', 'tb_mc68881_op_class_dispatch', '--assert-level=error')
 Invoke-Ghdl @('-e', '--std=08', 'tb_mc68881_known_defects')
 Invoke-Ghdl @('-r', '--std=08', 'tb_mc68881_known_defects', '--assert-level=error')
+Invoke-Ghdl @('-e', '--std=08', 'tb_mc68881_cir_dialog')
+Invoke-Ghdl @('-r', '--std=08', 'tb_mc68881_cir_dialog', '--assert-level=error')
 
 Write-Host 'GHDL tests passed.'

--- a/src/mc68881_alu.vhd
+++ b/src/mc68881_alu.vhd
@@ -87,38 +87,6 @@ architecture rtl of mc68881_alu is
            op = FPU_OP_TST;
   end function;
 
-  -- All simple ops use registered dispatch to break combinational path
-  -- from operand_reg through FP logic to result_reg.
-  function compute_simple_result(
-    op : fpu_op_t;
-    a : fp80_t;
-    b : fp80_t;
-    rm : fp_round_mode_t;
-    rp : fp_round_prec_t
-  ) return fp80_t is
-  begin
-    case op is
-      when FPU_OP_INT =>
-        return fint_fp80(a, rm);
-      when FPU_OP_CMP =>
-        return fp80_from_int(compare_fp80(a, b));
-      when FPU_OP_ABS =>
-        return abs_fp80(a);
-      when FPU_OP_NEG =>
-        return neg_fp80(a);
-      when FPU_OP_INTRZ =>
-        return fintrz_fp80(a);
-      when FPU_OP_GETEXP =>
-        return fgetexp_fp80(a);
-      when FPU_OP_GETMAN =>
-        return fgetman_fp80(a);
-      when FPU_OP_TST =>
-        return ftst_fp80(a);
-      when others =>
-        return (others => '0');
-    end case;
-  end function;
-
   signal result_reg : fp80_t := (others => '0');
   signal busy_reg : std_logic := '0';
 
@@ -556,7 +524,17 @@ begin
             if simple_hold_count_reg > 0 then
               simple_hold_count_reg <= simple_hold_count_reg - 1;
             else
-              result_reg <= compute_simple_result(simple_op_reg, simple_a_reg, simple_b_reg, simple_rm_reg, simple_rp_reg);
+              case simple_op_reg is
+                when FPU_OP_INT    => result_reg <= fint_fp80(simple_a_reg, simple_rm_reg);
+                when FPU_OP_CMP    => result_reg <= fp80_from_int(compare_fp80(simple_a_reg, simple_b_reg));
+                when FPU_OP_ABS    => result_reg <= abs_fp80(simple_a_reg);
+                when FPU_OP_NEG    => result_reg <= neg_fp80(simple_a_reg);
+                when FPU_OP_INTRZ  => result_reg <= fintrz_fp80(simple_a_reg);
+                when FPU_OP_GETEXP => result_reg <= fgetexp_fp80(simple_a_reg);
+                when FPU_OP_GETMAN => result_reg <= fgetman_fp80(simple_a_reg);
+                when FPU_OP_TST    => result_reg <= ftst_fp80(simple_a_reg);
+                when others        => result_reg <= (others => '0');
+              end case;
               simple_compute_pending_reg <= '0';
             end if;
           end if;

--- a/src/mc68881_packed_decimal_unit.vhd
+++ b/src/mc68881_packed_decimal_unit.vhd
@@ -39,8 +39,6 @@ end entity mc68881_packed_decimal_unit;
 architecture rtl of mc68881_packed_decimal_unit is
   subtype packed96_t is std_logic_vector(95 downto 0);
   type packed_digits_t is array (0 to 16) of natural range 0 to 9;
-  type natural12_t is array (0 to 11) of natural;
-
   type packed_state_t is (
     ST_IDLE,
     ST_SCALE_CHUNK,
@@ -50,7 +48,9 @@ architecture rtl of mc68881_packed_decimal_unit is
     ST_ENC_DIGIT_SUB,
     ST_ENC_DIGIT_SCALE,
     ST_ENC_POSTROUND,
+    ST_ENC_POSTROUND_PROP,
     ST_ENC_KROUND,
+    ST_ENC_KROUND_PROP,
     ST_ENC_PACK,
     ST_DEC_ACCUM_U64,
     ST_DEC_TO_FP,
@@ -71,10 +71,6 @@ architecture rtl of mc68881_packed_decimal_unit is
     AR_ST_IDLE,
     AR_ST_WAIT,
     AR_ST_COMMIT
-  );
-
-  constant POW2_SMALL : natural12_t := (
-    1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048
   );
 
   constant FP80_ONE : fp80_t := x"3FFF8000000000000000";
@@ -125,10 +121,14 @@ architecture rtl of mc68881_packed_decimal_unit is
   signal inexact_reg : std_logic := '0';
 
   signal scale_abs_exp_reg : natural range 0 to 12000 := 0;
+  signal scale_abs_exp_slv : std_logic_vector(11 downto 0);
   signal scale_use_neg_reg : std_logic := '0';
   signal scale_bit_idx_reg : natural range 0 to 12 := 0;
 
   signal mant_u64_reg : unsigned(63 downto 0) := (others => '0');
+
+  signal kround_carry_reg : std_logic := '0';
+  signal kround_idx_reg : natural range 0 to 16 := 0;
 
   signal rsp_valid_reg : std_logic := '0';
   signal rsp_word_reg : packed96_t := (others => '0');
@@ -216,6 +216,9 @@ architecture rtl of mc68881_packed_decimal_unit is
     end case;
   end function;
 begin
+  -- Convert scale_abs_exp_reg to SLV for bit-indexing (replaces divider chain)
+  scale_abs_exp_slv <= std_logic_vector(to_unsigned(scale_abs_exp_reg, 12));
+
   -- Drive shared FP unit ports
   fp_mul_start <= packed_mul_start_reg;
   fp_mul_a_out <= arith_mul_a_reg;
@@ -251,7 +254,6 @@ begin
     variable round_digit : natural := 0;
     variable has_trailing : boolean := false;
     variable scale_exp_local : integer := 0;
-    variable bit_value : natural := 0;
     variable tune_done : boolean := false;
     variable all_zero : boolean := true;
     variable exp0_i : integer := 0;
@@ -291,6 +293,8 @@ begin
       scale_use_neg_reg <= '0';
       scale_bit_idx_reg <= 0;
       mant_u64_reg <= (others => '0');
+      kround_carry_reg <= '0';
+      kround_idx_reg <= 0;
       rsp_valid_reg <= '0';
       rsp_word_reg <= (others => '0');
       rsp_fp_reg <= (others => '0');
@@ -398,47 +402,29 @@ begin
             end if;
 
           when AR_ENC_POSTROUND =>
-            digits_v := digits_reg;
             digit_int := arith_int_res_reg;
             if digit_int >= 5 then
-              carry := 1;
-              for idx in 16 downto 0 loop
-                if carry = 0 then
-                  exit;
-                end if;
-                if digits_v(idx) = 9 then
-                  digits_v(idx) := 0;
-                else
-                  digits_v(idx) := digits_v(idx) + 1;
-                  carry := 0;
-                end if;
-              end loop;
-              if carry = 1 then
-                for idx in 16 downto 1 loop
-                  digits_v(idx) := digits_v(idx-1);
-                end loop;
-                digits_v(0) := 1;
-                exp10_reg <= exp10_reg + 1;
-              end if;
-            end if;
-
-            digits_reg <= digits_v;
-
-            k_clamped := clamp_integer(req_k_reg, -64, 17);
-            if k_clamped > 0 then
-              keep_digits := k_clamped;
+              -- Start serialized carry propagation from digit 16 down to 0
+              kround_carry_reg <= '1';
+              kround_idx_reg <= 16;
+              state_reg <= ST_ENC_POSTROUND_PROP;
             else
-              keep_digits := exp10_reg + 1 + (-k_clamped);
-            end if;
+              k_clamped := clamp_integer(req_k_reg, -64, 17);
+              if k_clamped > 0 then
+                keep_digits := k_clamped;
+              else
+                keep_digits := exp10_reg + 1 + (-k_clamped);
+              end if;
 
-            if keep_digits < 1 then
-              keep_digits := 1;
-            elsif keep_digits > 17 then
-              keep_digits := 17;
-            end if;
+              if keep_digits < 1 then
+                keep_digits := 1;
+              elsif keep_digits > 17 then
+                keep_digits := 17;
+              end if;
 
-            keep_digits_reg <= keep_digits;
-            state_reg <= ST_ENC_KROUND;
+              keep_digits_reg <= keep_digits;
+              state_reg <= ST_ENC_KROUND;
+            end if;
 
           when others =>
             null;
@@ -628,14 +614,12 @@ begin
           if scale_bit_idx_reg = 12 then
             state_reg <= scale_return_state_reg;
           else
-            bit_value := (scale_abs_exp_reg / POW2_SMALL(scale_bit_idx_reg)) mod 2;
-            if bit_value = 1 then
+            if scale_abs_exp_slv(scale_bit_idx_reg) = '1' then
               do_mul := true;
               mul_a_v := work_fp_reg;
               mul_b_v := pow10_by_pow2(scale_bit_idx_reg, scale_use_neg_reg = '1');
               arith_commit := AR_SCALE_BITS;
-            end if;
-            if bit_value = 0 then
+            else
               scale_bit_idx_reg <= scale_bit_idx_reg + 1;
             end if;
           end if;
@@ -687,8 +671,6 @@ begin
           arith_commit := AR_ENC_DIGIT_SCALE;
 
         when ST_ENC_POSTROUND =>
-          digits_v := digits_reg;
-
           if not fp80_is_zero(work_fp_reg) then
             inexact_reg <= '1';
           end if;
@@ -696,62 +678,124 @@ begin
           do_int := true;
           int_arg_v := work_fp_reg;
           arith_commit := AR_ENC_POSTROUND;
+
+        when ST_ENC_POSTROUND_PROP =>
+          -- Per-digit carry propagation (reuses kround registers)
+          if digits_reg(kround_idx_reg) = 9 then
+            digits_reg(kround_idx_reg) <= 0;
+            if kround_idx_reg = 0 then
+              -- Carry out: all digits were 9, now all 0.
+              digits_reg(0) <= 1;
+              exp10_reg <= exp10_reg + 1;
+              -- Compute keep_digits and transition to KROUND
+              -- Note: exp10_reg increment is deferred (signal), so use old value
+              -- to match original behavior where keep_digits was computed
+              -- after exp10 signal assignment (also deferred).
+              k_clamped := clamp_integer(req_k_reg, -64, 17);
+              if k_clamped > 0 then
+                keep_digits := k_clamped;
+              else
+                keep_digits := exp10_reg + 1 + (-k_clamped);
+              end if;
+              if keep_digits < 1 then
+                keep_digits := 1;
+              elsif keep_digits > 17 then
+                keep_digits := 17;
+              end if;
+              keep_digits_reg <= keep_digits;
+              state_reg <= ST_ENC_KROUND;
+            else
+              kround_idx_reg <= kround_idx_reg - 1;
+            end if;
+          else
+            digits_reg(kround_idx_reg) <= digits_reg(kround_idx_reg) + 1;
+            -- Carry absorbed, compute keep_digits and transition to KROUND
+            k_clamped := clamp_integer(req_k_reg, -64, 17);
+            if k_clamped > 0 then
+              keep_digits := k_clamped;
+            else
+              keep_digits := exp10_reg + 1 + (-k_clamped);
+            end if;
+            if keep_digits < 1 then
+              keep_digits := 1;
+            elsif keep_digits > 17 then
+              keep_digits := 17;
+            end if;
+            keep_digits_reg <= keep_digits;
+            state_reg <= ST_ENC_KROUND;
+          end if;
+
         when ST_ENC_KROUND =>
-          digits_v := digits_reg;
           keep_digits := keep_digits_reg;
 
           if keep_digits < 17 then
-            round_digit := digits_v(keep_digits);
+            round_digit := digits_reg(keep_digits);
             carry := 0;
 
+            -- Combinational OR-reduce: check for trailing nonzero digits
             if round_digit > 5 then
               carry := 1;
             elsif round_digit = 5 then
               has_trailing := false;
               for idx in 0 to 16 loop
-                if idx > keep_digits and digits_v(idx) /= 0 then
+                if idx > keep_digits and digits_reg(idx) /= 0 then
                   has_trailing := true;
-                  exit;
                 end if;
               end loop;
-              if has_trailing or (digits_v(keep_digits-1) mod 2 = 1) then
+              if has_trailing or (digits_reg(keep_digits-1) mod 2 = 1) then
                 carry := 1;
               end if;
             end if;
 
+            -- Combinational OR-reduce: set inexact if any discarded digit nonzero
             for idx in 0 to 16 loop
-              if idx >= keep_digits and digits_v(idx) /= 0 then
+              if idx >= keep_digits and digits_reg(idx) /= 0 then
                 inexact_reg <= '1';
-                exit;
               end if;
             end loop;
 
-            for idx in 16 downto 0 loop
-              if idx < keep_digits then
-                if carry = 1 then
-                  if digits_v(idx) = 9 then
-                    digits_v(idx) := 0;
-                  else
-                    digits_v(idx) := digits_v(idx) + 1;
-                    carry := 0;
-                  end if;
-                end if;
-              else
-                digits_v(idx) := 0;
+            -- Zero out discarded digits
+            for idx in 0 to 16 loop
+              if idx >= keep_digits then
+                digits_reg(idx) <= 0;
               end if;
             end loop;
 
             if carry = 1 then
-              for idx in 16 downto 1 loop
-                digits_v(idx) := digits_v(idx-1);
-              end loop;
-              digits_v(0) := 1;
-              exp10_reg <= exp10_reg + 1;
+              -- Start serialized carry propagation from keep_digits-1 down to 0
+              kround_carry_reg <= '1';
+              kround_idx_reg <= keep_digits - 1;
+              state_reg <= ST_ENC_KROUND_PROP;
+            else
+              state_reg <= ST_ENC_PACK;
             end if;
+          else
+            state_reg <= ST_ENC_PACK;
           end if;
 
-          digits_reg <= digits_v;
-          state_reg <= ST_ENC_PACK;
+        when ST_ENC_KROUND_PROP =>
+          -- Per-digit carry propagation: one digit per cycle
+          if kround_carry_reg = '1' then
+            if digits_reg(kround_idx_reg) = 9 then
+              digits_reg(kround_idx_reg) <= 0;
+              if kround_idx_reg = 0 then
+                -- Carry out: all digits were 9, now all 0.
+                -- Result is 1.000...0 with exponent incremented.
+                digits_reg(0) <= 1;
+                exp10_reg <= exp10_reg + 1;
+                kround_carry_reg <= '0';
+                state_reg <= ST_ENC_PACK;
+              else
+                kround_idx_reg <= kround_idx_reg - 1;
+              end if;
+            else
+              digits_reg(kround_idx_reg) <= digits_reg(kround_idx_reg) + 1;
+              kround_carry_reg <= '0';
+              state_reg <= ST_ENC_PACK;
+            end if;
+          else
+            state_reg <= ST_ENC_PACK;
+          end if;
 
         when ST_ENC_PACK =>
           packed_word_v := (others => '0');

--- a/src/mc68881_pkg.vhd
+++ b/src/mc68881_pkg.vhd
@@ -283,6 +283,86 @@ package mc68881_pkg is
   function fscale_fp80(a : fp80_t; b : fp80_t) return fp80_t;
   function sgldiv_fp80(a : fp80_t; b : fp80_t; round_mode : fp_round_mode_t) return fp80_t;
   function sglmul_fp80(a : fp80_t; b : fp80_t; round_mode : fp_round_mode_t) return fp80_t;
+
+  -- ===== Section 7 Coprocessor Interface Types =====
+
+  -- CIR register addresses (5-bit, maps to A[4:1] of CPU-space address).
+  constant CIR_ADDR_RESPONSE     : unsigned(4 downto 0) := "00000";  -- $00
+  constant CIR_ADDR_CONTROL      : unsigned(4 downto 0) := "00001";  -- $02
+  constant CIR_ADDR_SAVE         : unsigned(4 downto 0) := "00010";  -- $04
+  constant CIR_ADDR_RESTORE      : unsigned(4 downto 0) := "00011";  -- $06
+  constant CIR_ADDR_OPWORD       : unsigned(4 downto 0) := "00100";  -- $08
+  constant CIR_ADDR_COMMAND      : unsigned(4 downto 0) := "00101";  -- $0A
+  constant CIR_ADDR_CONDITION    : unsigned(4 downto 0) := "00111";  -- $0E
+  constant CIR_ADDR_OPERAND      : unsigned(4 downto 0) := "01000";  -- $10
+  constant CIR_ADDR_REGSELECT    : unsigned(4 downto 0) := "01010";  -- $14
+  constant CIR_ADDR_INSTADDR     : unsigned(4 downto 0) := "01100";  -- $18
+  constant CIR_ADDR_OPADDR       : unsigned(4 downto 0) := "01110";  -- $1C
+
+  -- Dialog FSM states.
+  type cir_dialog_state_t is (
+    CIR_IDLE,
+    CIR_DECODE,
+    CIR_XFER_SRC,
+    CIR_XFER_SRC_WAIT,
+    CIR_EXECUTE,
+    CIR_XFER_DST,
+    CIR_XFER_DST_WAIT,
+    CIR_COND_EVAL,
+    CIR_EXCEPT_PRE,
+    CIR_EXCEPT_MID,
+    CIR_EXCEPT_POST,
+    CIR_SAVE_FORMAT,
+    CIR_SAVE_FRAME,
+    CIR_RESTORE_FORMAT,
+    CIR_RESTORE_FRAME
+  );
+
+  -- Response primitive categories (bits 15:13 of Response CIR).
+  constant CIR_RESP_BUSY         : std_logic_vector(2 downto 0) := "000";
+  constant CIR_RESP_NULL         : std_logic_vector(2 downto 0) := "001";
+  constant CIR_RESP_SUPERVISOR   : std_logic_vector(2 downto 0) := "010";
+  constant CIR_RESP_TRANSFER     : std_logic_vector(2 downto 0) := "011";
+  constant CIR_RESP_WRITEBACK    : std_logic_vector(2 downto 0) := "100";
+  constant CIR_RESP_EXCEPT_PRE   : std_logic_vector(2 downto 0) := "101";
+  constant CIR_RESP_EXCEPT_MID   : std_logic_vector(2 downto 0) := "110";
+  constant CIR_RESP_EXCEPT_POST  : std_logic_vector(2 downto 0) := "111";
+
+  -- Common response primitive words.
+  constant CIR_PRIM_BUSY         : std_logic_vector(15 downto 0) := x"0000";
+  constant CIR_PRIM_NULL         : std_logic_vector(15 downto 0) := x"2001";
+
+  -- Operation Word type field [8:6] — instruction family.
+  constant CIR_TYPE_CPGEN        : std_logic_vector(2 downto 0) := "000";
+  constant CIR_TYPE_CPCOND       : std_logic_vector(2 downto 0) := "001";
+  constant CIR_TYPE_CPBCC_W      : std_logic_vector(2 downto 0) := "010";
+  constant CIR_TYPE_CPBCC_L      : std_logic_vector(2 downto 0) := "011";
+  constant CIR_TYPE_CPSAVE       : std_logic_vector(2 downto 0) := "100";
+  constant CIR_TYPE_CPRESTORE    : std_logic_vector(2 downto 0) := "101";
+
+  -- Source format field [12:10] of cpGEN command word.
+  constant CIR_SRC_LONG          : std_logic_vector(2 downto 0) := "000";
+  constant CIR_SRC_SINGLE        : std_logic_vector(2 downto 0) := "001";
+  constant CIR_SRC_EXTENDED      : std_logic_vector(2 downto 0) := "010";
+  constant CIR_SRC_PACKED        : std_logic_vector(2 downto 0) := "011";
+  constant CIR_SRC_WORD          : std_logic_vector(2 downto 0) := "100";
+  constant CIR_SRC_DOUBLE        : std_logic_vector(2 downto 0) := "101";
+  constant CIR_SRC_BYTE          : std_logic_vector(2 downto 0) := "110";
+  constant CIR_SRC_FPN           : std_logic_vector(2 downto 0) := "111";
+
+  -- FSAVE frame format words.
+  constant CIR_FRAME_NULL_FW     : std_logic_vector(15 downto 0) := x"0000";
+  constant CIR_FRAME_IDLE_FW     : std_logic_vector(15 downto 0) := x"0018";
+  constant CIR_FRAME_BUSY_FW     : std_logic_vector(15 downto 0) := x"00B4";
+  constant CIR_FRAME_IDLE_WORDS  : natural := 6;   -- 24 bytes / 4
+  constant CIR_FRAME_BUSY_WORDS  : natural := 45;  -- 180 bytes / 4
+
+  -- Helper: number of 32-bit operand words for a given source format.
+  function cir_src_word_count(src_fmt : std_logic_vector(2 downto 0)) return natural;
+
+  -- Helper: decode command word bits [6:0] to fpu_op_t.
+  function cir_decode_cpgen_opcode(cmd_word : std_logic_vector(15 downto 0)) return fpu_op_t;
+
 end package mc68881_pkg;
 
 package body mc68881_pkg is
@@ -1129,6 +1209,39 @@ package body mc68881_pkg is
       return FPU_OP_NOP;
     end if;
 
+    return FPU_OP_NOP;
+  end function;
+
+  function cir_src_word_count(src_fmt : std_logic_vector(2 downto 0)) return natural is
+  begin
+    case src_fmt is
+      when CIR_SRC_LONG | CIR_SRC_SINGLE | CIR_SRC_WORD | CIR_SRC_BYTE =>
+        return 1;
+      when CIR_SRC_DOUBLE =>
+        return 2;
+      when CIR_SRC_EXTENDED | CIR_SRC_PACKED =>
+        return 3;
+      when CIR_SRC_FPN =>
+        return 0;
+      when others =>
+        return 0;
+    end case;
+  end function;
+
+  function cir_decode_cpgen_opcode(cmd_word : std_logic_vector(15 downto 0)) return fpu_op_t is
+    variable opcode_bits : std_logic_vector(6 downto 0);
+    variable key : op_key_t;
+  begin
+    opcode_bits := cmd_word(6 downto 0);
+    -- Build an op_key in OP_NS_CORE_V1 namespace and look up via descriptors.
+    key.namespace := OP_NS_CORE_V1;
+    key.opcode_id := '0' & opcode_bits;
+    for op in fpu_op_t loop
+      if OP_DESCRIPTORS(op).core_v1_decode_id_valid and
+         OP_DESCRIPTORS(op).core_v1_decode_id = key.opcode_id then
+        return op;
+      end if;
+    end loop;
     return FPU_OP_NOP;
   end function;
 

--- a/src/mc68881_top.vhd
+++ b/src/mc68881_top.vhd
@@ -190,6 +190,11 @@ architecture rtl of mc68881_top is
   signal cir_regselect_word    : std_logic_vector(15 downto 0) := (others => '0');
   signal cir_operand_addr_reg  : std_logic_vector(31 downto 0) := (others => '0');
 
+  -- CIR ALU launch handshake signals.
+  signal cir_launch_alu        : std_logic := '0';           -- One-cycle pulse from cir_dialog_proc
+  signal cir_decoded_op        : fpu_op_t := FPU_OP_NOP;     -- Combinational decode of command word
+  signal cir_arith_active_reg  : std_logic := '0';           -- Tracks CIR-launched arith op in alu_control_proc
+
   signal exc_event_valid_reg : std_logic := '0';
   signal exc_event_result_reg : fp80_t := (others => '0');
   signal exc_event_opa_reg : fp80_t := (others => '0');
@@ -1655,18 +1660,22 @@ begin
   op_sel_write_decoded <= decode_op_sel_word(d_in);
   op_class_write_decoded <= op_class(op_sel_write_decoded);
   conditional_prog_op_write <= '1' when is_conditional_prog_op(op_sel_write_decoded) else '0';
+  -- CIR: combinational decode of command word opcode bits [6:0] to fpu_op_t.
+  cir_decoded_op <= cir_decode_cpgen_opcode(cir_command_reg);
   -- One-cycle launch pulse on the rising edge of an OPSEL write when engines
   -- are idle.  The opsel_write_prev_reg guard ensures sustained bus_write
   -- levels do not re-fire the pulse on subsequent clocks.
   op_issue_pulse <= '1' when (
-    bus_write = '1' and
-    addr = ADDR_OPSEL and
-    opsel_write_prev_reg = '0' and
-    op_class_write_decoded /= OP_CLASS_NONE and
-    micro_active_reg = '0' and
-    frame_busy_reg = '0' and
-    busy = '0' and
-    not (conditional_prog_op_write = '1' and cir_response_pending_reg = '1')
+    (bus_write = '1' and
+     addr = ADDR_OPSEL and
+     opsel_write_prev_reg = '0' and
+     op_class_write_decoded /= OP_CLASS_NONE and
+     micro_active_reg = '0' and
+     frame_busy_reg = '0' and
+     busy = '0' and
+     not (conditional_prog_op_write = '1' and cir_response_pending_reg = '1'))
+    or
+    (cir_launch_alu = '1')
   ) else '0';
 
   alu_inst : entity work.mc68881_alu
@@ -1826,6 +1835,13 @@ begin
           when others =>
             null;
         end case;
+      end if;
+
+      -- CIR reg-to-reg launch: load op_sel and operands from register file.
+      if cir_launch_alu = '1' then
+        op_sel_reg <= cir_decoded_op;
+        operand_reg(0) <= fp_reg_file_reg(cir_dst_reg_idx);  -- Dest = operand A
+        operand_reg(1) <= fp_reg_file_reg(cir_src_reg_idx);  -- Source = operand B
       end if;
 
       if ctrl_move_write_req_reg = '1' then
@@ -2220,6 +2236,7 @@ begin
       exc_event_force_inexact_reg <= '0';
       exc_event_force_invalid_reg <= '0';
       exc_event_force_bsun_reg <= '0';
+      cir_arith_active_reg <= '0';
       sys_ctrl_save_req_reg <= '0';
       sys_ctrl_restore_req_reg <= '0';
       frame_op_waiting_reg <= '0';
@@ -2299,18 +2316,36 @@ begin
         result_ready_reg <= '0';
         result_ex_hi_reg <= (others => '0');
         aux_result_ex_hi_reg <= (others => '0');
-        last_op_sel_reg <= op_sel_write_decoded;
         fpiar_issue_snapshot_reg <= fpiar_reg;
         micro_active_reg <= '1';
-        total_cycles := op_cycle_count(
-          op_sel_write_decoded,
-          src_kind_reg,
-          ea_mode_reg,
-          cycle_case_reg,
-          mc68020_src_reg = '1',
-          mc68020_dst_reg = '1',
-          packed_dynamic_k_reg = '1'
-        );
+
+        if cir_launch_alu = '1' then
+          -- CIR reg-to-reg path: use decoded command word opcode.
+          last_op_sel_reg <= cir_decoded_op;
+          total_cycles := op_cycle_count(
+            cir_decoded_op,
+            FPU_SRC_FPM,
+            EA_MODE_DN_AN,
+            EA_CYCLE_BEST,
+            false,
+            false,
+            false
+          );
+          cir_arith_active_reg <= '1';
+        else
+          -- Legacy bus-write path: use d_in-decoded opcode.
+          last_op_sel_reg <= op_sel_write_decoded;
+          total_cycles := op_cycle_count(
+            op_sel_write_decoded,
+            src_kind_reg,
+            ea_mode_reg,
+            cycle_case_reg,
+            mc68020_src_reg = '1',
+            mc68020_dst_reg = '1',
+            packed_dynamic_k_reg = '1'
+          );
+        end if;
+
         micro_total_reg <= std_logic_vector(to_unsigned(total_cycles, 32));
         if total_cycles = 0 then
           micro_remaining_reg <= 0;
@@ -2319,6 +2354,10 @@ begin
         end if;
 
         -- Dispatch uses operation classes to keep execution paths scalable.
+        if cir_launch_alu = '1' then
+          -- CIR path always launches ALU for arithmetic operations.
+          op_start_reg <= '1';
+        else
         case op_class_write_decoded is
           when OP_CLASS_ARITH =>
             op_start_reg <= '1';
@@ -2692,12 +2731,23 @@ begin
           when others =>
             result_ready_reg <= '1';
         end case;
+        end if;  -- cir_launch_alu guard
       end if;
 
       if valid = '1' then
         result_lo_reg <= result(FP80_RESULT_LO_WIDTH-1 downto 0);
         result_hi_reg <= result(FP80_RESULT_LO_WIDTH+FP80_RESULT_HI_WIDTH-1 downto FP80_RESULT_LO_WIDTH);
         result_ex_reg <= result(FP_WIDTH-1 downto FP_WIDTH-FP80_RESULT_EX_WIDTH);
+        -- CIR: write ALU result to destination FP register.
+        if cir_arith_active_reg = '1' then
+          fp_reg_file_reg(cir_dst_reg_idx) <= result;
+          cir_arith_active_reg <= '0';
+          -- Trigger exception classification for the CIR operation.
+          exc_event_valid_reg <= '1';
+          exc_event_result_reg <= result;
+          exc_event_opa_reg <= result;
+          exc_event_opb_reg <= FP80_CLASSIFY_ONE;
+        end if;
         if aux_valid = '1' then
           aux_result_lo_reg <= aux_result(FP80_RESULT_LO_WIDTH-1 downto 0);
           aux_result_hi_reg <= aux_result(FP80_RESULT_LO_WIDTH+FP80_RESULT_HI_WIDTH-1 downto FP80_RESULT_LO_WIDTH);
@@ -2956,6 +3006,7 @@ begin
       cir_instr_type <= (others => '0');
       cir_src_fmt <= (others => '0');
       cir_dst_reg_idx <= 0;
+      cir_src_reg_idx <= 0;
       cir_reg_to_reg <= '0';
       cir_opword_written <= '0';
       cir_command_written <= '0';
@@ -2975,6 +3026,7 @@ begin
             cir_command_reg <= d_in(15 downto 0);
             cir_src_fmt <= d_in(12 downto 10);
             cir_dst_reg_idx <= to_integer(unsigned(d_in(9 downto 7)));
+            cir_src_reg_idx <= to_integer(unsigned(d_in(12 downto 10)));
             cir_reg_to_reg <= d_in(14);
             cir_command_written <= '1';
 
@@ -3009,7 +3061,10 @@ begin
       cir_state_reg <= CIR_IDLE;
       cir_xfer_word_idx <= 0;
       cir_xfer_word_count <= 0;
+      cir_launch_alu <= '0';
     elsif rising_edge(clk) then
+      cir_launch_alu <= '0';  -- default: clear one-shot pulse
+
       case cir_state_reg is
 
         when CIR_IDLE =>
@@ -3034,7 +3089,8 @@ begin
 
         when CIR_DECODE =>
           if cir_src_fmt = CIR_SRC_FPN then
-            -- Register-to-register: go to execute (Task 4 wires ALU)
+            -- Register-to-register: launch ALU and go to execute
+            cir_launch_alu <= '1';
             cir_state_reg <= CIR_EXECUTE;
           else
             -- Memory source: request operand transfer
@@ -3054,9 +3110,10 @@ begin
           null;  -- Reserved for multi-cycle format conversion
 
         when CIR_EXECUTE =>
-          -- Wait for ALU completion (Task 4 wires this)
-          -- For now, stub: stay in execute state
-          null;
+          -- Wait for ALU completion, then return to idle.
+          if valid = '1' then
+            cir_state_reg <= CIR_IDLE;
+          end if;
 
         when CIR_XFER_DST =>
           -- Task 7: destination transfer

--- a/src/mc68881_top.vhd
+++ b/src/mc68881_top.vhd
@@ -2942,6 +2942,201 @@ begin
     end if;
   end process;
 
+  -- =====================================================================
+  -- Section 7 CIR Dialog Processes
+  -- =====================================================================
+
+  -- CIR register write handler — latches OpWord, Command, Condition, etc.
+  cir_write_proc : process(clk, reset_n)
+  begin
+    if reset_n = '0' then
+      cir_opword_reg <= (others => '0');
+      cir_command_reg <= (others => '0');
+      cir_condition_reg <= (others => '0');
+      cir_instr_type <= (others => '0');
+      cir_src_fmt <= (others => '0');
+      cir_dst_reg_idx <= 0;
+      cir_reg_to_reg <= '0';
+      cir_opword_written <= '0';
+      cir_command_written <= '0';
+      cir_control_ack <= '0';
+    elsif rising_edge(clk) then
+      -- Clear one-shot flags
+      cir_control_ack <= '0';
+
+      if bus_write = '1' then
+        case addr is
+          when CIR_ADDR_OPWORD =>
+            cir_opword_reg <= d_in(15 downto 0);
+            cir_instr_type <= d_in(8 downto 6);
+            cir_opword_written <= '1';
+
+          when CIR_ADDR_COMMAND =>
+            cir_command_reg <= d_in(15 downto 0);
+            cir_src_fmt <= d_in(12 downto 10);
+            cir_dst_reg_idx <= to_integer(unsigned(d_in(9 downto 7)));
+            cir_reg_to_reg <= d_in(14);
+            cir_command_written <= '1';
+
+          when CIR_ADDR_CONDITION =>
+            cir_condition_reg <= d_in(5 downto 0);
+
+          when CIR_ADDR_INSTADDR =>
+            -- FPIAR capture from Instruction Address CIR
+            -- (fpiar_reg is written in existing process, so just note this)
+            null;
+
+          when CIR_ADDR_CONTROL =>
+            cir_control_ack <= d_in(0);
+
+          when others =>
+            null;
+        end case;
+      end if;
+
+      -- Clear written flags when FSM consumes them (transitions out of IDLE)
+      if cir_state_reg /= CIR_IDLE and cir_state_reg /= CIR_DECODE then
+        cir_opword_written <= '0';
+        cir_command_written <= '0';
+      end if;
+    end if;
+  end process;
+
+  -- CIR dialog state machine — drives FSM state transitions.
+  cir_dialog_proc : process(clk, reset_n)
+  begin
+    if reset_n = '0' then
+      cir_state_reg <= CIR_IDLE;
+      cir_xfer_word_idx <= 0;
+      cir_xfer_word_count <= 0;
+    elsif rising_edge(clk) then
+      case cir_state_reg is
+
+        when CIR_IDLE =>
+          -- cpGEN: wait for both OpWord + Command
+          if cir_opword_written = '1' and cir_command_written = '1' and
+             (cir_instr_type = CIR_TYPE_CPGEN) then
+            cir_state_reg <= CIR_DECODE;
+          end if;
+          -- cpBcc/cpScc: wait for OpWord + Condition write
+          -- (Condition CIR write is the trigger for conditional ops)
+          if cir_opword_written = '1' and
+             (cir_instr_type = CIR_TYPE_CPCOND or
+              cir_instr_type = CIR_TYPE_CPBCC_W or
+              cir_instr_type = CIR_TYPE_CPBCC_L) then
+            -- For conditional ops, the condition selector comes via Condition CIR.
+            -- We transition when both opword and a condition write have occurred.
+            -- For now, transition immediately (condition may already be written).
+            cir_state_reg <= CIR_COND_EVAL;
+          end if;
+          -- cpSAVE/cpRESTORE: triggered by Save/Restore CIR writes
+          -- (handled separately, not via OpWord)
+
+        when CIR_DECODE =>
+          if cir_src_fmt = CIR_SRC_FPN then
+            -- Register-to-register: go to execute (Task 4 wires ALU)
+            cir_state_reg <= CIR_EXECUTE;
+          else
+            -- Memory source: request operand transfer
+            cir_xfer_word_count <= cir_src_word_count(cir_src_fmt);
+            cir_xfer_word_idx <= 0;
+            cir_state_reg <= CIR_XFER_SRC;
+          end if;
+
+        when CIR_XFER_SRC =>
+          -- Wait for host to write operand words via Operand CIR
+          -- (Task 6 adds the actual operand write handling)
+          if cir_xfer_word_idx >= cir_xfer_word_count then
+            cir_state_reg <= CIR_EXECUTE;
+          end if;
+
+        when CIR_XFER_SRC_WAIT =>
+          null;  -- Reserved for multi-cycle format conversion
+
+        when CIR_EXECUTE =>
+          -- Wait for ALU completion (Task 4 wires this)
+          -- For now, stub: stay in execute state
+          null;
+
+        when CIR_XFER_DST =>
+          -- Task 7: destination transfer
+          null;
+
+        when CIR_XFER_DST_WAIT =>
+          null;
+
+        when CIR_COND_EVAL =>
+          -- Task 9-11: conditional evaluation
+          cir_state_reg <= CIR_IDLE;
+
+        when CIR_EXCEPT_PRE =>
+          if cir_control_ack = '1' then
+            cir_state_reg <= CIR_IDLE;
+          end if;
+
+        when CIR_EXCEPT_MID =>
+          if cir_control_ack = '1' then
+            cir_state_reg <= CIR_IDLE;
+          end if;
+
+        when CIR_EXCEPT_POST =>
+          if cir_control_ack = '1' then
+            cir_state_reg <= CIR_IDLE;
+          end if;
+
+        when CIR_SAVE_FORMAT =>
+          null;  -- Task 12
+
+        when CIR_SAVE_FRAME =>
+          null;  -- Task 12
+
+        when CIR_RESTORE_FORMAT =>
+          null;  -- Task 13
+
+        when CIR_RESTORE_FRAME =>
+          null;  -- Task 13
+
+      end case;
+    end if;
+  end process;
+
+  -- Combinational response primitive generation from FSM state.
+  cir_response_gen : process(cir_state_reg, cir_xfer_word_count, cir_exc_vector)
+  begin
+    case cir_state_reg is
+      when CIR_IDLE =>
+        cir_response_prim <= CIR_PRIM_NULL;
+      when CIR_DECODE =>
+        cir_response_prim <= CIR_PRIM_BUSY;
+      when CIR_EXECUTE =>
+        cir_response_prim <= CIR_PRIM_BUSY;
+      when CIR_XFER_SRC =>
+        -- Transfer Operand to-CP: [15:13]=011, [12]=1, [7:0]=byte count
+        cir_response_prim <= "0111" & "0000" &
+          std_logic_vector(to_unsigned(cir_xfer_word_count * 4, 8));
+      when CIR_XFER_SRC_WAIT =>
+        cir_response_prim <= CIR_PRIM_BUSY;
+      when CIR_XFER_DST =>
+        -- Transfer Operand from-CP: [15:13]=011, [12]=0, [7:0]=byte count
+        cir_response_prim <= "0110" & "0000" &
+          std_logic_vector(to_unsigned(cir_xfer_word_count * 4, 8));
+      when CIR_XFER_DST_WAIT =>
+        cir_response_prim <= CIR_PRIM_BUSY;
+      when CIR_COND_EVAL =>
+        cir_response_prim <= CIR_PRIM_NULL;  -- Task 9 refines this
+      when CIR_EXCEPT_PRE =>
+        cir_response_prim <= CIR_RESP_EXCEPT_PRE & "0" & "00" & cir_exc_vector;
+      when CIR_EXCEPT_MID =>
+        cir_response_prim <= CIR_RESP_EXCEPT_MID & "0" & "00" & cir_exc_vector;
+      when CIR_EXCEPT_POST =>
+        cir_response_prim <= CIR_RESP_EXCEPT_POST & "0" & "00" & cir_exc_vector;
+      when CIR_SAVE_FORMAT | CIR_SAVE_FRAME =>
+        cir_response_prim <= CIR_PRIM_BUSY;  -- Task 12 refines
+      when CIR_RESTORE_FORMAT | CIR_RESTORE_FRAME =>
+        cir_response_prim <= CIR_PRIM_BUSY;  -- Task 13 refines
+    end case;
+  end process;
+
   -- CIR reads use a registered data path; other reads are combinational.
   d_out <= d_out_reg when sync_read = '1' else d_out_comb;
   dsack0_n <= dsack0_i;

--- a/src/mc68881_top.vhd
+++ b/src/mc68881_top.vhd
@@ -167,6 +167,29 @@ architecture rtl of mc68881_top is
   signal cir_response_pending_reg : std_logic := '0';
   signal cir_trap_pending_reg : std_logic := '0';
   signal cir_protocol_violation_reg : std_logic := '0';
+
+  -- CIR dialog state machine signals (Section 7 coprocessor interface).
+  signal cir_state_reg         : cir_dialog_state_t := CIR_IDLE;
+  signal cir_opword_reg        : std_logic_vector(15 downto 0) := (others => '0');
+  signal cir_command_reg       : std_logic_vector(15 downto 0) := (others => '0');
+  signal cir_condition_reg     : std_logic_vector(5 downto 0) := (others => '0');
+  signal cir_instr_type        : std_logic_vector(2 downto 0) := (others => '0');
+  signal cir_src_fmt           : std_logic_vector(2 downto 0) := (others => '0');
+  signal cir_dst_reg_idx       : natural range 0 to 7 := 0;
+  signal cir_src_reg_idx       : natural range 0 to 7 := 0;
+  signal cir_reg_to_reg        : std_logic := '0';
+  signal cir_xfer_word_idx     : natural range 0 to 44 := 0;
+  signal cir_xfer_word_count   : natural range 0 to 45 := 0;
+  signal cir_response_prim     : std_logic_vector(15 downto 0) := CIR_PRIM_NULL;
+  signal cir_opword_written    : std_logic := '0';
+  signal cir_command_written   : std_logic := '0';
+  signal cir_exc_vector        : std_logic_vector(9 downto 0) := (others => '0');
+  signal cir_control_ack       : std_logic := '0';
+  signal frame_format_word_reg : std_logic_vector(15 downto 0) := (others => '0');
+  signal cir_operand_read_data : std_logic_vector(31 downto 0) := (others => '0');
+  signal cir_regselect_word    : std_logic_vector(15 downto 0) := (others => '0');
+  signal cir_operand_addr_reg  : std_logic_vector(31 downto 0) := (others => '0');
+
   signal exc_event_valid_reg : std_logic := '0';
   signal exc_event_result_reg : fp80_t := (others => '0');
   signal exc_event_opa_reg : fp80_t := (others => '0');

--- a/src/mc68881_top.vhd
+++ b/src/mc68881_top.vhd
@@ -65,6 +65,11 @@ architecture rtl of mc68881_top is
   signal move_cfg_decoded_reg : move_cfg_t := move_cfg_default;
   signal round_mode : fp_round_mode_t := FP_RND_NEAREST;
   signal round_prec : fp_round_prec_t := FP_PREC_EXTENDED;
+
+  -- Shared format converters (de-duplicated from FMOVE + CIR paths)
+  signal conv_fp_src : fp80_t := (others => '0');
+  signal conv_single_out : std_logic_vector(31 downto 0);
+  signal conv_double_out : std_logic_vector(63 downto 0);
   signal src_kind_reg : fpu_src_kind_t := FPU_SRC_FPM;
   signal ea_mode_reg  : ea_mode_t := EA_MODE_DN_AN;
   signal cycle_case_reg : ea_cycle_case_t := EA_CYCLE_BEST;
@@ -201,6 +206,7 @@ architecture rtl of mc68881_top is
   signal cir_operand_staging     : std_logic_vector(95 downto 0) := (others => '0');
   signal cir_operand_word_arrived : std_logic := '0';        -- Pulse from bus write → dialog proc
   signal cir_operand_read_done   : std_logic := '0';         -- Pulse from bus read → dialog proc
+  signal cir_operand_write_prev  : std_logic := '0';         -- Edge-detect for operand writes
 
   signal exc_event_valid_reg : std_logic := '0';
   signal exc_event_result_reg : fp80_t := (others => '0');
@@ -1624,6 +1630,14 @@ architecture rtl of mc68881_top is
   end function;
 
 begin
+  -- Shared format converters — single instance each, driven by conv_fp_src.
+  -- Source mux: CIR path uses cir_dst_reg_idx, FMOVE path uses move_cfg src_idx.
+  conv_fp_src <= fp_reg_file_reg(cir_dst_reg_idx)
+                 when cir_state_reg = CIR_XFER_DST
+                 else fp_reg_file_reg(move_cfg_decoded_reg.src_idx);
+  conv_single_out <= fp80_to_single(conv_fp_src, round_mode);
+  conv_double_out <= fp80_to_double(conv_fp_src, round_mode);
+
   addr      <= unsigned(a_in);
   bus_write <= '1' when (cs_n = '0' and as_n = '0' and ds_n = '0' and rw = '0') else '0';
   bus_read  <= '1' when (cs_n = '0' and as_n = '0' and ds_n = '0' and rw = '1') else '0';
@@ -2539,7 +2553,7 @@ begin
                     else
                       case mem_fmt is
                         when "01" =>
-                          single_bits := fp80_to_single(move_result, round_mode);
+                          single_bits := conv_single_out;
                           move_exc_enable := '1';
                           move_exc_result := fp80_from_single(single_bits);
                           if not fp80_is_nan(move_result) and not fp80_is_inf(move_result) and not fp80_is_zero(move_result) then
@@ -2561,7 +2575,7 @@ begin
                           result_ex_reg <= (others => '0');
                           result_ex_hi_reg <= (others => '0');
                         when "10" =>
-                          double_bits := fp80_to_double(move_result, round_mode);
+                          double_bits := conv_double_out;
                           move_exc_enable := '1';
                           move_exc_result := fp80_from_double(double_bits);
                           if not fp80_is_nan(move_result) and not fp80_is_inf(move_result) and not fp80_is_zero(move_result) then
@@ -2800,8 +2814,11 @@ begin
         result_hi_reg <= result(FP80_RESULT_LO_WIDTH+FP80_RESULT_HI_WIDTH-1 downto FP80_RESULT_LO_WIDTH);
         result_ex_reg <= result(FP_WIDTH-1 downto FP_WIDTH-FP80_RESULT_EX_WIDTH);
         -- CIR: write ALU result to destination FP register.
+        -- Gate writeback for compare/test ops that only update condition codes.
         if cir_arith_active_reg = '1' then
-          fp_reg_file_reg(cir_dst_reg_idx) <= result;
+          if last_op_sel_reg /= FPU_OP_CMP and last_op_sel_reg /= FPU_OP_TST then
+            fp_reg_file_reg(cir_dst_reg_idx) <= result;
+          end if;
           cir_arith_active_reg <= '0';
           -- Trigger exception classification for the CIR operation.
           exc_event_valid_reg <= '1';
@@ -3108,11 +3125,20 @@ begin
       cir_operand_staging <= (others => '0');
       cir_operand_word_arrived <= '0';
       cir_operand_read_done <= '0';
+      cir_operand_write_prev <= '0';
     elsif rising_edge(clk) then
       -- Clear one-shot flags
       cir_control_ack <= '0';
       cir_operand_word_arrived <= '0';
       cir_operand_read_done <= '0';
+
+      -- Edge-detect register for operand writes (prevents multi-pulse from
+      -- a single bus transaction that holds strobes active across clocks).
+      if bus_write = '1' and addr = CIR_ADDR_OPERAND then
+        cir_operand_write_prev <= '1';
+      else
+        cir_operand_write_prev <= '0';
+      end if;
 
       -- Detect host read of Operand CIR during destination transfer.
       if bus_read = '1' and addr = CIR_ADDR_OPERAND
@@ -3141,7 +3167,9 @@ begin
 
           when CIR_ADDR_OPERAND =>
             -- Store operand word during source transfer.
-            if cir_state_reg = CIR_XFER_SRC then
+            -- Edge-detect: only pulse on rising edge of bus_write to this addr
+            -- to prevent multi-pulse from a sustained bus strobe.
+            if cir_state_reg = CIR_XFER_SRC and cir_operand_write_prev = '0' then
               case cir_xfer_word_idx is
                 when 0 => cir_operand_staging(31 downto 0) <= d_in;
                 when 1 => cir_operand_staging(63 downto 32) <= d_in;
@@ -3164,8 +3192,11 @@ begin
         end case;
       end if;
 
-      -- Clear written flags when FSM consumes them (transitions out of IDLE)
-      if cir_state_reg /= CIR_IDLE and cir_state_reg /= CIR_DECODE then
+      -- Clear written flags when FSM consumes them.
+      -- Include CIR_DECODE: once the dialog FSM enters DECODE, the flags have
+      -- been consumed.  This prevents the reg-to-reg MOVE shortcut
+      -- (DECODE → IDLE) from leaving them asserted and re-triggering.
+      if cir_state_reg /= CIR_IDLE then
         cir_opword_written <= '0';
         cir_command_written <= '0';
       end if;
@@ -3180,8 +3211,7 @@ begin
         -- cir_src_fmt = destination memory format (bits[12:10]).
         case cir_src_fmt is
           when CIR_SRC_SINGLE =>
-            cir_operand_staging(31 downto 0) <=
-              fp80_to_single(fp_reg_file_reg(cir_dst_reg_idx), round_mode);
+            cir_operand_staging(31 downto 0) <= conv_single_out;
           when CIR_SRC_LONG =>
             cir_operand_staging(31 downto 0) <=
               std_logic_vector(to_signed(
@@ -3196,8 +3226,7 @@ begin
                 fp80_to_int_trunc(fp_reg_file_reg(cir_dst_reg_idx)), 8));
           when CIR_SRC_DOUBLE =>
             -- Double: word 0 = upper 32, word 1 = lower 32
-            cir_operand_staging(63 downto 0) <=
-              fp80_to_double(fp_reg_file_reg(cir_dst_reg_idx), round_mode);
+            cir_operand_staging(63 downto 0) <= conv_double_out;
           when CIR_SRC_EXTENDED =>
             -- Extended: word 0[15:0]=sign+exp, word 1=mant_hi, word 2=mant_lo
             cir_operand_staging(15 downto 0) <=

--- a/src/mc68881_top.vhd
+++ b/src/mc68881_top.vhd
@@ -178,6 +178,7 @@ architecture rtl of mc68881_top is
   signal cir_dst_reg_idx       : natural range 0 to 7 := 0;
   signal cir_src_reg_idx       : natural range 0 to 7 := 0;
   signal cir_reg_to_reg        : std_logic := '0';
+  signal cir_direction         : std_logic := '0';  -- Bit 13: 0=mem→reg, 1=reg→mem
   signal cir_xfer_word_idx     : natural range 0 to 44 := 0;
   signal cir_xfer_word_count   : natural range 0 to 45 := 0;
   signal cir_response_prim     : std_logic_vector(15 downto 0) := CIR_PRIM_NULL;
@@ -194,6 +195,12 @@ architecture rtl of mc68881_top is
   signal cir_launch_alu        : std_logic := '0';           -- One-cycle pulse from cir_dialog_proc
   signal cir_decoded_op        : fpu_op_t := FPU_OP_NOP;     -- Combinational decode of command word
   signal cir_arith_active_reg  : std_logic := '0';           -- Tracks CIR-launched arith op in alu_control_proc
+  signal cir_move_pending_reg  : std_logic := '0';           -- One-cycle deferred FMOVE copy
+
+  -- CIR operand staging for memory-source/destination transfers (up to 3 x 32-bit words).
+  signal cir_operand_staging     : std_logic_vector(95 downto 0) := (others => '0');
+  signal cir_operand_word_arrived : std_logic := '0';        -- Pulse from bus write → dialog proc
+  signal cir_operand_read_done   : std_logic := '0';         -- Pulse from bus read → dialog proc
 
   signal exc_event_valid_reg : std_logic := '0';
   signal exc_event_result_reg : fp80_t := (others => '0');
@@ -1837,11 +1844,49 @@ begin
         end case;
       end if;
 
-      -- CIR reg-to-reg launch: load op_sel and operands from register file.
+      -- CIR launch: load op_sel and operands for ALU.
       if cir_launch_alu = '1' then
         op_sel_reg <= cir_decoded_op;
         operand_reg(0) <= fp_reg_file_reg(cir_dst_reg_idx);  -- Dest = operand A
-        operand_reg(1) <= fp_reg_file_reg(cir_src_reg_idx);  -- Source = operand B
+        if cir_reg_to_reg = '1' then
+          -- Register-to-register: source from FP register file.
+          operand_reg(1) <= fp_reg_file_reg(cir_src_reg_idx);
+        else
+          -- Memory source: convert staged operand words to FP80.
+          case cir_src_fmt is
+            when CIR_SRC_LONG =>
+              operand_reg(1) <= fp80_from_int(
+                signed32_to_integer(cir_operand_staging(31 downto 0)));
+            when CIR_SRC_SINGLE =>
+              operand_reg(1) <= fp80_from_single(
+                cir_operand_staging(31 downto 0));
+            when CIR_SRC_EXTENDED =>
+              -- Word 0 bits[15:0] = sign+exp, word 1 = mant_hi, word 2 = mant_lo.
+              operand_reg(1) <= cir_operand_staging(15 downto 0) &
+                                cir_operand_staging(63 downto 32) &
+                                cir_operand_staging(95 downto 64);
+            when CIR_SRC_WORD =>
+              operand_reg(1) <= fp80_from_int(
+                signed16_to_integer(cir_operand_staging(15 downto 0)));
+            when CIR_SRC_DOUBLE =>
+              -- Word 0 = upper 32, word 1 = lower 32.
+              operand_reg(1) <= fp80_from_double(
+                cir_operand_staging(31 downto 0) &
+                cir_operand_staging(63 downto 32));
+            when CIR_SRC_BYTE =>
+              operand_reg(1) <= fp80_from_int(
+                signed8_to_integer(cir_operand_staging(7 downto 0)));
+            when CIR_SRC_PACKED =>
+              -- Word 0 (staging[31:0]) = packed[95:64], word 1 = [63:32], word 2 = [31:0].
+              operand_reg(1) <= packed96_to_fp80_fast(
+                cir_operand_staging(31 downto 0) &
+                cir_operand_staging(63 downto 32) &
+                cir_operand_staging(95 downto 64),
+                fp_reg_file_reg(cir_dst_reg_idx));
+            when others =>
+              operand_reg(1) <= (others => '0');
+          end case;
+        end if;
       end if;
 
       if ctrl_move_write_req_reg = '1' then
@@ -2237,6 +2282,7 @@ begin
       exc_event_force_invalid_reg <= '0';
       exc_event_force_bsun_reg <= '0';
       cir_arith_active_reg <= '0';
+      cir_move_pending_reg <= '0';
       sys_ctrl_save_req_reg <= '0';
       sys_ctrl_restore_req_reg <= '0';
       frame_op_waiting_reg <= '0';
@@ -2267,6 +2313,12 @@ begin
       exc_event_force_bsun_reg <= '0';
       sys_ctrl_save_req_reg <= '0';
       sys_ctrl_restore_req_reg <= '0';
+
+      -- Keep cir_response_reg tracking FSM-based primitives when no
+      -- conditional dialog result is pending.
+      if cir_response_pending_reg = '0' then
+        cir_response_reg <= x"0000" & cir_response_prim;
+      end if;
 
       if packed_result_valid_reg = '1' and packed_pending_reg = '1' then
         if packed_req_mode_reg = PACKED_REQ_DECODE then
@@ -2331,7 +2383,9 @@ begin
             false,
             false
           );
-          cir_arith_active_reg <= '1';
+          if op_class(cir_decoded_op) /= OP_CLASS_MOVE then
+            cir_arith_active_reg <= '1';
+          end if;
         else
           -- Legacy bus-write path: use d_in-decoded opcode.
           last_op_sel_reg <= op_sel_write_decoded;
@@ -2355,8 +2409,15 @@ begin
 
         -- Dispatch uses operation classes to keep execution paths scalable.
         if cir_launch_alu = '1' then
-          -- CIR path always launches ALU for arithmetic operations.
-          op_start_reg <= '1';
+          -- CIR path: launch ALU for arithmetic ops only.
+          -- MOVE ops bypass the ALU (which doesn't handle OP_CLASS_MOVE).
+          -- The converted source is in operand_reg(1) after this edge, so
+          -- we defer the register file copy to the next cycle via a flag.
+          if op_class(cir_decoded_op) = OP_CLASS_MOVE then
+            cir_move_pending_reg <= '1';
+          else
+            op_start_reg <= '1';
+          end if;
         else
         case op_class_write_decoded is
           when OP_CLASS_ARITH =>
@@ -2756,6 +2817,24 @@ begin
         result_ready_reg <= '1';
       end if;
 
+      -- CIR FMOVE deferred copy: operand_reg(1) now holds the converted
+      -- source value (set by bus_frame_proc on the previous edge).  Copy it
+      -- to the destination FP register and mark result ready.
+      if cir_move_pending_reg = '1' then
+        fp_reg_file_reg(cir_dst_reg_idx) <= operand_reg(1);
+        result_lo_reg <= operand_reg(1)(FP80_RESULT_LO_WIDTH-1 downto 0);
+        result_hi_reg <= operand_reg(1)(FP80_RESULT_LO_WIDTH+FP80_RESULT_HI_WIDTH-1
+                                        downto FP80_RESULT_LO_WIDTH);
+        result_ex_reg <= operand_reg(1)(FP_WIDTH-1 downto FP_WIDTH-FP80_RESULT_EX_WIDTH);
+        result_ready_reg <= '1';
+        -- Trigger exception classification for the moved value.
+        exc_event_valid_reg <= '1';
+        exc_event_result_reg <= operand_reg(1);
+        exc_event_opa_reg <= operand_reg(1);
+        exc_event_opb_reg <= FP80_CLASSIFY_ONE;
+        cir_move_pending_reg <= '0';
+      end if;
+
       -- Frame-op completion: wait for frame_busy to go high then return low.
       -- The sys_ctrl_*_req guard prevents false completion before bus_frame_proc
       -- has started the frame op (see timing proof in plan).
@@ -2831,7 +2910,10 @@ begin
     cir_response_reg,
     cir_response_pending_reg,
     cir_trap_pending_reg,
-    cir_protocol_violation_reg
+    cir_protocol_violation_reg,
+    cir_state_reg,
+    cir_xfer_word_idx,
+    cir_operand_staging
   )
     variable cfg0 : std_logic_vector(31 downto 0);
     variable cfg1 : std_logic_vector(31 downto 0);
@@ -2849,7 +2931,18 @@ begin
     if bus_read = '1' then
       case addr is
         when ADDR_RES_L => d_out_comb <= result_lo_reg;
-        when ADDR_RES_H => d_out_comb <= result_hi_reg;
+        when ADDR_RES_H =>
+          if cir_state_reg = CIR_XFER_DST or cir_state_reg = CIR_XFER_DST_WAIT then
+            -- CIR Operand read: return current word from staging.
+            case cir_xfer_word_idx is
+              when 0 => d_out_comb <= cir_operand_staging(31 downto 0);
+              when 1 => d_out_comb <= cir_operand_staging(63 downto 32);
+              when 2 => d_out_comb <= cir_operand_staging(95 downto 64);
+              when others => d_out_comb <= (others => '0');
+            end case;
+          else
+            d_out_comb <= result_hi_reg;
+          end if;
         when ADDR_RES_E =>
           d_out_comb(FP80_RESULT_EX_WIDTH-1 downto 0) <= result_ex_reg;
           d_out_comb(31 downto 16) <= result_ex_hi_reg;
@@ -3008,12 +3101,24 @@ begin
       cir_dst_reg_idx <= 0;
       cir_src_reg_idx <= 0;
       cir_reg_to_reg <= '0';
+      cir_direction <= '0';
       cir_opword_written <= '0';
       cir_command_written <= '0';
       cir_control_ack <= '0';
+      cir_operand_staging <= (others => '0');
+      cir_operand_word_arrived <= '0';
+      cir_operand_read_done <= '0';
     elsif rising_edge(clk) then
       -- Clear one-shot flags
       cir_control_ack <= '0';
+      cir_operand_word_arrived <= '0';
+      cir_operand_read_done <= '0';
+
+      -- Detect host read of Operand CIR during destination transfer.
+      if bus_read = '1' and addr = CIR_ADDR_OPERAND
+         and cir_state_reg = CIR_XFER_DST then
+        cir_operand_read_done <= '1';
+      end if;
 
       if bus_write = '1' then
         case addr is
@@ -3028,10 +3133,23 @@ begin
             cir_dst_reg_idx <= to_integer(unsigned(d_in(9 downto 7)));
             cir_src_reg_idx <= to_integer(unsigned(d_in(12 downto 10)));
             cir_reg_to_reg <= d_in(14);
+            cir_direction <= d_in(13);
             cir_command_written <= '1';
 
           when CIR_ADDR_CONDITION =>
             cir_condition_reg <= d_in(5 downto 0);
+
+          when CIR_ADDR_OPERAND =>
+            -- Store operand word during source transfer.
+            if cir_state_reg = CIR_XFER_SRC then
+              case cir_xfer_word_idx is
+                when 0 => cir_operand_staging(31 downto 0) <= d_in;
+                when 1 => cir_operand_staging(63 downto 32) <= d_in;
+                when 2 => cir_operand_staging(95 downto 64) <= d_in;
+                when others => null;
+              end case;
+              cir_operand_word_arrived <= '1';
+            end if;
 
           when CIR_ADDR_INSTADDR =>
             -- FPIAR capture from Instruction Address CIR
@@ -3050,6 +3168,47 @@ begin
       if cir_state_reg /= CIR_IDLE and cir_state_reg /= CIR_DECODE then
         cir_opword_written <= '0';
         cir_command_written <= '0';
+      end if;
+
+      -- Fill operand staging for reg→mem transfer when FSM enters CIR_XFER_DST.
+      -- The dialog proc transitions to CIR_XFER_DST from CIR_DECODE; we detect
+      -- that transition on the next edge (CIR_XFER_DST with word_idx=0).
+      if cir_state_reg = CIR_XFER_DST and cir_xfer_word_idx = 0
+         and cir_operand_read_done = '0' then
+        -- Convert FP register to destination format and pack into staging.
+        -- cir_dst_reg_idx = source FP register (bits[9:7] of command word).
+        -- cir_src_fmt = destination memory format (bits[12:10]).
+        case cir_src_fmt is
+          when CIR_SRC_SINGLE =>
+            cir_operand_staging(31 downto 0) <=
+              fp80_to_single(fp_reg_file_reg(cir_dst_reg_idx), round_mode);
+          when CIR_SRC_LONG =>
+            cir_operand_staging(31 downto 0) <=
+              std_logic_vector(to_signed(
+                fp80_to_int_trunc(fp_reg_file_reg(cir_dst_reg_idx)), 32));
+          when CIR_SRC_WORD =>
+            cir_operand_staging(31 downto 0) <= x"0000" &
+              std_logic_vector(to_signed(
+                fp80_to_int_trunc(fp_reg_file_reg(cir_dst_reg_idx)), 16));
+          when CIR_SRC_BYTE =>
+            cir_operand_staging(31 downto 0) <= x"000000" &
+              std_logic_vector(to_signed(
+                fp80_to_int_trunc(fp_reg_file_reg(cir_dst_reg_idx)), 8));
+          when CIR_SRC_DOUBLE =>
+            -- Double: word 0 = upper 32, word 1 = lower 32
+            cir_operand_staging(63 downto 0) <=
+              fp80_to_double(fp_reg_file_reg(cir_dst_reg_idx), round_mode);
+          when CIR_SRC_EXTENDED =>
+            -- Extended: word 0[15:0]=sign+exp, word 1=mant_hi, word 2=mant_lo
+            cir_operand_staging(15 downto 0) <=
+              fp_reg_file_reg(cir_dst_reg_idx)(79 downto 64);
+            cir_operand_staging(63 downto 32) <=
+              fp_reg_file_reg(cir_dst_reg_idx)(63 downto 32);
+            cir_operand_staging(95 downto 64) <=
+              fp_reg_file_reg(cir_dst_reg_idx)(31 downto 0);
+          when others =>
+            cir_operand_staging <= (others => '0');
+        end case;
       end if;
     end if;
   end process;
@@ -3088,22 +3247,46 @@ begin
           -- (handled separately, not via OpWord)
 
         when CIR_DECODE =>
-          if cir_src_fmt = CIR_SRC_FPN then
-            -- Register-to-register: launch ALU and go to execute
+          if cir_reg_to_reg = '1' then
+            -- Register-to-register: launch ALU and go to execute.
+            -- MOVE ops bypass the ALU, so go directly to IDLE.
             cir_launch_alu <= '1';
-            cir_state_reg <= CIR_EXECUTE;
+            if op_class(cir_decoded_op) = OP_CLASS_MOVE then
+              cir_state_reg <= CIR_IDLE;
+            else
+              cir_state_reg <= CIR_EXECUTE;
+            end if;
+          elsif cir_direction = '1' then
+            -- Register→memory (FMOVE FPn,<ea>): convert and present data.
+            -- cir_dst_reg_idx holds the source FP register (bits[9:7]).
+            -- cir_src_fmt holds the destination memory format (bits[12:10]).
+            cir_xfer_word_count <= cir_src_word_count(cir_src_fmt);
+            cir_xfer_word_idx <= 0;
+            cir_state_reg <= CIR_XFER_DST;
           else
-            -- Memory source: request operand transfer
+            -- Memory→register: request operand transfer from host.
             cir_xfer_word_count <= cir_src_word_count(cir_src_fmt);
             cir_xfer_word_idx <= 0;
             cir_state_reg <= CIR_XFER_SRC;
           end if;
 
         when CIR_XFER_SRC =>
-          -- Wait for host to write operand words via Operand CIR
-          -- (Task 6 adds the actual operand write handling)
-          if cir_xfer_word_idx >= cir_xfer_word_count then
-            cir_state_reg <= CIR_EXECUTE;
+          -- Wait for host to write operand words via Operand CIR.
+          -- cir_operand_word_arrived is pulsed by the bus write process.
+          if cir_operand_word_arrived = '1' then
+            if cir_xfer_word_idx + 1 >= cir_xfer_word_count then
+              -- All words received: launch ALU with converted operand.
+              -- MOVE ops bypass the ALU, so go directly to IDLE.
+              cir_launch_alu <= '1';
+              cir_xfer_word_idx <= cir_xfer_word_idx + 1;
+              if op_class(cir_decoded_op) = OP_CLASS_MOVE then
+                cir_state_reg <= CIR_IDLE;
+              else
+                cir_state_reg <= CIR_EXECUTE;
+              end if;
+            else
+              cir_xfer_word_idx <= cir_xfer_word_idx + 1;
+            end if;
           end if;
 
         when CIR_XFER_SRC_WAIT =>
@@ -3116,11 +3299,20 @@ begin
           end if;
 
         when CIR_XFER_DST =>
-          -- Task 7: destination transfer
-          null;
+          -- Host reads operand words via CIR_ADDR_OPERAND.
+          if cir_operand_read_done = '1' then
+            if cir_xfer_word_idx + 1 >= cir_xfer_word_count then
+              -- Hold state one extra cycle so d_out_comb returns staging
+              -- data through the dsack assertion window.  Don't increment
+              -- word_idx so the mux continues returning the correct word.
+              cir_state_reg <= CIR_XFER_DST_WAIT;
+            else
+              cir_xfer_word_idx <= cir_xfer_word_idx + 1;
+            end if;
+          end if;
 
         when CIR_XFER_DST_WAIT =>
-          null;
+          cir_state_reg <= CIR_IDLE;
 
         when CIR_COND_EVAL =>
           -- Task 9-11: conditional evaluation

--- a/src/mc68881_trig_unit.vhd
+++ b/src/mc68881_trig_unit.vhd
@@ -382,6 +382,9 @@ architecture rtl of mc68881_trig_unit is
   signal c_reg : fp80_t := (others => '0');
   signal poly_reg : fp80_t := (others => '0');
   signal tmp_reg : fp80_t := (others => '0');
+  signal fintrz_tmp : fp80_t;
+  signal fgetman_a : fp80_t;
+  signal fgetman_tmp : fp80_t;
   signal tanh_x2_reg : fp80_t := (others => '0');
   signal result_reg : fp80_t := (others => '0');
   signal aux_result_reg : fp80_t := (others => '0');
@@ -664,6 +667,11 @@ begin
     end if;
   end process;
 
+  -- Shared combinational de-duplicated functions
+  fintrz_tmp <= fintrz_fp80(tmp_reg);
+  fgetman_a <= fgetman_fp80(a_reg);
+  fgetman_tmp <= fgetman_fp80(tmp_reg);
+
   process(clk, reset_n)
     variable abs_a : fp80_t;
     variable exp_bits : unsigned(FP_EXP_WIDTH-1 downto 0);
@@ -677,6 +685,12 @@ begin
     variable x_local : fp80_t;
     variable z_local : fp80_t;
     variable unbiased_exp_local : integer;
+    variable abs_a_gt_one : boolean;
+    variable a_exp_v : unsigned(FP_EXP_WIDTH-1 downto 0);
+    variable a_mant_v : unsigned(63 downto 0);
+    variable frac_abs_ge_half : boolean;
+    variable v_exp : unsigned(FP_EXP_WIDTH-1 downto 0);
+    variable v_mant : unsigned(63 downto 0);
   begin
     if reset_n = '0' then
       state_reg <= ST_IDLE;
@@ -748,6 +762,12 @@ begin
 
         when ST_CLASSIFY =>
           abs_a := abs_fp80(a_reg);
+          -- Pre-compute |a| > 1.0 using direct field comparison (replaces 4 compare_fp80 calls)
+          a_exp_v := unsigned(abs_a(78 downto 64));
+          a_mant_v := unsigned(abs_a(63 downto 0));
+          abs_a_gt_one := a_exp_v > to_unsigned(FP_EXP_BIAS, FP_EXP_WIDTH)
+                       or (a_exp_v = to_unsigned(FP_EXP_BIAS, FP_EXP_WIDTH)
+                           and a_mant_v > x"8000000000000000");
           trans_input_adjust_en_reg <= '0';
           trans_input_adjust_sub_reg <= '0';
           trans_input_adjust_const_reg <= FP80_ZERO;
@@ -987,7 +1007,7 @@ begin
                   result_reg <= FP80_NEG_INF;
                   flag_divzero_reg <= '1';
                   state_reg <= ST_DONE;
-                elsif compare_fp80(a_reg, FP80_NEG_ONE) < 0 then
+                elsif a_reg(FP_WIDTH-1) = '1' and abs_a_gt_one then
                   result_reg <= canonical_nan(FP80_ZERO);
                   state_reg <= ST_DONE;
                 elsif fp80_is_zero(a_reg) then
@@ -1092,7 +1112,7 @@ begin
                   coeff3_reg <= FP80_NEG_ONE_THIRD;
                   coeff4_reg <= FP80_ZERO;
                   coeff5_reg <= FP80_ONE_FIFTH;
-                  if compare_fp80(abs_a, FP80_ONE) > 0 then
+                  if abs_a_gt_one then
                     trans_post_add_en_reg <= '1';
                     trans_post_add_sub_reg <= '1';
                     if fp80_sign(a_reg) = '1' then
@@ -1116,7 +1136,7 @@ begin
                 end if;
 
               when FPU_OP_ASIN =>
-                if compare_fp80(abs_a, FP80_ONE) > 0 then
+                if abs_a_gt_one then
                   result_reg <= canonical_nan(FP80_ZERO);
                   state_reg <= ST_DONE;
                 elsif fp80_is_zero(a_reg) then
@@ -1143,7 +1163,7 @@ begin
                 end if;
 
               when FPU_OP_ACOS =>
-                if compare_fp80(abs_a, FP80_ONE) > 0 then
+                if abs_a_gt_one then
                   result_reg <= canonical_nan(FP80_ZERO);
                   state_reg <= ST_DONE;
                 elsif fp80_is_zero(a_reg) then
@@ -1182,7 +1202,7 @@ begin
                   end if;
                   flag_divzero_reg <= '1';
                   state_reg <= ST_DONE;
-                elsif compare_fp80(abs_a, FP80_ONE) > 0 then
+                elsif abs_a_gt_one then
                   result_reg <= canonical_nan(FP80_ZERO);
                   state_reg <= ST_DONE;
                 elsif fp80_is_zero(a_reg) then
@@ -1288,7 +1308,7 @@ begin
           state_reg <= ST_FP_MUL;
 
         when ST_TRIG_MOD_INV4_POST =>
-          q_fp_reg <= fintrz_fp80(tmp_reg);
+          q_fp_reg <= fintrz_tmp;
           state_reg <= ST_TRIG_MOD_QPI_PREP;
 
         when ST_TRIG_MOD_QPI_PREP =>
@@ -1324,7 +1344,7 @@ begin
           state_reg <= ST_FP_MUL;
 
         when ST_TRIG_SCALE_POST =>
-          q_fp_reg <= fintrz_fp80(tmp_reg);
+          q_fp_reg <= fintrz_tmp;
           state_reg <= ST_TRIG_FRAC_PREP;
 
         when ST_TRIG_FRAC_PREP =>
@@ -1339,7 +1359,13 @@ begin
         when ST_TRIG_FRAC_POST =>
           frac := tmp_reg;
           q_mod_local := fp80_int_mod4(q_fp_reg);
-          if frac(FP_WIDTH-1) = '0' and compare_fp80(frac, FP80_HALF) >= 0 then
+          -- |frac| >= 0.5: compare exponent/mantissa against FP80_HALF (exp=3FFE, mant=8000...)
+          v_exp := unsigned(frac(78 downto 64));
+          v_mant := unsigned(frac(63 downto 0));
+          frac_abs_ge_half := v_exp > to_unsigned(FP_EXP_BIAS - 1, FP_EXP_WIDTH)
+                           or (v_exp = to_unsigned(FP_EXP_BIAS - 1, FP_EXP_WIDTH)
+                               and v_mant >= x"8000000000000000");
+          if frac(FP_WIDTH-1) = '0' and frac_abs_ge_half then
             q_mod_local := (q_mod_local + 1) mod 4;
             add_a_reg <= q_fp_reg;
             add_b_reg <= FP80_ONE;
@@ -1349,7 +1375,7 @@ begin
             cont_state_reg <= ST_TRIG_QROUND_POST;
             q_mod_reg <= q_mod_local;
             state_reg <= ST_FP_ADD;
-          elsif frac(FP_WIDTH-1) = '1' and compare_fp80(abs_fp80(frac), FP80_HALF) >= 0 then
+          elsif frac(FP_WIDTH-1) = '1' and frac_abs_ge_half then
             q_mod_local := (q_mod_local + 3) mod 4;
             add_a_reg <= q_fp_reg;
             add_b_reg <= FP80_ONE;
@@ -1390,7 +1416,12 @@ begin
 
         when ST_TRIG_RESIDUAL_POST =>
           r_clamped := tmp_reg;
-          if compare_fp80(abs_fp80(r_clamped), FP80_EPS_TRIG) <= 0 then
+          -- |r_clamped| <= 2^-20: check exponent field <= EPS exponent (3FEB)
+          v_exp := unsigned(r_clamped(78 downto 64));
+          v_mant := unsigned(r_clamped(63 downto 0));
+          if v_exp < to_unsigned(16363, FP_EXP_WIDTH)
+             or (v_exp = to_unsigned(16363, FP_EXP_WIDTH)
+                 and v_mant <= x"8000000000000000") then
             r_clamped := FP80_ZERO;
           end if;
           r_reg <= r_clamped;
@@ -1639,7 +1670,13 @@ begin
           state_reg <= ST_FP_DIV;
 
         when ST_TRIG_TAN_DIV_POST =>
-          if op_reg = FPU_OP_TANH and compare_fp80(abs_fp80(tmp_reg), FP80_ONE) > 0 then
+          -- |tmp_reg| > 1.0: direct field comparison replaces compare_fp80
+          v_exp := unsigned(tmp_reg(78 downto 64));
+          v_mant := unsigned(tmp_reg(63 downto 0));
+          if op_reg = FPU_OP_TANH
+             and (v_exp > to_unsigned(FP_EXP_BIAS, FP_EXP_WIDTH)
+                  or (v_exp = to_unsigned(FP_EXP_BIAS, FP_EXP_WIDTH)
+                      and v_mant > x"8000000000000000")) then
             if tmp_reg(FP_WIDTH-1) = '1' then
               result_reg <= FP80_NEG_ONE;
             else
@@ -1709,8 +1746,8 @@ begin
           state_reg <= ST_TRIG_TAN_DIV;
 
         when ST_EXP_REDUCE_K_POST =>
-          exp_k_reg <= fintrz_fp80(tmp_reg);
-          mul_a_reg <= fintrz_fp80(tmp_reg);
+          exp_k_reg <= fintrz_tmp;
+          mul_a_reg <= fintrz_tmp;
           mul_b_reg <= FP80_LN2;
           mul_rm_reg <= FP_RND_NEAREST;
           mul_rp_reg <= FP_PREC_EXTENDED;
@@ -1747,7 +1784,7 @@ begin
           else
             log_exp_term_zero_reg <= '0';
           end if;
-          x_reg <= fgetman_fp80(a_reg);
+          x_reg <= fgetman_a;
           state_reg <= ST_LOG_GETEXP_POST;
 
         when ST_LOG_GETEXP_POST =>
@@ -1767,7 +1804,7 @@ begin
         when ST_LOGNP1_Z_POST =>
           -- z = tmp_reg = a + 1.  Finish FLOGNP1 setup using z.
           z_local := tmp_reg;
-          x_local := fgetman_fp80(z_local);
+          x_local := fgetman_tmp;
           unbiased_exp_local := fgetexp_unbiased_int(z_local);
           log_unbiased_exp_reg <= unbiased_exp_local;
           log_scale_reg <= FP80_LN2;

--- a/tb/tb_mc68881_cir_dialog.vhd
+++ b/tb/tb_mc68881_cir_dialog.vhd
@@ -1,0 +1,1345 @@
+-- CIR Dialog Protocol Testbench
+-- Tests the Section 7 coprocessor interface register dialog.
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use std.env.all;
+
+use work.mc68881_pkg.all;
+
+entity tb_mc68881_cir_dialog is
+end entity tb_mc68881_cir_dialog;
+
+architecture sim of tb_mc68881_cir_dialog is
+  signal a_in     : std_logic_vector(4 downto 0) := (others => '0');
+  signal d_in     : std_logic_vector(31 downto 0) := (others => '0');
+  signal d_out    : std_logic_vector(31 downto 0);
+  signal size_n   : std_logic_vector(1 downto 0) := "11";
+  signal as_n     : std_logic := '1';
+  signal cs_n     : std_logic := '1';
+  signal rw       : std_logic := '1';
+  signal ds_n     : std_logic := '1';
+  signal dsack0_n : std_logic;
+  signal dsack1_n : std_logic;
+  signal reset_n  : std_logic := '0';
+  signal clk      : std_logic := '0';
+  signal sense_n  : std_logic;
+
+  constant CLK_PERIOD : time := 10 ns;
+
+  -- Legacy addresses (coexist with CIR addresses in current implementation).
+  constant ADDR_OPSEL    : unsigned(4 downto 0) := to_unsigned(0, 5);
+  constant ADDR_OPA_L    : unsigned(4 downto 0) := to_unsigned(1, 5);
+  constant ADDR_OPA_H    : unsigned(4 downto 0) := to_unsigned(2, 5);
+  constant ADDR_OPA_E    : unsigned(4 downto 0) := to_unsigned(3, 5);
+  constant ADDR_RES_L    : unsigned(4 downto 0) := to_unsigned(7, 5);
+  constant ADDR_RES_H    : unsigned(4 downto 0) := to_unsigned(8, 5);
+  constant ADDR_RES_E    : unsigned(4 downto 0) := to_unsigned(9, 5);
+  constant ADDR_STATUS   : unsigned(4 downto 0) := to_unsigned(10, 5);
+  constant ADDR_MOVE_CFG : unsigned(4 downto 0) := to_unsigned(23, 5);
+
+  -- Legacy opcode IDs.
+  constant OP_FMOVE : std_logic_vector(31 downto 0) := x"00000005";
+
+  -- CIR addresses (as unsigned, matching package constants).
+  constant CIR_OPWORD   : unsigned(4 downto 0) := unsigned(std_logic_vector(CIR_ADDR_OPWORD));
+  constant CIR_COMMAND  : unsigned(4 downto 0) := unsigned(std_logic_vector(CIR_ADDR_COMMAND));
+  constant CIR_OPERAND  : unsigned(4 downto 0) := unsigned(std_logic_vector(CIR_ADDR_OPERAND));
+  constant CIR_RESPONSE : unsigned(4 downto 0) := to_unsigned(13, 5);
+
+  -- Expected CIR response primitives (lower 16 bits of response register).
+  -- MC68020 CIR protocol: Null=0x2001, Busy=0x0000.
+  constant RESP_NULL           : std_logic_vector(15 downto 0) := CIR_PRIM_NULL;  -- x"2001"
+  constant RESP_BUSY           : std_logic_vector(15 downto 0) := CIR_PRIM_BUSY;  -- x"0000"
+  constant RESP_XFER_TO_CP_4   : std_logic_vector(15 downto 0) := x"7004";  -- 1 longword to-CP
+  constant RESP_XFER_FROM_CP_4 : std_logic_vector(15 downto 0) := x"6004";  -- 1 longword from-CP
+
+  -- FP80 test constants.
+  constant FP80_ONE_VAL   : fp80_t := x"3FFF8000000000000000";  -- 1.0
+  constant FP80_TWO_VAL   : fp80_t := x"40008000000000000000";  -- 2.0
+  constant FP80_THREE_VAL : fp80_t := x"4000C000000000000000";  -- 3.0
+  constant FP80_FIVE_VAL  : fp80_t := x"4001A000000000000000";  -- 5.0
+  constant FP80_NEG_ONE   : fp80_t := x"BFFF8000000000000000";  -- -1.0
+
+  -- cpGEN command word builder for register-to-register operations.
+  -- R/M=1, bits[12:10]=src_reg, bits[9:7]=dst_reg, bits[6:0]=core_v1 opcode
+  function make_cpgen_reg_cmd(
+    src_reg : natural range 0 to 7;
+    dst_reg : natural range 0 to 7;
+    opcode  : std_logic_vector(6 downto 0)
+  ) return std_logic_vector is
+    variable cmd : std_logic_vector(15 downto 0) := (others => '0');
+  begin
+    cmd(14) := '1';  -- R/M = register
+    cmd(12 downto 10) := std_logic_vector(to_unsigned(src_reg, 3));
+    cmd(9 downto 7) := std_logic_vector(to_unsigned(dst_reg, 3));
+    cmd(6 downto 0) := opcode;
+    return x"0000" & cmd;
+  end function;
+
+  -- cpGEN command word builder for memory-source operations.
+  -- R/M=0, bits[12:10]=src_fmt, bits[9:7]=dst_reg, bits[6:0]=core_v1 opcode
+  function make_cpgen_mem_cmd(
+    src_fmt : std_logic_vector(2 downto 0);
+    dst_reg : natural range 0 to 7;
+    opcode  : std_logic_vector(6 downto 0)
+  ) return std_logic_vector is
+    variable cmd : std_logic_vector(15 downto 0) := (others => '0');
+  begin
+    cmd(14) := '0';  -- R/M = memory
+    cmd(12 downto 10) := src_fmt;
+    cmd(9 downto 7) := std_logic_vector(to_unsigned(dst_reg, 3));
+    cmd(6 downto 0) := opcode;
+    return x"0000" & cmd;
+  end function;
+
+  -- cpGEN OpWord: F-line with cpID=001, type=000 (cpGEN).
+  -- FPU only uses bits [8:6] for type. Bits [5:0] are EA (irrelevant to FPU).
+  constant CPGEN_OPWORD : std_logic_vector(31 downto 0) := x"0000" & x"0000";
+
+  -- Core_v1 opcode IDs from OP_DESCRIPTORS.
+  constant OPCODE_FADD : std_logic_vector(6 downto 0) := "0000001";  -- 0x01
+  constant OPCODE_FSUB : std_logic_vector(6 downto 0) := "0000010";  -- 0x02
+  constant OPCODE_FMUL : std_logic_vector(6 downto 0) := "0000011";  -- 0x03
+  constant OPCODE_FDIV : std_logic_vector(6 downto 0) := "0000100";  -- 0x04
+  constant OPCODE_FMOVE : std_logic_vector(6 downto 0) := "0000101";  -- 0x05
+  constant OPCODE_FNEG : std_logic_vector(6 downto 0) := "0010011";  -- 0x13
+
+  function make_move_cfg(
+    mode : std_logic_vector(1 downto 0);
+    src_idx : natural;
+    dst_idx : natural;
+    mem_fmt : std_logic_vector(1 downto 0);
+    ctrl_to_reg : std_logic;
+    ctrl_sel : std_logic_vector(1 downto 0);
+    movem_mask : std_logic_vector(7 downto 0);
+    movem_dir : std_logic
+  ) return std_logic_vector is
+    variable cfg : move_cfg_t := move_cfg_default;
+  begin
+    cfg.src_idx := src_idx;
+    cfg.mem_fmt := mem_fmt;
+    cfg.mode := decode_move_cfg_mode(mode);
+    cfg.ctrl_to_reg := ctrl_to_reg;
+    cfg.dst_idx := dst_idx;
+    cfg.ctrl_sel := ctrl_sel;
+    cfg.movem_mask := movem_mask;
+    cfg.movem_dir_to_reg := movem_dir;
+    return encode_move_cfg(cfg);
+  end function;
+
+  -- ----- Bus access procedures (matching existing TB pattern) -----
+
+  procedure bus_write(
+    signal a_in_s : out std_logic_vector(4 downto 0);
+    signal d_in_s : out std_logic_vector(31 downto 0);
+    signal rw_s   : out std_logic;
+    signal cs_n_s : out std_logic;
+    signal as_n_s : out std_logic;
+    signal ds_n_s : out std_logic;
+    constant addr_c : unsigned(4 downto 0);
+    constant data : std_logic_vector(31 downto 0)
+  ) is
+  begin
+    a_in_s <= std_logic_vector(addr_c);
+    d_in_s <= data;
+    rw_s <= '0';
+    cs_n_s <= '0';
+    as_n_s <= '0';
+    ds_n_s <= '0';
+    wait for CLK_PERIOD;
+    cs_n_s <= '1';
+    as_n_s <= '1';
+    ds_n_s <= '1';
+    rw_s <= '1';
+    wait for CLK_PERIOD;
+  end procedure;
+
+  procedure bus_read(
+    signal a_in_s : out std_logic_vector(4 downto 0);
+    signal rw_s   : out std_logic;
+    signal cs_n_s : out std_logic;
+    signal as_n_s : out std_logic;
+    signal ds_n_s : out std_logic;
+    signal dsack0_n_s : in std_logic;
+    signal dsack1_n_s : in std_logic;
+    signal d_out_s : in std_logic_vector(31 downto 0);
+    variable data_s : out std_logic_vector(31 downto 0);
+    constant addr_c : unsigned(4 downto 0)
+  ) is
+  begin
+    a_in_s <= std_logic_vector(addr_c);
+    rw_s <= '1';
+    cs_n_s <= '0';
+    as_n_s <= '0';
+    ds_n_s <= '0';
+    wait until (dsack0_n_s = '0') or (dsack1_n_s = '0');
+    wait for CLK_PERIOD/4;
+    data_s := d_out_s;
+    wait for CLK_PERIOD/4;
+    cs_n_s <= '1';
+    as_n_s <= '1';
+    ds_n_s <= '1';
+    wait for CLK_PERIOD;
+  end procedure;
+
+  procedure wait_for_valid(
+    signal a_in_s : out std_logic_vector(4 downto 0);
+    signal rw_s   : out std_logic;
+    signal cs_n_s : out std_logic;
+    signal as_n_s : out std_logic;
+    signal ds_n_s : out std_logic;
+    signal dsack0_n_s : in std_logic;
+    signal dsack1_n_s : in std_logic;
+    signal d_out_s : in std_logic_vector(31 downto 0);
+    variable status_s : out std_logic_vector(31 downto 0)
+  ) is
+  begin
+    for poll_idx in 0 to 4095 loop
+      bus_read(a_in_s, rw_s, cs_n_s, as_n_s, ds_n_s,
+               dsack0_n_s, dsack1_n_s, d_out_s, status_s, ADDR_STATUS);
+      exit when status_s(0) = '1';
+    end loop;
+    assert status_s(0) = '1'
+      report "Timeout waiting for STATUS.valid"
+      severity failure;
+  end procedure;
+
+  -- ----- FP80 verification -----
+
+  procedure check_fp80(
+    constant got : fp80_t;
+    constant expected : fp80_t;
+    constant test_name : string
+  ) is
+  begin
+    assert got = expected
+      report "FAIL " & test_name &
+             ": expected=" & to_hstring(expected) &
+             " got=" & to_hstring(got)
+      severity failure;
+  end procedure;
+
+  -- ----- CIR Response register read -----
+
+  procedure cir_read_response(
+    signal a_in_s : out std_logic_vector(4 downto 0);
+    signal rw_s   : out std_logic;
+    signal cs_n_s : out std_logic;
+    signal as_n_s : out std_logic;
+    signal ds_n_s : out std_logic;
+    signal dsack0_n_s : in std_logic;
+    signal dsack1_n_s : in std_logic;
+    signal d_out_s : in std_logic_vector(31 downto 0);
+    variable resp : out std_logic_vector(15 downto 0)
+  ) is
+    variable rd : std_logic_vector(31 downto 0) := (others => '0');
+  begin
+    bus_read(a_in_s, rw_s, cs_n_s, as_n_s, ds_n_s,
+             dsack0_n_s, dsack1_n_s, d_out_s, rd, CIR_RESPONSE);
+    resp := rd(15 downto 0);
+  end procedure;
+
+  -- Poll CIR Response until Null (idle), returning the last non-null response seen.
+  procedure cir_poll_until_null(
+    signal a_in_s : out std_logic_vector(4 downto 0);
+    signal rw_s   : out std_logic;
+    signal cs_n_s : out std_logic;
+    signal as_n_s : out std_logic;
+    signal ds_n_s : out std_logic;
+    signal dsack0_n_s : in std_logic;
+    signal dsack1_n_s : in std_logic;
+    signal d_out_s : in std_logic_vector(31 downto 0);
+    variable last_resp : out std_logic_vector(15 downto 0)
+  ) is
+    variable resp : std_logic_vector(15 downto 0) := (others => '0');
+  begin
+    for poll_idx in 0 to 4095 loop
+      cir_read_response(a_in_s, rw_s, cs_n_s, as_n_s, ds_n_s,
+                        dsack0_n_s, dsack1_n_s, d_out_s, resp);
+      if resp = RESP_NULL then
+        exit;
+      end if;
+      last_resp := resp;
+    end loop;
+    assert resp = RESP_NULL
+      report "Timeout polling CIR Response for Null"
+      severity failure;
+  end procedure;
+
+  -- ----- Legacy FP register load helper -----
+  -- Uses the legacy FMOVE (mem→reg) path to load an FP register with a value.
+  procedure legacy_load_fp_reg(
+    signal a_in_s : out std_logic_vector(4 downto 0);
+    signal d_in_s : out std_logic_vector(31 downto 0);
+    signal rw_s   : out std_logic;
+    signal cs_n_s : out std_logic;
+    signal as_n_s : out std_logic;
+    signal ds_n_s : out std_logic;
+    signal dsack0_n_s : in std_logic;
+    signal dsack1_n_s : in std_logic;
+    signal d_out_s : in std_logic_vector(31 downto 0);
+    constant fp_idx : natural range 0 to 7;
+    constant value  : fp80_t
+  ) is
+    variable status_word : std_logic_vector(31 downto 0) := (others => '0');
+    variable cfg_word : std_logic_vector(31 downto 0) := (others => '0');
+  begin
+    -- Write FP80 value to operand A (legacy addresses 1-3).
+    bus_write(a_in_s, d_in_s, rw_s, cs_n_s, as_n_s, ds_n_s,
+              ADDR_OPA_L, value(31 downto 0));
+    bus_write(a_in_s, d_in_s, rw_s, cs_n_s, as_n_s, ds_n_s,
+              ADDR_OPA_H, value(63 downto 32));
+    bus_write(a_in_s, d_in_s, rw_s, cs_n_s, as_n_s, ds_n_s,
+              ADDR_OPA_E, x"0000" & value(79 downto 64));
+    -- Configure FMOVE mem→reg: mode="01", src=0(OPA), dst=fp_idx, fmt="00"(extended).
+    cfg_word := make_move_cfg("01", 0, fp_idx, "00", '0', "00", (others => '0'), '0');
+    bus_write(a_in_s, d_in_s, rw_s, cs_n_s, as_n_s, ds_n_s,
+              ADDR_MOVE_CFG, cfg_word);
+    -- Trigger legacy FMOVE.
+    bus_write(a_in_s, d_in_s, rw_s, cs_n_s, as_n_s, ds_n_s,
+              ADDR_OPSEL, OP_FMOVE);
+    -- Wait for completion.
+    wait_for_valid(a_in_s, rw_s, cs_n_s, as_n_s, ds_n_s,
+                   dsack0_n_s, dsack1_n_s, d_out_s, status_word);
+  end procedure;
+
+  -- ----- Read ALU result from legacy result registers -----
+  procedure read_result_fp80(
+    signal a_in_s : out std_logic_vector(4 downto 0);
+    signal rw_s   : out std_logic;
+    signal cs_n_s : out std_logic;
+    signal as_n_s : out std_logic;
+    signal ds_n_s : out std_logic;
+    signal dsack0_n_s : in std_logic;
+    signal dsack1_n_s : in std_logic;
+    signal d_out_s : in std_logic_vector(31 downto 0);
+    variable result : out fp80_t
+  ) is
+    variable rd_lo : std_logic_vector(31 downto 0) := (others => '0');
+    variable rd_hi : std_logic_vector(31 downto 0) := (others => '0');
+    variable rd_ex : std_logic_vector(31 downto 0) := (others => '0');
+  begin
+    bus_read(a_in_s, rw_s, cs_n_s, as_n_s, ds_n_s,
+             dsack0_n_s, dsack1_n_s, d_out_s, rd_lo, ADDR_RES_L);
+    bus_read(a_in_s, rw_s, cs_n_s, as_n_s, ds_n_s,
+             dsack0_n_s, dsack1_n_s, d_out_s, rd_hi, ADDR_RES_H);
+    bus_read(a_in_s, rw_s, cs_n_s, as_n_s, ds_n_s,
+             dsack0_n_s, dsack1_n_s, d_out_s, rd_ex, ADDR_RES_E);
+    result := rd_ex(15 downto 0) & rd_hi & rd_lo;
+  end procedure;
+
+  -- ----- CIR dialog: execute cpGEN register-to-register -----
+  procedure cpgen_reg_to_reg(
+    signal a_in_s : out std_logic_vector(4 downto 0);
+    signal d_in_s : out std_logic_vector(31 downto 0);
+    signal rw_s   : out std_logic;
+    signal cs_n_s : out std_logic;
+    signal as_n_s : out std_logic;
+    signal ds_n_s : out std_logic;
+    signal dsack0_n_s : in std_logic;
+    signal dsack1_n_s : in std_logic;
+    signal d_out_s : in std_logic_vector(31 downto 0);
+    constant opcode  : std_logic_vector(6 downto 0);
+    constant src_reg : natural range 0 to 7;
+    constant dst_reg : natural range 0 to 7
+  ) is
+    variable status_word : std_logic_vector(31 downto 0) := (others => '0');
+    variable cmd_word : std_logic_vector(31 downto 0) := (others => '0');
+  begin
+    -- Step 1: Write OpWord (cpGEN type).
+    bus_write(a_in_s, d_in_s, rw_s, cs_n_s, as_n_s, ds_n_s,
+              CIR_OPWORD, CPGEN_OPWORD);
+
+    -- Step 2: Write Command word (reg-to-reg, src, dst, opcode).
+    cmd_word := make_cpgen_reg_cmd(src_reg, dst_reg, opcode);
+    bus_write(a_in_s, d_in_s, rw_s, cs_n_s, as_n_s, ds_n_s,
+              CIR_COMMAND, cmd_word);
+
+    -- Step 3: Wait for ALU completion via STATUS.valid polling.
+    -- The CIR FSM transitions IDLE→DECODE→EXECUTE→IDLE; valid fires at end.
+    wait_for_valid(a_in_s, rw_s, cs_n_s, as_n_s, ds_n_s,
+                   dsack0_n_s, dsack1_n_s, d_out_s, status_word);
+  end procedure;
+
+  -- ----- CIR dialog: execute cpGEN with single-precision memory source -----
+  procedure cpgen_mem_single(
+    signal a_in_s : out std_logic_vector(4 downto 0);
+    signal d_in_s : out std_logic_vector(31 downto 0);
+    signal rw_s   : out std_logic;
+    signal cs_n_s : out std_logic;
+    signal as_n_s : out std_logic;
+    signal ds_n_s : out std_logic;
+    signal dsack0_n_s : in std_logic;
+    signal dsack1_n_s : in std_logic;
+    signal d_out_s : in std_logic_vector(31 downto 0);
+    constant opcode  : std_logic_vector(6 downto 0);
+    constant dst_reg : natural range 0 to 7;
+    constant single_val : std_logic_vector(31 downto 0)
+  ) is
+    variable status_word : std_logic_vector(31 downto 0) := (others => '0');
+    variable cmd_word : std_logic_vector(31 downto 0) := (others => '0');
+  begin
+    -- Write OpWord (cpGEN type).
+    bus_write(a_in_s, d_in_s, rw_s, cs_n_s, as_n_s, ds_n_s,
+              CIR_OPWORD, CPGEN_OPWORD);
+    -- Write Command word (memory source, single format).
+    cmd_word := make_cpgen_mem_cmd(CIR_SRC_SINGLE, dst_reg, opcode);
+    bus_write(a_in_s, d_in_s, rw_s, cs_n_s, as_n_s, ds_n_s,
+              CIR_COMMAND, cmd_word);
+    -- FSM enters CIR_XFER_SRC. Write the single-precision operand word.
+    wait for CLK_PERIOD * 2;  -- Let FSM reach CIR_XFER_SRC
+    bus_write(a_in_s, d_in_s, rw_s, cs_n_s, as_n_s, ds_n_s,
+              CIR_OPERAND, single_val);
+    -- Wait for ALU completion.
+    wait_for_valid(a_in_s, rw_s, cs_n_s, as_n_s, ds_n_s,
+                   dsack0_n_s, dsack1_n_s, d_out_s, status_word);
+  end procedure;
+
+  -- ----- CIR dialog: FMOVE FPn to memory (single format) -----
+  procedure cpgen_reg_to_mem_single(
+    signal a_in_s : out std_logic_vector(4 downto 0);
+    signal d_in_s : out std_logic_vector(31 downto 0);
+    signal rw_s   : out std_logic;
+    signal cs_n_s : out std_logic;
+    signal as_n_s : out std_logic;
+    signal ds_n_s : out std_logic;
+    signal dsack0_n_s : in std_logic;
+    signal dsack1_n_s : in std_logic;
+    signal d_out_s : in std_logic_vector(31 downto 0);
+    constant src_reg : natural range 0 to 7;
+    variable single_out : out std_logic_vector(31 downto 0)
+  ) is
+    variable cmd_word : std_logic_vector(31 downto 0) := (others => '0');
+  begin
+    -- Write OpWord (cpGEN type).
+    bus_write(a_in_s, d_in_s, rw_s, cs_n_s, as_n_s, ds_n_s,
+              CIR_OPWORD, CPGEN_OPWORD);
+    -- Write Command word: R/M=0, direction=1 (reg→mem), fmt=Single, src_reg in bits[9:7].
+    -- Note: FMOVE opcode = 0x05 in core_v1 encoding.
+    cmd_word := (others => '0');
+    cmd_word(13) := '1';  -- direction = reg→mem
+    cmd_word(12 downto 10) := CIR_SRC_SINGLE;  -- destination format
+    cmd_word(9 downto 7) := std_logic_vector(to_unsigned(src_reg, 3));
+    cmd_word(6 downto 0) := "0000101";  -- FMOVE opcode (core_v1 = 0x05)
+    bus_write(a_in_s, d_in_s, rw_s, cs_n_s, as_n_s, ds_n_s,
+              CIR_COMMAND, x"0000" & cmd_word(15 downto 0));
+    -- FSM enters CIR_XFER_DST. Wait for staging to be ready.
+    wait for CLK_PERIOD * 3;
+    -- Read 1 word from Operand CIR.
+    bus_read(a_in_s, rw_s, cs_n_s, as_n_s, ds_n_s,
+             dsack0_n_s, dsack1_n_s, d_out_s, single_out, CIR_OPERAND);
+  end procedure;
+
+  -- ----- CIR dialog: execute cpGEN with long-integer memory source -----
+  procedure cpgen_mem_long(
+    signal a_in_s : out std_logic_vector(4 downto 0);
+    signal d_in_s : out std_logic_vector(31 downto 0);
+    signal rw_s   : out std_logic;
+    signal cs_n_s : out std_logic;
+    signal as_n_s : out std_logic;
+    signal ds_n_s : out std_logic;
+    signal dsack0_n_s : in std_logic;
+    signal dsack1_n_s : in std_logic;
+    signal d_out_s : in std_logic_vector(31 downto 0);
+    constant opcode  : std_logic_vector(6 downto 0);
+    constant dst_reg : natural range 0 to 7;
+    constant long_val : std_logic_vector(31 downto 0)
+  ) is
+    variable status_word : std_logic_vector(31 downto 0) := (others => '0');
+    variable cmd_word : std_logic_vector(31 downto 0) := (others => '0');
+  begin
+    bus_write(a_in_s, d_in_s, rw_s, cs_n_s, as_n_s, ds_n_s,
+              CIR_OPWORD, CPGEN_OPWORD);
+    cmd_word := make_cpgen_mem_cmd(CIR_SRC_LONG, dst_reg, opcode);
+    bus_write(a_in_s, d_in_s, rw_s, cs_n_s, as_n_s, ds_n_s,
+              CIR_COMMAND, cmd_word);
+    wait for CLK_PERIOD * 2;
+    bus_write(a_in_s, d_in_s, rw_s, cs_n_s, as_n_s, ds_n_s,
+              CIR_OPERAND, long_val);
+    wait_for_valid(a_in_s, rw_s, cs_n_s, as_n_s, ds_n_s,
+                   dsack0_n_s, dsack1_n_s, d_out_s, status_word);
+  end procedure;
+
+  -- ----- Sized bus access for sub-32-bit peripheral modes -----
+  -- Each 32-bit CIR register access becomes N beats (2 for 16-bit, 4 for 8-bit).
+  -- FPU always captures/presents full 32-bit data; only DSACK encoding changes.
+
+  procedure bus_write_sized(
+    signal a_in_s     : out std_logic_vector(4 downto 0);
+    signal d_in_s     : out std_logic_vector(31 downto 0);
+    signal rw_s       : out std_logic;
+    signal cs_n_s     : out std_logic;
+    signal as_n_s     : out std_logic;
+    signal ds_n_s     : out std_logic;
+    signal size_n_s   : out std_logic_vector(1 downto 0);
+    signal dsack0_n_s : in std_logic;
+    signal dsack1_n_s : in std_logic;
+    constant addr_c   : unsigned(4 downto 0);
+    constant data     : std_logic_vector(31 downto 0);
+    constant sz       : std_logic_vector(1 downto 0);
+    constant beats    : natural
+  ) is
+  begin
+    for beat in 0 to beats - 1 loop
+      size_n_s <= sz;
+      a_in_s <= std_logic_vector(addr_c);
+      d_in_s <= data;
+      rw_s   <= '0';
+      cs_n_s <= '0';
+      as_n_s <= '0';
+      ds_n_s <= '0';
+      wait until (dsack0_n_s = '0') or (dsack1_n_s = '0');
+      if sz = "10" then
+        assert dsack0_n_s = '1' and dsack1_n_s = '0'
+          report "16-bit DSACK mismatch on write beat " & integer'image(beat)
+          severity failure;
+      else
+        assert dsack0_n_s = '0' and dsack1_n_s = '1'
+          report "8-bit DSACK mismatch on write beat " & integer'image(beat)
+          severity failure;
+      end if;
+      cs_n_s <= '1';
+      as_n_s <= '1';
+      ds_n_s <= '1';
+      rw_s   <= '1';
+      wait for CLK_PERIOD;
+    end loop;
+  end procedure;
+
+  procedure bus_read_sized(
+    signal a_in_s     : out std_logic_vector(4 downto 0);
+    signal rw_s       : out std_logic;
+    signal cs_n_s     : out std_logic;
+    signal as_n_s     : out std_logic;
+    signal ds_n_s     : out std_logic;
+    signal size_n_s   : out std_logic_vector(1 downto 0);
+    signal dsack0_n_s : in std_logic;
+    signal dsack1_n_s : in std_logic;
+    signal d_out_s    : in std_logic_vector(31 downto 0);
+    variable data_s   : out std_logic_vector(31 downto 0);
+    constant addr_c   : unsigned(4 downto 0);
+    constant sz       : std_logic_vector(1 downto 0);
+    constant beats    : natural
+  ) is
+  begin
+    for beat in 0 to beats - 1 loop
+      size_n_s <= sz;
+      a_in_s <= std_logic_vector(addr_c);
+      rw_s   <= '1';
+      cs_n_s <= '0';
+      as_n_s <= '0';
+      ds_n_s <= '0';
+      wait until (dsack0_n_s = '0') or (dsack1_n_s = '0');
+      if sz = "10" then
+        assert dsack0_n_s = '1' and dsack1_n_s = '0'
+          report "16-bit DSACK mismatch on read beat " & integer'image(beat)
+          severity failure;
+      else
+        assert dsack0_n_s = '0' and dsack1_n_s = '1'
+          report "8-bit DSACK mismatch on read beat " & integer'image(beat)
+          severity failure;
+      end if;
+      wait for CLK_PERIOD/4;
+      if beat = 0 then
+        data_s := d_out_s;
+      end if;
+      wait for CLK_PERIOD/4;
+      cs_n_s <= '1';
+      as_n_s <= '1';
+      ds_n_s <= '1';
+      wait for CLK_PERIOD;
+    end loop;
+  end procedure;
+
+  procedure wait_for_valid_sized(
+    signal a_in_s     : out std_logic_vector(4 downto 0);
+    signal rw_s       : out std_logic;
+    signal cs_n_s     : out std_logic;
+    signal as_n_s     : out std_logic;
+    signal ds_n_s     : out std_logic;
+    signal size_n_s   : out std_logic_vector(1 downto 0);
+    signal dsack0_n_s : in std_logic;
+    signal dsack1_n_s : in std_logic;
+    signal d_out_s    : in std_logic_vector(31 downto 0);
+    variable status_s : out std_logic_vector(31 downto 0);
+    constant sz       : std_logic_vector(1 downto 0);
+    constant beats    : natural
+  ) is
+  begin
+    for poll_idx in 0 to 4095 loop
+      bus_read_sized(a_in_s, rw_s, cs_n_s, as_n_s, ds_n_s, size_n_s,
+                     dsack0_n_s, dsack1_n_s, d_out_s, status_s,
+                     ADDR_STATUS, sz, beats);
+      exit when status_s(0) = '1';
+    end loop;
+    assert status_s(0) = '1'
+      report "Timeout waiting for STATUS.valid (sized)"
+      severity failure;
+  end procedure;
+
+begin
+  clk <= not clk after CLK_PERIOD/2;
+
+  dut : entity work.mc68881_top
+    port map (
+      a_in     => a_in,
+      d_in     => d_in,
+      d_out    => d_out,
+      size_n   => size_n,
+      as_n     => as_n,
+      cs_n     => cs_n,
+      rw       => rw,
+      ds_n     => ds_n,
+      dsack0_n => dsack0_n,
+      dsack1_n => dsack1_n,
+      reset_n  => reset_n,
+      clk      => clk,
+      sense_n  => sense_n
+    );
+
+  process
+    variable status_word : std_logic_vector(31 downto 0) := (others => '0');
+    variable result_fp80 : fp80_t := (others => '0');
+    variable single_result : std_logic_vector(31 downto 0) := (others => '0');
+    variable resp : std_logic_vector(15 downto 0) := (others => '0');
+    variable last_resp : std_logic_vector(15 downto 0) := (others => '0');
+    variable cmd_word : std_logic_vector(31 downto 0) := (others => '0');
+  begin
+    -- Reset.
+    reset_n <= '0';
+    wait for 2 * CLK_PERIOD;
+    reset_n <= '1';
+    wait for 2 * CLK_PERIOD;
+
+    -- ================================================================
+    -- TEST 1: FADD FP1,FP0 (register-to-register)
+    --   Load FP0=1.0, FP1=2.0, execute FADD FP1,FP0 → FP0 should be 3.0
+    -- ================================================================
+    report "TEST 1: FADD FP1,FP0 (reg-to-reg)" severity note;
+
+    -- Pre-load FP0 with 1.0 via legacy FMOVE.
+    legacy_load_fp_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                       dsack0_n, dsack1_n, d_out, 0, FP80_ONE_VAL);
+
+    -- Pre-load FP1 with 2.0 via legacy FMOVE.
+    legacy_load_fp_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                       dsack0_n, dsack1_n, d_out, 1, FP80_TWO_VAL);
+
+    -- Execute FADD FP1,FP0 via CIR dialog.
+    cpgen_reg_to_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                     dsack0_n, dsack1_n, d_out,
+                     OPCODE_FADD, 1, 0);
+
+    -- Read result from legacy result registers.
+    read_result_fp80(a_in, rw, cs_n, as_n, ds_n,
+                     dsack0_n, dsack1_n, d_out, result_fp80);
+
+    report "FADD result=" & to_hstring(result_fp80) severity note;
+    check_fp80(result_fp80, FP80_THREE_VAL, "FADD FP1,FP0 = 1.0+2.0");
+
+    -- ================================================================
+    -- TEST 2: FSUB FP1,FP0 (register-to-register)
+    --   FP0=3.0 (from test 1), FP1=2.0, FSUB FP1,FP0 → FP0 = 3.0-2.0 = 1.0
+    -- ================================================================
+    report "TEST 2: FSUB FP1,FP0 (reg-to-reg)" severity note;
+
+    cpgen_reg_to_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                     dsack0_n, dsack1_n, d_out,
+                     OPCODE_FSUB, 1, 0);
+
+    read_result_fp80(a_in, rw, cs_n, as_n, ds_n,
+                     dsack0_n, dsack1_n, d_out, result_fp80);
+
+    report "FSUB result=" & to_hstring(result_fp80) severity note;
+    check_fp80(result_fp80, FP80_ONE_VAL, "FSUB FP1,FP0 = 3.0-2.0");
+
+    -- ================================================================
+    -- TEST 3: FMUL FP1,FP0 (register-to-register)
+    --   FP0=1.0 (from test 2), reload FP1=5.0, FMUL FP1,FP0 → FP0 = 5.0
+    -- ================================================================
+    report "TEST 3: FMUL FP1,FP0 (reg-to-reg)" severity note;
+
+    legacy_load_fp_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                       dsack0_n, dsack1_n, d_out, 1, FP80_FIVE_VAL);
+
+    cpgen_reg_to_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                     dsack0_n, dsack1_n, d_out,
+                     OPCODE_FMUL, 1, 0);
+
+    read_result_fp80(a_in, rw, cs_n, as_n, ds_n,
+                     dsack0_n, dsack1_n, d_out, result_fp80);
+
+    report "FMUL result=" & to_hstring(result_fp80) severity note;
+    check_fp80(result_fp80, FP80_FIVE_VAL, "FMUL FP1,FP0 = 1.0*5.0");
+
+    -- ================================================================
+    -- TEST 4: FNEG FP0,FP0 (monadic, register-to-register)
+    --   FP0=5.0, FNEG FP0,FP0 → FP0 = -5.0
+    -- ================================================================
+    report "TEST 4: FNEG FP0,FP0 (reg-to-reg)" severity note;
+
+    cpgen_reg_to_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                     dsack0_n, dsack1_n, d_out,
+                     OPCODE_FNEG, 0, 0);
+
+    read_result_fp80(a_in, rw, cs_n, as_n, ds_n,
+                     dsack0_n, dsack1_n, d_out, result_fp80);
+
+    report "FNEG result=" & to_hstring(result_fp80) severity note;
+    -- -5.0 = 0xC001_A000_0000_0000_0000
+    check_fp80(result_fp80, x"C001A000000000000000", "FNEG FP0,FP0 = -(5.0)");
+
+    -- ================================================================
+    -- TEST 5: FADD.S with single-precision memory source
+    --   FP0 = -5.0 (from test 4), FADD.S #7.0,FP0 → FP0 = -5.0 + 7.0 = 2.0
+    --   Single 7.0 = 0x40E00000
+    -- ================================================================
+    report "TEST 5: FADD.S #7.0,FP0 (memory source)" severity note;
+
+    cpgen_mem_single(a_in, d_in, rw, cs_n, as_n, ds_n,
+                     dsack0_n, dsack1_n, d_out,
+                     OPCODE_FADD, 0, x"40E00000");
+
+    read_result_fp80(a_in, rw, cs_n, as_n, ds_n,
+                     dsack0_n, dsack1_n, d_out, result_fp80);
+
+    report "FADD.S result=" & to_hstring(result_fp80) severity note;
+    check_fp80(result_fp80, FP80_TWO_VAL, "FADD.S #7.0,FP0 = -5.0+7.0");
+
+    -- ================================================================
+    -- TEST 6: FADD.L with long-integer memory source
+    --   FP0 = 2.0 (from test 5), FADD.L #100,FP0 → FP0 = 102.0
+    --   Long integer 100 = 0x00000064
+    -- ================================================================
+    report "TEST 6: FADD.L #100,FP0 (memory source)" severity note;
+
+    cpgen_mem_long(a_in, d_in, rw, cs_n, as_n, ds_n,
+                   dsack0_n, dsack1_n, d_out,
+                   OPCODE_FADD, 0, x"00000064");
+
+    read_result_fp80(a_in, rw, cs_n, as_n, ds_n,
+                     dsack0_n, dsack1_n, d_out, result_fp80);
+
+    -- FP80 102.0 = sign=0, exp=4005 (bias+6), mant=CC00000000000000
+    report "FADD.L result=" & to_hstring(result_fp80) severity note;
+    check_fp80(result_fp80, x"4005CC00000000000000", "FADD.L #100,FP0 = 2.0+100");
+
+    -- ================================================================
+    -- TEST 7: FMOVE FP0 → memory (single-precision destination transfer)
+    --   FP0 = 102.0 (from test 6), read back as single via CIR_XFER_DST
+    --   IEEE 754 single 102.0 = 0x42CC0000
+    -- ================================================================
+    report "TEST 7: FMOVE FP0 -> mem single (destination transfer)" severity note;
+
+    cpgen_reg_to_mem_single(a_in, d_in, rw, cs_n, as_n, ds_n,
+                             dsack0_n, dsack1_n, d_out,
+                             0, single_result);
+
+    report "FMOVE reg->mem single result=" & to_hstring(single_result) severity note;
+    assert single_result = x"42CC0000"
+      report "FAIL FMOVE FP0->mem single: expected=42CC0000 got=" & to_hstring(single_result)
+      severity failure;
+
+    -- ================================================================
+    -- TEST 8: CIR Response verification — reg-to-reg (Busy → Null)
+    --   Reload FP0=1.0, FP1=2.0. Execute FADD via CIR, check Response.
+    -- ================================================================
+    report "TEST 8: CIR Response for reg-to-reg (Busy->Null)" severity note;
+
+    legacy_load_fp_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                       dsack0_n, dsack1_n, d_out, 0, FP80_ONE_VAL);
+    legacy_load_fp_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                       dsack0_n, dsack1_n, d_out, 1, FP80_TWO_VAL);
+
+    -- Before dialog: Response should be Null (idle).
+    cir_read_response(a_in, rw, cs_n, as_n, ds_n,
+                      dsack0_n, dsack1_n, d_out, resp);
+    report "Pre-dialog response=" & to_hstring(resp) severity note;
+    assert resp = RESP_NULL
+      report "FAIL: pre-dialog response not Null: " & to_hstring(resp)
+      severity failure;
+
+    -- Write OpWord + Command to start dialog.
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPWORD, CPGEN_OPWORD);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_COMMAND, make_cpgen_reg_cmd(1, 0, OPCODE_FADD));
+
+    -- Immediately read response — should see Busy (DECODE or EXECUTE).
+    cir_read_response(a_in, rw, cs_n, as_n, ds_n,
+                      dsack0_n, dsack1_n, d_out, resp);
+    report "Mid-dialog response=" & to_hstring(resp) severity note;
+    -- Accept Busy or Null (if ALU finished very quickly).
+    assert resp = RESP_BUSY or resp = RESP_NULL
+      report "FAIL: mid-dialog response not Busy/Null: " & to_hstring(resp)
+      severity failure;
+
+    -- Poll until Null.
+    cir_poll_until_null(a_in, rw, cs_n, as_n, ds_n,
+                        dsack0_n, dsack1_n, d_out, last_resp);
+    report "TEST 8 PASSED" severity note;
+
+    -- ================================================================
+    -- TEST 9: CIR Response verification — memory-source (Transfer Operand)
+    --   FP0=3.0 (from test 8). FADD.S #-1.0 via CIR with response checks.
+    --   Single -1.0 = 0xBF800000
+    -- ================================================================
+    report "TEST 9: CIR Response for mem-source (Transfer Operand)" severity note;
+
+    -- Write OpWord + Command for FADD.S (mem→reg).
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPWORD, CPGEN_OPWORD);
+    cmd_word := make_cpgen_mem_cmd(CIR_SRC_SINGLE, 0, OPCODE_FADD);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_COMMAND, cmd_word);
+
+    -- FSM should be in CIR_XFER_SRC. Read Response → Transfer Operand to-CP.
+    wait for CLK_PERIOD * 2;
+    cir_read_response(a_in, rw, cs_n, as_n, ds_n,
+                      dsack0_n, dsack1_n, d_out, resp);
+    report "Xfer-src response=" & to_hstring(resp) severity note;
+    assert resp = RESP_XFER_TO_CP_4
+      report "FAIL: expected Transfer Operand to-CP ($7004), got " & to_hstring(resp)
+      severity failure;
+
+    -- Write operand data.
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPERAND, x"BF800000");  -- single -1.0
+
+    -- Poll until Null (ALU completes).
+    cir_poll_until_null(a_in, rw, cs_n, as_n, ds_n,
+                        dsack0_n, dsack1_n, d_out, last_resp);
+
+    -- Verify result: 3.0 + (-1.0) = 2.0.
+    read_result_fp80(a_in, rw, cs_n, as_n, ds_n,
+                     dsack0_n, dsack1_n, d_out, result_fp80);
+    check_fp80(result_fp80, FP80_TWO_VAL, "FADD.S #-1.0 via response poll");
+    report "TEST 9 PASSED" severity note;
+
+    -- ================================================================
+    -- TEST 10: CIR Response verification — destination transfer (Transfer from-CP)
+    --   FP0=2.0 (from test 9). FMOVE FP0→mem single with response checks.
+    -- ================================================================
+    report "TEST 10: CIR Response for dst-xfer (Transfer from-CP)" severity note;
+
+    -- Write OpWord + Command for FMOVE FP0→mem single.
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPWORD, CPGEN_OPWORD);
+    cmd_word := (others => '0');
+    cmd_word(13) := '1';  -- direction = reg→mem
+    cmd_word(12 downto 10) := CIR_SRC_SINGLE;
+    cmd_word(9 downto 7) := "000";  -- src_reg = FP0
+    cmd_word(6 downto 0) := "0000101";  -- FMOVE
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_COMMAND, x"0000" & cmd_word(15 downto 0));
+
+    -- FSM should be in CIR_XFER_DST. Read Response → Transfer Operand from-CP.
+    wait for CLK_PERIOD * 3;
+    cir_read_response(a_in, rw, cs_n, as_n, ds_n,
+                      dsack0_n, dsack1_n, d_out, resp);
+    report "Xfer-dst response=" & to_hstring(resp) severity note;
+    assert resp = RESP_XFER_FROM_CP_4
+      report "FAIL: expected Transfer from-CP ($6004), got " & to_hstring(resp)
+      severity failure;
+
+    -- Read the operand data.
+    bus_read(a_in, rw, cs_n, as_n, ds_n,
+             dsack0_n, dsack1_n, d_out, single_result, CIR_OPERAND);
+
+    -- Verify single-precision 2.0 = 0x40000000.
+    assert single_result = x"40000000"
+      report "FAIL: FMOVE FP0->mem single: expected 40000000 got " & to_hstring(single_result)
+      severity failure;
+
+    -- Poll until Null.
+    cir_poll_until_null(a_in, rw, cs_n, as_n, ds_n,
+                        dsack0_n, dsack1_n, d_out, last_resp);
+    report "TEST 10 PASSED" severity note;
+
+    -- ================================================================
+    -- TEST 11: FMUL 3.5 * (-2.25) = -7.875 (E2E with non-trivial FP values)
+    --   Load FP0=3.5 via CIR mem-source FMOVE.S (0x40600000)
+    --   Load FP1=-2.25 via CIR mem-source FMOVE.S (0xC0100000)
+    --   FMUL FP1,FP0 → FP0 = -7.875
+    --   Readback via FMOVE FP0→mem single → 0xC0FC0000
+    -- ================================================================
+    report "TEST 11: FMUL 3.5 * (-2.25) = -7.875 (E2E)" severity note;
+
+    -- Load FP0 = 3.5 via CIR FMOVE.S
+    cpgen_mem_single(a_in, d_in, rw, cs_n, as_n, ds_n,
+                     dsack0_n, dsack1_n, d_out,
+                     OPCODE_FMOVE, 0, x"40600000");  -- 3.5
+
+    -- Load FP1 = -2.25 via CIR FMOVE.S
+    cpgen_mem_single(a_in, d_in, rw, cs_n, as_n, ds_n,
+                     dsack0_n, dsack1_n, d_out,
+                     OPCODE_FMOVE, 1, x"C0100000");  -- -2.25
+
+    -- FMUL FP1,FP0
+    cpgen_reg_to_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                     dsack0_n, dsack1_n, d_out,
+                     OPCODE_FMUL, 1, 0);
+
+    -- Readback as single
+    cpgen_reg_to_mem_single(a_in, d_in, rw, cs_n, as_n, ds_n,
+                             dsack0_n, dsack1_n, d_out,
+                             0, single_result);
+
+    report "TEST 11 result=" & to_hstring(single_result) severity note;
+    assert single_result = x"C0FC0000"
+      report "FAIL TEST 11: FMUL 3.5*(-2.25) expected=C0FC0000 got=" & to_hstring(single_result)
+      severity failure;
+    report "TEST 11 PASSED" severity note;
+
+    -- ================================================================
+    -- TEST 12: FSUB (-7.875) - (-2.25) = -5.625
+    --   FP0=-7.875 (from test 11), FP1=-2.25 (from test 11)
+    --   FSUB FP1,FP0 → FP0 = (-7.875) - (-2.25) = -5.625
+    --   Readback → 0xC0B40000
+    -- ================================================================
+    report "TEST 12: FSUB (-7.875) - (-2.25) = -5.625 (E2E)" severity note;
+
+    cpgen_reg_to_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                     dsack0_n, dsack1_n, d_out,
+                     OPCODE_FSUB, 1, 0);
+
+    cpgen_reg_to_mem_single(a_in, d_in, rw, cs_n, as_n, ds_n,
+                             dsack0_n, dsack1_n, d_out,
+                             0, single_result);
+
+    report "TEST 12 result=" & to_hstring(single_result) severity note;
+    assert single_result = x"C0B40000"
+      report "FAIL TEST 12: FSUB expected=C0B40000 got=" & to_hstring(single_result)
+      severity failure;
+    report "TEST 12 PASSED" severity note;
+
+    -- ================================================================
+    -- TEST 13: FADD.S #12.375 + (-5.625) = 6.75
+    --   FP0=-5.625 (from test 12)
+    --   FADD.S #12.375 (0x41460000) via CIR mem-source → FP0 = 6.75
+    --   Readback → 0x40D80000
+    -- ================================================================
+    report "TEST 13: FADD.S #12.375 + (-5.625) = 6.75 (E2E)" severity note;
+
+    cpgen_mem_single(a_in, d_in, rw, cs_n, as_n, ds_n,
+                     dsack0_n, dsack1_n, d_out,
+                     OPCODE_FADD, 0, x"41460000");  -- 12.375
+
+    cpgen_reg_to_mem_single(a_in, d_in, rw, cs_n, as_n, ds_n,
+                             dsack0_n, dsack1_n, d_out,
+                             0, single_result);
+
+    report "TEST 13 result=" & to_hstring(single_result) severity note;
+    assert single_result = x"40D80000"
+      report "FAIL TEST 13: FADD.S expected=40D80000 got=" & to_hstring(single_result)
+      severity failure;
+    report "TEST 13 PASSED" severity note;
+
+    -- ================================================================
+    -- TEST 14: FDIV 6.75 / (-2.25) = -3.0
+    --   FP0=6.75 (from test 13), FP1=-2.25 (still loaded)
+    --   FDIV FP1,FP0 → FP0 = 6.75 / (-2.25) = -3.0
+    --   Readback → 0xC0400000
+    -- ================================================================
+    report "TEST 14: FDIV 6.75 / (-2.25) = -3.0 (E2E)" severity note;
+
+    cpgen_reg_to_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                     dsack0_n, dsack1_n, d_out,
+                     OPCODE_FDIV, 1, 0);
+
+    cpgen_reg_to_mem_single(a_in, d_in, rw, cs_n, as_n, ds_n,
+                             dsack0_n, dsack1_n, d_out,
+                             0, single_result);
+
+    report "TEST 14 result=" & to_hstring(single_result) severity note;
+    assert single_result = x"C0400000"
+      report "FAIL TEST 14: FDIV expected=C0400000 got=" & to_hstring(single_result)
+      severity failure;
+    report "TEST 14 PASSED" severity note;
+
+    -- ================================================================
+    -- TEST 15: 16-bit peripheral mode E2E
+    --   All CIR accesses use size_n="10" (16-bit port, 2 beats per access).
+    --   Verifies DSACK encoding (dsack0_n='1', dsack1_n='0') on every beat.
+    --   Load FP2=10.0, FP3=3.0, FADD FP3,FP2 → 13.0, readback → 0x41500000
+    -- ================================================================
+    report "TEST 15: 16-bit peripheral mode E2E" severity note;
+
+    -- Load FP2 = 10.0 via CIR FMOVE.S (16-bit bus, 2 beats per access)
+    bus_write_sized(a_in, d_in, rw, cs_n, as_n, ds_n, size_n,
+                    dsack0_n, dsack1_n, CIR_OPWORD, CPGEN_OPWORD, "10", 2);
+    cmd_word := make_cpgen_mem_cmd(CIR_SRC_SINGLE, 2, OPCODE_FMOVE);
+    bus_write_sized(a_in, d_in, rw, cs_n, as_n, ds_n, size_n,
+                    dsack0_n, dsack1_n, CIR_COMMAND, cmd_word, "10", 2);
+    wait for CLK_PERIOD * 2;
+    bus_write_sized(a_in, d_in, rw, cs_n, as_n, ds_n, size_n,
+                    dsack0_n, dsack1_n, CIR_OPERAND, x"41200000", "10", 2);
+    wait_for_valid_sized(a_in, rw, cs_n, as_n, ds_n, size_n,
+                         dsack0_n, dsack1_n, d_out, status_word, "10", 2);
+
+    -- Load FP3 = 3.0 via CIR FMOVE.S (16-bit bus)
+    bus_write_sized(a_in, d_in, rw, cs_n, as_n, ds_n, size_n,
+                    dsack0_n, dsack1_n, CIR_OPWORD, CPGEN_OPWORD, "10", 2);
+    cmd_word := make_cpgen_mem_cmd(CIR_SRC_SINGLE, 3, OPCODE_FMOVE);
+    bus_write_sized(a_in, d_in, rw, cs_n, as_n, ds_n, size_n,
+                    dsack0_n, dsack1_n, CIR_COMMAND, cmd_word, "10", 2);
+    wait for CLK_PERIOD * 2;
+    bus_write_sized(a_in, d_in, rw, cs_n, as_n, ds_n, size_n,
+                    dsack0_n, dsack1_n, CIR_OPERAND, x"40400000", "10", 2);
+    wait_for_valid_sized(a_in, rw, cs_n, as_n, ds_n, size_n,
+                         dsack0_n, dsack1_n, d_out, status_word, "10", 2);
+
+    -- FADD FP3,FP2 via CIR reg-to-reg (16-bit bus)
+    bus_write_sized(a_in, d_in, rw, cs_n, as_n, ds_n, size_n,
+                    dsack0_n, dsack1_n, CIR_OPWORD, CPGEN_OPWORD, "10", 2);
+    cmd_word := make_cpgen_reg_cmd(3, 2, OPCODE_FADD);
+    bus_write_sized(a_in, d_in, rw, cs_n, as_n, ds_n, size_n,
+                    dsack0_n, dsack1_n, CIR_COMMAND, cmd_word, "10", 2);
+    wait_for_valid_sized(a_in, rw, cs_n, as_n, ds_n, size_n,
+                         dsack0_n, dsack1_n, d_out, status_word, "10", 2);
+
+    -- Readback FP2 as single via CIR FMOVE reg→mem (16-bit bus)
+    bus_write_sized(a_in, d_in, rw, cs_n, as_n, ds_n, size_n,
+                    dsack0_n, dsack1_n, CIR_OPWORD, CPGEN_OPWORD, "10", 2);
+    cmd_word := (others => '0');
+    cmd_word(13) := '1';  -- direction = reg→mem
+    cmd_word(12 downto 10) := CIR_SRC_SINGLE;
+    cmd_word(9 downto 7) := "010";  -- FP2
+    cmd_word(6 downto 0) := OPCODE_FMOVE;
+    bus_write_sized(a_in, d_in, rw, cs_n, as_n, ds_n, size_n,
+                    dsack0_n, dsack1_n, CIR_COMMAND,
+                    x"0000" & cmd_word(15 downto 0), "10", 2);
+    wait for CLK_PERIOD * 3;
+    bus_read_sized(a_in, rw, cs_n, as_n, ds_n, size_n,
+                   dsack0_n, dsack1_n, d_out, single_result,
+                   CIR_OPERAND, "10", 2);
+
+    size_n <= "11";  -- restore 32-bit mode
+    report "TEST 15 result=" & to_hstring(single_result) severity note;
+    assert single_result = x"41500000"
+      report "FAIL TEST 15: 16-bit E2E FADD 10+3=13 expected=41500000 got=" &
+             to_hstring(single_result)
+      severity failure;
+    report "TEST 15 PASSED" severity note;
+
+    -- ================================================================
+    -- TEST 16: 8-bit peripheral mode E2E
+    --   All CIR accesses use size_n="01" (8-bit port, 4 beats per access).
+    --   Verifies DSACK encoding (dsack0_n='0', dsack1_n='1') on every beat.
+    --   Load FP4=8.0, FMUL.S #0.5,FP4 → 4.0, readback → 0x40800000
+    -- ================================================================
+    report "TEST 16: 8-bit peripheral mode E2E" severity note;
+
+    -- Load FP4 = 8.0 via CIR FMOVE.S (8-bit bus, 4 beats per access)
+    bus_write_sized(a_in, d_in, rw, cs_n, as_n, ds_n, size_n,
+                    dsack0_n, dsack1_n, CIR_OPWORD, CPGEN_OPWORD, "01", 4);
+    cmd_word := make_cpgen_mem_cmd(CIR_SRC_SINGLE, 4, OPCODE_FMOVE);
+    bus_write_sized(a_in, d_in, rw, cs_n, as_n, ds_n, size_n,
+                    dsack0_n, dsack1_n, CIR_COMMAND, cmd_word, "01", 4);
+    wait for CLK_PERIOD * 2;
+    bus_write_sized(a_in, d_in, rw, cs_n, as_n, ds_n, size_n,
+                    dsack0_n, dsack1_n, CIR_OPERAND, x"41000000", "01", 4);
+    wait_for_valid_sized(a_in, rw, cs_n, as_n, ds_n, size_n,
+                         dsack0_n, dsack1_n, d_out, status_word, "01", 4);
+
+    -- FMUL.S #0.5,FP4 via CIR mem-source (8-bit bus)
+    bus_write_sized(a_in, d_in, rw, cs_n, as_n, ds_n, size_n,
+                    dsack0_n, dsack1_n, CIR_OPWORD, CPGEN_OPWORD, "01", 4);
+    cmd_word := make_cpgen_mem_cmd(CIR_SRC_SINGLE, 4, OPCODE_FMUL);
+    bus_write_sized(a_in, d_in, rw, cs_n, as_n, ds_n, size_n,
+                    dsack0_n, dsack1_n, CIR_COMMAND, cmd_word, "01", 4);
+    wait for CLK_PERIOD * 2;
+    bus_write_sized(a_in, d_in, rw, cs_n, as_n, ds_n, size_n,
+                    dsack0_n, dsack1_n, CIR_OPERAND, x"3F000000", "01", 4);
+    wait_for_valid_sized(a_in, rw, cs_n, as_n, ds_n, size_n,
+                         dsack0_n, dsack1_n, d_out, status_word, "01", 4);
+
+    -- Readback FP4 as single via CIR FMOVE reg→mem (8-bit bus)
+    bus_write_sized(a_in, d_in, rw, cs_n, as_n, ds_n, size_n,
+                    dsack0_n, dsack1_n, CIR_OPWORD, CPGEN_OPWORD, "01", 4);
+    cmd_word := (others => '0');
+    cmd_word(13) := '1';  -- direction = reg→mem
+    cmd_word(12 downto 10) := CIR_SRC_SINGLE;
+    cmd_word(9 downto 7) := "100";  -- FP4
+    cmd_word(6 downto 0) := OPCODE_FMOVE;
+    bus_write_sized(a_in, d_in, rw, cs_n, as_n, ds_n, size_n,
+                    dsack0_n, dsack1_n, CIR_COMMAND,
+                    x"0000" & cmd_word(15 downto 0), "01", 4);
+    wait for CLK_PERIOD * 3;
+    bus_read_sized(a_in, rw, cs_n, as_n, ds_n, size_n,
+                   dsack0_n, dsack1_n, d_out, single_result,
+                   CIR_OPERAND, "01", 4);
+
+    size_n <= "11";  -- restore 32-bit mode
+    report "TEST 16 result=" & to_hstring(single_result) severity note;
+    assert single_result = x"40800000"
+      report "FAIL TEST 16: 8-bit E2E FMUL 8*0.5=4 expected=40800000 got=" &
+             to_hstring(single_result)
+      severity failure;
+    report "TEST 16 PASSED" severity note;
+
+    -- ================================================================
+    -- TEST 17: FADD.B #3, FP0 (byte-integer memory source)
+    --   Reload FP0 = 2.0, then FADD.B #3 → 5.0
+    --   CIR_SRC_BYTE = "110", 1 word, lower 8 bits sign-extended
+    -- ================================================================
+    report "TEST 17: FADD.B #3 (byte source)" severity note;
+
+    cpgen_mem_single(a_in, d_in, rw, cs_n, as_n, ds_n,
+                     dsack0_n, dsack1_n, d_out,
+                     OPCODE_FMOVE, 0, x"40000000");  -- Load FP0 = 2.0
+
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPWORD, CPGEN_OPWORD);
+    cmd_word := make_cpgen_mem_cmd(CIR_SRC_BYTE, 0, OPCODE_FADD);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_COMMAND, cmd_word);
+    wait for CLK_PERIOD * 2;
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPERAND, x"00000003");  -- byte 3
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n,
+                   dsack0_n, dsack1_n, d_out, status_word);
+
+    cpgen_reg_to_mem_single(a_in, d_in, rw, cs_n, as_n, ds_n,
+                             dsack0_n, dsack1_n, d_out,
+                             0, single_result);
+    report "TEST 17 result=" & to_hstring(single_result) severity note;
+    assert single_result = x"40A00000"
+      report "FAIL TEST 17: FADD.B 2+3=5 expected=40A00000 got=" &
+             to_hstring(single_result)
+      severity failure;
+    report "TEST 17 PASSED" severity note;
+
+    -- ================================================================
+    -- TEST 18: FMUL.W #-4, FP0 (word-integer memory source)
+    --   FP0 = 5.0 (from test 17), FMUL.W #-4 → -20.0
+    --   CIR_SRC_WORD = "100", 1 word, lower 16 bits sign-extended
+    --   Signed word -4 = 0xFFFC
+    -- ================================================================
+    report "TEST 18: FMUL.W #-4 (word source)" severity note;
+
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPWORD, CPGEN_OPWORD);
+    cmd_word := make_cpgen_mem_cmd(CIR_SRC_WORD, 0, OPCODE_FMUL);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_COMMAND, cmd_word);
+    wait for CLK_PERIOD * 2;
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPERAND, x"0000FFFC");  -- word -4
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n,
+                   dsack0_n, dsack1_n, d_out, status_word);
+
+    cpgen_reg_to_mem_single(a_in, d_in, rw, cs_n, as_n, ds_n,
+                             dsack0_n, dsack1_n, d_out,
+                             0, single_result);
+    report "TEST 18 result=" & to_hstring(single_result) severity note;
+    assert single_result = x"C1A00000"
+      report "FAIL TEST 18: FMUL.W 5*(-4)=-20 expected=C1A00000 got=" &
+             to_hstring(single_result)
+      severity failure;
+    report "TEST 18 PASSED" severity note;
+
+    -- ================================================================
+    -- TEST 19: FSUB.L #7, FP0 (long-integer memory source)
+    --   FP0 = -20.0 (from test 18), FSUB.L #7 → -27.0
+    --   CIR_SRC_LONG = "000", 1 word, 32-bit signed integer
+    -- ================================================================
+    report "TEST 19: FSUB.L #7 (long source)" severity note;
+
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPWORD, CPGEN_OPWORD);
+    cmd_word := make_cpgen_mem_cmd(CIR_SRC_LONG, 0, OPCODE_FSUB);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_COMMAND, cmd_word);
+    wait for CLK_PERIOD * 2;
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPERAND, x"00000007");  -- long 7
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n,
+                   dsack0_n, dsack1_n, d_out, status_word);
+
+    cpgen_reg_to_mem_single(a_in, d_in, rw, cs_n, as_n, ds_n,
+                             dsack0_n, dsack1_n, d_out,
+                             0, single_result);
+    report "TEST 19 result=" & to_hstring(single_result) severity note;
+    assert single_result = x"C1D80000"
+      report "FAIL TEST 19: FSUB.L (-20)-7=-27 expected=C1D80000 got=" &
+             to_hstring(single_result)
+      severity failure;
+    report "TEST 19 PASSED" severity note;
+
+    -- ================================================================
+    -- TEST 20: FADD.P #70, FP0 (packed-decimal memory source)
+    --   FP0 = -27.0 (from test 19), FADD.P #70 → 43.0
+    --   CIR_SRC_PACKED = "011", 3 words
+    --   Packed 70.0: SM=0, SE=0, YY=00, exp=0001, int_digit=7, frac=0
+    --   Word 0 (MSW): 0x00010007
+    --   Word 1: 0x00000000
+    --   Word 2 (LSW): 0x00000000
+    -- ================================================================
+    report "TEST 20: FADD.P #70 (packed decimal source)" severity note;
+
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPWORD, CPGEN_OPWORD);
+    cmd_word := make_cpgen_mem_cmd(CIR_SRC_PACKED, 0, OPCODE_FADD);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_COMMAND, cmd_word);
+    wait for CLK_PERIOD * 2;
+    -- Write 3 operand words (MSW first).
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPERAND, x"00010007");  -- word 0: SM=0, exp=001, digit=7
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPERAND, x"00000000");  -- word 1: frac digits = 0
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPERAND, x"00000000");  -- word 2: frac digits = 0
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n,
+                   dsack0_n, dsack1_n, d_out, status_word);
+
+    cpgen_reg_to_mem_single(a_in, d_in, rw, cs_n, as_n, ds_n,
+                             dsack0_n, dsack1_n, d_out,
+                             0, single_result);
+    report "TEST 20 result=" & to_hstring(single_result) severity note;
+    assert single_result = x"422C0000"
+      report "FAIL TEST 20: FADD.P (-27)+70=43 expected=422C0000 got=" &
+             to_hstring(single_result)
+      severity failure;
+    report "TEST 20 PASSED" severity note;
+
+    -- ================================================================
+    -- TEST 21: FDIV.B #3, FP5 (byte → repeating binary fraction)
+    --   FP5 = 10.0, FDIV.B #3 → 10/3 ≈ 3.3333...
+    --   10/3 = 1.10101010... × 2^1, guard=0 → round down
+    -- ================================================================
+    report "TEST 21: FDIV.B #3 -> 10/3 (fractional)" severity note;
+
+    cpgen_mem_single(a_in, d_in, rw, cs_n, as_n, ds_n,
+                     dsack0_n, dsack1_n, d_out,
+                     OPCODE_FMOVE, 5, x"41200000");  -- FP5 = 10.0
+
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPWORD, CPGEN_OPWORD);
+    cmd_word := make_cpgen_mem_cmd(CIR_SRC_BYTE, 5, OPCODE_FDIV);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_COMMAND, cmd_word);
+    wait for CLK_PERIOD * 2;
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPERAND, x"00000003");
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n,
+                   dsack0_n, dsack1_n, d_out, status_word);
+
+    cpgen_reg_to_mem_single(a_in, d_in, rw, cs_n, as_n, ds_n,
+                             dsack0_n, dsack1_n, d_out,
+                             5, single_result);
+    report "TEST 21 result=" & to_hstring(single_result) severity note;
+    assert single_result = x"40555555"
+      report "FAIL TEST 21: FDIV.B 10/3 expected=40555555 got=" &
+             to_hstring(single_result)
+      severity failure;
+    report "TEST 21 PASSED" severity note;
+
+    -- ================================================================
+    -- TEST 22: FDIV.W #7, FP5 (word → repeating binary fraction)
+    --   FP5 = 10.0, FDIV.W #7 → 10/7 ≈ 1.4286
+    --   10/7 = 1.011011011... × 2^0, guard=1 → round up
+    -- ================================================================
+    report "TEST 22: FDIV.W #7 -> 10/7 (fractional)" severity note;
+
+    cpgen_mem_single(a_in, d_in, rw, cs_n, as_n, ds_n,
+                     dsack0_n, dsack1_n, d_out,
+                     OPCODE_FMOVE, 5, x"41200000");  -- FP5 = 10.0
+
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPWORD, CPGEN_OPWORD);
+    cmd_word := make_cpgen_mem_cmd(CIR_SRC_WORD, 5, OPCODE_FDIV);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_COMMAND, cmd_word);
+    wait for CLK_PERIOD * 2;
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPERAND, x"00000007");
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n,
+                   dsack0_n, dsack1_n, d_out, status_word);
+
+    cpgen_reg_to_mem_single(a_in, d_in, rw, cs_n, as_n, ds_n,
+                             dsack0_n, dsack1_n, d_out,
+                             5, single_result);
+    report "TEST 22 result=" & to_hstring(single_result) severity note;
+    assert single_result = x"3FB6DB6E"
+      report "FAIL TEST 22: FDIV.W 10/7 expected=3FB6DB6E got=" &
+             to_hstring(single_result)
+      severity failure;
+    report "TEST 22 PASSED" severity note;
+
+    -- ================================================================
+    -- TEST 23: FDIV.L #-3, FP5 (long → negative repeating fraction)
+    --   FP5 = 10.0, FDIV.L #-3 → -10/3 ≈ -3.3333...
+    --   Same magnitude as test 21, sign flipped.
+    -- ================================================================
+    report "TEST 23: FDIV.L #-3 -> -10/3 (fractional)" severity note;
+
+    cpgen_mem_single(a_in, d_in, rw, cs_n, as_n, ds_n,
+                     dsack0_n, dsack1_n, d_out,
+                     OPCODE_FMOVE, 5, x"41200000");  -- FP5 = 10.0
+
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPWORD, CPGEN_OPWORD);
+    cmd_word := make_cpgen_mem_cmd(CIR_SRC_LONG, 5, OPCODE_FDIV);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_COMMAND, cmd_word);
+    wait for CLK_PERIOD * 2;
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPERAND, x"FFFFFFFD");  -- long -3
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n,
+                   dsack0_n, dsack1_n, d_out, status_word);
+
+    cpgen_reg_to_mem_single(a_in, d_in, rw, cs_n, as_n, ds_n,
+                             dsack0_n, dsack1_n, d_out,
+                             5, single_result);
+    report "TEST 23 result=" & to_hstring(single_result) severity note;
+    assert single_result = x"C0555555"
+      report "FAIL TEST 23: FDIV.L 10/(-3) expected=C0555555 got=" &
+             to_hstring(single_result)
+      severity failure;
+    report "TEST 23 PASSED" severity note;
+
+    -- ================================================================
+    -- TEST 24: FDIV.P packed(6), FP5 (packed-decimal → fractional)
+    --   FP5 = 10.0, FDIV.P #6 → 10/6 = 5/3 ≈ 1.6667
+    --   5/3 = 1.10101010... × 2^0, guard=0 → round down
+    -- ================================================================
+    report "TEST 24: FDIV.P #6 -> 10/6 (fractional)" severity note;
+
+    cpgen_mem_single(a_in, d_in, rw, cs_n, as_n, ds_n,
+                     dsack0_n, dsack1_n, d_out,
+                     OPCODE_FMOVE, 5, x"41200000");  -- FP5 = 10.0
+
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPWORD, CPGEN_OPWORD);
+    cmd_word := make_cpgen_mem_cmd(CIR_SRC_PACKED, 5, OPCODE_FDIV);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_COMMAND, cmd_word);
+    wait for CLK_PERIOD * 2;
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPERAND, x"00000006");  -- word 0: digit=6, exp=0
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPERAND, x"00000000");  -- word 1
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPERAND, x"00000000");  -- word 2
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n,
+                   dsack0_n, dsack1_n, d_out, status_word);
+
+    cpgen_reg_to_mem_single(a_in, d_in, rw, cs_n, as_n, ds_n,
+                             dsack0_n, dsack1_n, d_out,
+                             5, single_result);
+    report "TEST 24 result=" & to_hstring(single_result) severity note;
+    assert single_result = x"3FD55555"
+      report "FAIL TEST 24: FDIV.P 10/6 expected=3FD55555 got=" &
+             to_hstring(single_result)
+      severity failure;
+    report "TEST 24 PASSED" severity note;
+
+    -- ================================================================
+    report "All CIR dialog tests PASSED" severity note;
+    std.env.finish;
+  end process;
+
+end architecture sim;


### PR DESCRIPTION
## Summary

### Section 7: CIR Coprocessor Interface (Phase 1)
- CIR types, constants, and helper functions in package
- CIR dialog signals wired to top-level
- CIR dialog FSM skeleton with state transitions and response generation
- cpGEN reg-to-reg path through dialog FSM to ALU
- CIR memory-source/destination transfers with E2E tests

### LUT Reduction (8 phases, est. 7K-10.8K LUT savings)
- **Phase 1**: Packed decimal divider elimination — SLV bit indexing replaces 11 parallel dividers
- **Phase 2**: Trig `fintrz_fp80` de-duplication — 4 calls to 1 shared concurrent signal
- **Phase 3**: Trig `fgetman_fp80` de-duplication — 2 calls to shared concurrent signals
- **Phase 4**: Trig `compare_fp80` consolidation — 9 calls replaced with direct unsigned field comparisons
- **Phase 5**: Packed decimal ST_ENC_KROUND carry serialization — loop to per-digit FSM
- **Phase 6**: Packed decimal ST_ENC_POSTROUND carry serialization — reuses Phase 5 registers
- **Phase 7**: ALU `compute_simple_result` selective dispatch — inline case for branch pruning
- **Phase 8**: Top-level format converter sharing — single `fp80_to_single`/`fp80_to_double` instance

### PR Review Fixes
- Fix CIR reg-to-reg FMOVE leaving command flags asserted (re-trigger bug)
- Edge-detect operand CIR writes to prevent multi-pulse from sustained bus strobes
- Gate CIR arithmetic writeback for CMP/TST (condition-code-only ops)

## Test plan
- [x] All GHDL tests pass (microseq, ALU, packed decimal, trig, top-level, FMOVE, CIR dialog)
- [x] Vivado synthesis to measure actual LUT delta
- [x] Vivado implementation — verify timing closure (WNS > 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)