### PR TITLE
Implement exception dialog paths and FPIAR capture (S7 Phase 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,20 +33,20 @@ The current plan and progress tracking live in `docs/fpu-progress-checklist.md`.
 
 | Resource | Used | Available | Util% |
 |----------|------|-----------|-------|
-| Slice LUTs | 64,641 | 133,800 | 48.31% |
-| Registers | 13,096 | 267,600 | 4.89% |
+| Slice LUTs | 52,361 | 133,800 | 39.13% |
+| Registers | 13,131 | 267,600 | 4.91% |
 | Block RAM | 5 tiles | 365 | 1.37% |
 | DSP48E1 | 33 | 740 | 4.46% |
 
-*Non-incremental synthesis + implementation, Vivado 2025.2, `xc7a200tfbg676-1`. Date: 2026-03-04.
-Includes Section 7 CIR coprocessor interface with FSAVE/FRESTORE Busy frame support (~7K LUTs);
-see "CIR feature gating" below.*
+*Non-incremental synthesis + implementation, Vivado 2025.2, `xc7a200tfbg676-1`. Date: 2026-03-05.
+Includes Section 7 CIR coprocessor interface with FSAVE/FRESTORE Busy frame support and
+full exception dialog paths; see "CIR feature gating" below.*
 
 ### Timing
 - Target clock: 10 MHz (100 ns period) — matches MC68881 bus timing.
 - Multi-cycle path constraints on sequential FP units (mul: 4 cycles, addsub: 6 cycles,
   div: 6 cycles) and trig engine hold states.
-- Post-route physopt WNS: **+8.700 ns** (87% slack margin at 100 ns period).
+- Post-route WNS: **+16.631 ns** (83% slack margin at 100 ns period; effective Fmax ~12 MHz).
 - WHS (hold): no violations.
 
 ### Target device compatibility
@@ -55,9 +55,9 @@ the core is ~58K LUTs and fits comfortably on smaller devices:
 
 | Device | LUTs | DSPs | Fit (full)? | Fit (no CIR)? |
 |--------|------|------|-------------|---------------|
-| Xilinx Artix-7 200T | 134,600 | 740 | Yes (48%) | Yes (43%) |
-| Xilinx Artix-7 100T | 63,400 | 240 | Yes (~102%) | Yes (~91%) |
-| Xilinx Zynq UltraScale+ ZU3EG | ~71,000 | 360 | Yes (~91%) | Yes (~82%) |
+| Xilinx Artix-7 200T | 134,600 | 740 | Yes (39%) | Yes (34%) |
+| Xilinx Artix-7 100T | 63,400 | 240 | Yes (~83%) | Yes (~72%) |
+| Xilinx Zynq UltraScale+ ZU3EG | ~71,000 | 360 | Yes (~74%) | Yes (~64%) |
 | Intel Cyclone V 5CEBA7 | 150,720 ALMs | 156 | Yes | Yes |
 
 All RTL is vendor-portable (inferred DSP/BRAM, no Xilinx IP cores). Porting to
@@ -165,11 +165,11 @@ use only the register-mapped peripheral interface. The CIR generic defaults to
 `true`.
 
 ## Remaining work
-- **Section 7 coprocessor interface (Phase 4+)**: Full exception dialog paths
-  (pre/mid/BSUN/format), FPIAR capture points, and protocol/cycle testbenches.
-  Phases 1-3 (CIR types, dialog FSM, reg-to-reg, memory-source/destination
-  transfers, conditional dialog paths for FBcc/FDBcc/FScc/FTRAPcc/FNOP,
-  FSAVE/FRESTORE with Null/Idle/Busy frames) are complete.
+- **Section 7 coprocessor interface (Phase 5)**: Close timing/cycle tests and
+  regression matrix. Phases 1-4 are complete (CIR types, dialog FSM, reg-to-reg,
+  memory-source/destination transfers, conditional dialog paths for
+  FBcc/FDBcc/FScc/FTRAPcc/FNOP, FSAVE/FRESTORE with Null/Idle/Busy frames,
+  exception dialog paths, FPIAR capture).
 - **Test coverage**: Denormal handling (C1), exception detection expansion (C3),
   FPCR/FPSR architectural field completeness (C4), FPIAR tracking (C5),
   per-opcode self-checking testbenches (D1), cycle-count verification (D4),

--- a/docs/fpu-progress-checklist.md
+++ b/docs/fpu-progress-checklist.md
@@ -458,6 +458,29 @@ Keep this list short, actionable, and updated whenever a defect is fixed or newl
 - Follow-up:
   - Keep `tb/tb_mc68881_known_defects.vhd` as a persistent recheck for this vector.
 
+## Implementation Snapshot (2026-03-05, Phase 4)
+- Milestone:
+  - Section 7 CIR Phase 4 complete (exception dialog paths, FPIAR capture).
+  - Tree-based CLZ optimization: replaced all sequential 64-iteration CLZ loops
+    (fgetexp_fp80, fgetman_fp80, fgetexp_unbiased_int, packed-decimal encoder/decoder,
+    addsub count_leading_zeros) with a shared `clz()` function in mc68881_pkg using
+    binary-halving tree structure. Reduces synthesis from ~64-125 cascaded priority
+    encoder stages to ~6-11 LUT levels.
+  - Critical path moved from trig CLZ (682 logic levels, 399.9ns) to packed-decimal
+    scaling path (112 logic levels, 83.3ns) — a fundamentally different bottleneck.
+  - LUT usage dropped ~10 percentage points (49% → 39%) due to elimination of
+    cascaded mux chains from sequential CLZ synthesis.
+  - New worst path: `cir_operand_staging_reg[12]` → `operand_reg_reg[1][76]`
+    (packed-decimal-to-FP80 conversion via scale_fp80_by_pow10).
+  - Effective Fmax: ~12 MHz (up from ~10 MHz practical limit in Phase 3).
+- Run data (non-incremental synthesis + implementation):
+  - Utilization (post-place): `Slice LUTs = 52361 / 133800 (39.13%)`
+  - DSPs: 33 / 740 (4.46%)
+  - Registers: 13131 / 267600 (4.91%)
+  - BRAM: 5 tiles / 365 (1.37%)
+  - Timing: `WNS=16.631ns`, `TNS=0.000ns`
+  - WNS improvement of +7.9 ns from Phase 3 (+8.700 → +16.631); 83% slack margin.
+
 ## Implementation Snapshot (2026-03-04, Phase 3)
 - Milestone:
   - Section 7 CIR Phase 3 complete (FSAVE/FRESTORE with Null/Idle/Busy frames).
@@ -673,7 +696,15 @@ Legend:
   - Tests: 8 new E2E tests (32-39) covering Null/Idle/Busy FSAVE, FRESTORE
     Null reset, FRESTORE Idle/Busy round-trip, invalid format word exception,
     and full save→restore→save data integrity verification.
-- `[ ]` Phase 4: Wire full exception dialog paths (pre/mid/BSUN/format) and FPIAR capture points.
+- `[x]` Phase 4: Wire full exception dialog paths (pre/mid/BSUN/format) and FPIAR capture points.
+  - Done: Exception dialog paths (pre-instruction, mid-instruction, BSUN, format error),
+    FPIAR capture from CIR_ADDR_INSTADDR, exception priority (INVALID > DIVZERO).
+  - Done: Tree-based CLZ optimization — replaced 5 sequential 64-iteration CLZ loops
+    with shared `clz()` function using binary-halving tree (O(log N) logic depth).
+    Critical path dropped from 682 logic levels to 112; WNS recovered from +0.612ns
+    to +16.631ns; LUTs dropped from 49% to 39%.
+  - Tests: 46 CIR dialog tests (tb_mc68881_cir_dialog), full ALU regression,
+    known defects regression — all passing.
 - `[ ]` Phase 5: Close timing/cycle tests and regression matrix.
 
 ## Exit Criteria

--- a/src/mc68881_fp80_addsub_unit.vhd
+++ b/src/mc68881_fp80_addsub_unit.vhd
@@ -118,46 +118,6 @@ architecture rtl of mc68881_fp80_addsub_unit is
     return res;
   end function;
 
-  -- Leading zero detector: returns count of leading zeros in a 67-bit value.
-  -- Uses a tree structure for O(log N) logic depth instead of iterative loop.
-  function count_leading_zeros(value : unsigned) return natural is
-    variable cnt : natural := 0;
-    variable v   : unsigned(value'length-1 downto 0) := value;
-  begin
-    -- For 67-bit input, check power-of-2 chunks from MSB.
-    -- 64, 32, 16, 8, 4, 2, 1
-    if value'length > 64 then
-      if v(v'left downto v'left - 63) = 0 then
-        cnt := cnt + 64;
-        v := v(v'left - 64 downto 0) & (63 downto 0 => '0');
-      end if;
-    end if;
-    if v(v'left downto v'left - 31) = 0 then
-      cnt := cnt + 32;
-      v := v(v'left - 32 downto 0) & (31 downto 0 => '0');
-    end if;
-    if v(v'left downto v'left - 15) = 0 then
-      cnt := cnt + 16;
-      v := v(v'left - 16 downto 0) & (15 downto 0 => '0');
-    end if;
-    if v(v'left downto v'left - 7) = 0 then
-      cnt := cnt + 8;
-      v := v(v'left - 8 downto 0) & (7 downto 0 => '0');
-    end if;
-    if v(v'left downto v'left - 3) = 0 then
-      cnt := cnt + 4;
-      v := v(v'left - 4 downto 0) & (3 downto 0 => '0');
-    end if;
-    if v(v'left downto v'left - 1) = 0 then
-      cnt := cnt + 2;
-      v := v(v'left - 2 downto 0) & "00";
-    end if;
-    if v(v'left) = '0' then
-      cnt := cnt + 1;
-    end if;
-    return cnt;
-  end function;
-
 begin
 
   -- Synchronous reset: consistent with mc68881_fp80_mul_unit and allows
@@ -381,7 +341,7 @@ begin
               null;
             elsif norm_mant(norm_mant'left) = '0' then
               -- Need to normalize: find shift amount via LZD.
-              lzc := count_leading_zeros(norm_mant);
+              lzc := clz(norm_mant);
               -- Clamp shift to exponent (don't go below exp=0).
               if lzc > to_integer(norm_exp) then
                 shift_amt := to_integer(norm_exp);

--- a/src/mc68881_pkg.vhd
+++ b/src/mc68881_pkg.vhd
@@ -306,9 +306,12 @@ package mc68881_pkg is
     CIR_XFER_SRC,
     CIR_XFER_SRC_WAIT,
     CIR_EXECUTE,
+    CIR_EXECUTE_DONE,
     CIR_XFER_DST,
     CIR_XFER_DST_WAIT,
     CIR_COND_EVAL,
+    CIR_COND_WAIT,
+    CIR_COND_CHECK,
     CIR_EXCEPT_PRE,
     CIR_EXCEPT_MID,
     CIR_EXCEPT_POST,
@@ -358,6 +361,18 @@ package mc68881_pkg is
   constant CIR_FRAME_IDLE_WORDS  : natural := 6;   -- 24 bytes / 4
   constant CIR_FRAME_BUSY_WORDS  : natural := 45;  -- 180 bytes / 4
   constant CIR_FRAME_BUSY_HDR    : natural := 12;  -- Header words 0-11 (operands + metadata)
+
+  -- Exception vector numbers for Response CIR (10-bit field).
+  -- MC68881 vectors at offsets $C0-$D8 (vectors 48-54); format error is vector 14.
+  constant CIR_VEC_FORMAT  : std_logic_vector(9 downto 0) := "00" & x"0E";  -- 14: Format error
+  constant CIR_VEC_TRAPCC  : std_logic_vector(9 downto 0) := "00" & x"07";  -- 7: cpTRAPcc
+  constant CIR_VEC_BSUN    : std_logic_vector(9 downto 0) := "00" & x"30";  -- 48: BSUN
+  constant CIR_VEC_INEXACT : std_logic_vector(9 downto 0) := "00" & x"31";  -- 49: Inexact
+  constant CIR_VEC_DIVZERO : std_logic_vector(9 downto 0) := "00" & x"32";  -- 50: Divide by zero
+  constant CIR_VEC_UNDERFL : std_logic_vector(9 downto 0) := "00" & x"33";  -- 51: Underflow
+  constant CIR_VEC_OPERR   : std_logic_vector(9 downto 0) := "00" & x"34";  -- 52: Operand error
+  constant CIR_VEC_OVERFL  : std_logic_vector(9 downto 0) := "00" & x"35";  -- 53: Overflow
+  constant CIR_VEC_SNAN    : std_logic_vector(9 downto 0) := "00" & x"36";  -- 54: Signaling NaN
 
   -- Helper: number of 32-bit operand words for a given source format.
   function cir_src_word_count(src_fmt : std_logic_vector(2 downto 0)) return natural;

--- a/src/mc68881_pkg.vhd
+++ b/src/mc68881_pkg.vhd
@@ -244,6 +244,7 @@ package mc68881_pkg is
   function neg_fp80(value : fp80_t) return fp80_t;
   function fint_fp80(value : fp80_t; round_mode : fp_round_mode_t) return fp80_t;
   function fintrz_fp80(value : fp80_t) return fp80_t;
+  function clz(value : unsigned) return natural;
   function fgetexp_fp80(value : fp80_t) return fp80_t;
   function fgetman_fp80(value : fp80_t) return fp80_t;
   function ftst_fp80(value : fp80_t) return fp80_t;
@@ -2386,11 +2387,48 @@ package body mc68881_pkg is
     return pack_fp80(result_u);
   end function;
 
+  -- Tree-based count-leading-zeros: O(log N) logic depth instead of
+  -- sequential loop.  Width-generic via compile-time guards.
+  function clz(value : unsigned) return natural is
+    variable cnt : natural := 0;
+    variable v   : unsigned(value'length-1 downto 0) := value;
+  begin
+    if value'length > 64 then
+      if v(v'left downto v'left - 63) = 0 then
+        cnt := cnt + 64;
+        v := v(v'left - 64 downto 0) & (63 downto 0 => '0');
+      end if;
+    end if;
+    if v(v'left downto v'left - 31) = 0 then
+      cnt := cnt + 32;
+      v := v(v'left - 32 downto 0) & (31 downto 0 => '0');
+    end if;
+    if v(v'left downto v'left - 15) = 0 then
+      cnt := cnt + 16;
+      v := v(v'left - 16 downto 0) & (15 downto 0 => '0');
+    end if;
+    if v(v'left downto v'left - 7) = 0 then
+      cnt := cnt + 8;
+      v := v(v'left - 8 downto 0) & (7 downto 0 => '0');
+    end if;
+    if v(v'left downto v'left - 3) = 0 then
+      cnt := cnt + 4;
+      v := v(v'left - 4 downto 0) & (3 downto 0 => '0');
+    end if;
+    if v(v'left downto v'left - 1) = 0 then
+      cnt := cnt + 2;
+      v := v(v'left - 2 downto 0) & "00";
+    end if;
+    if v(v'left) = '0' then
+      cnt := cnt + 1;
+    end if;
+    return cnt;
+  end function;
+
   function fgetexp_fp80(value : fp80_t) return fp80_t is
     variable value_u : fp_unpacked_t := unpack_fp80(value);
     variable result_u : fp_unpacked_t;
     variable unbiased_exp : integer := 0;
-    variable mantissa_norm : unsigned(FP_MANT_WIDTH-1 downto 0) := (others => '0');
   begin
     if fp80_is_nan(value) then
       return value;
@@ -2412,14 +2450,8 @@ package body mc68881_pkg is
     end if;
 
     if value_u.exp = 0 then
-      -- Normalize subnormal mantissa before extracting the unbiased exponent.
-      unbiased_exp := 1 - FP_EXP_BIAS;
-      mantissa_norm := value_u.mant;
-      for idx in 0 to FP_MANT_WIDTH-1 loop
-        exit when mantissa_norm(mantissa_norm'left) = '1';
-        mantissa_norm := shift_left(mantissa_norm, 1);
-        unbiased_exp := unbiased_exp - 1;
-      end loop;
+      -- Subnormal: unbiased exponent adjusted by leading zero count.
+      unbiased_exp := 1 - FP_EXP_BIAS - clz(value_u.mant);
     else
       unbiased_exp := to_integer(value_u.exp) - FP_EXP_BIAS;
     end if;
@@ -2428,7 +2460,6 @@ package body mc68881_pkg is
 
   function fgetman_fp80(value : fp80_t) return fp80_t is
     variable result_u : fp_unpacked_t := unpack_fp80(value);
-    variable mantissa_norm : unsigned(FP_MANT_WIDTH-1 downto 0) := (others => '0');
   begin
     if fp80_is_nan(value) or fp80_is_zero(value) then
       return value;
@@ -2443,12 +2474,7 @@ package body mc68881_pkg is
 
     if result_u.exp = 0 then
       -- Normalize denormal mantissas before forcing exponent to bias.
-      mantissa_norm := result_u.mant;
-      for idx in 0 to FP_MANT_WIDTH-1 loop
-        exit when mantissa_norm(mantissa_norm'left) = '1';
-        mantissa_norm := shift_left(mantissa_norm, 1);
-      end loop;
-      result_u.mant := mantissa_norm;
+      result_u.mant := shift_left(result_u.mant, clz(result_u.mant));
     end if;
 
     result_u.exp := to_unsigned(FP_EXP_BIAS, FP_EXP_WIDTH);

--- a/src/mc68881_top.vhd
+++ b/src/mc68881_top.vhd
@@ -2477,7 +2477,12 @@ begin
 
       if bus_read = '1' and addr = ADDR_CIR_RESPONSE then
         cir_response_pending_reg <= '0';
-        cir_trap_pending_reg <= '0';
+        -- Only clear trap_pending when NOT in the condition-eval pipeline,
+        -- otherwise the CIR response read between CIR_COND_EVAL and
+        -- CIR_COND_CHECK would race-clear the flag before it is sampled.
+        if cir_state_reg /= CIR_COND_WAIT and cir_state_reg /= CIR_COND_CHECK then
+          cir_trap_pending_reg <= '0';
+        end if;
         cir_protocol_violation_reg <= '0';
       end if;
 
@@ -3512,6 +3517,7 @@ begin
       alu_restore_req_reg <= '0';
       alu_restore_wr_reg <= '0';
       packed_restore_wr <= '0';
+      cir_exc_vector <= (others => '0');
     elsif rising_edge(clk) then
       cir_launch_alu <= '0';  -- default: clear one-shot pulse
       cir_flags_consumed <= '0';
@@ -3620,6 +3626,10 @@ begin
         when CIR_EXECUTE_DONE =>
           -- FPSR EXC byte is now stable. Check FPCR exception enables.
           -- Priority (highest first): INVALID > OVERFLOW > UNDERFLOW > DIVZERO > INEXACT.
+          -- NOTE: INVALID always maps to CIR_VEC_SNAN (vector 54). The real MC68881
+          -- distinguishes SNAN (vector 54) from OPERR (vector 52) based on whether
+          -- the invalid was from an SNaN input vs a domain error. This is a known
+          -- deviation; a future refinement could inspect operand signaling bits.
           if fpsr_reg(FPSR_EXC_LSB + FPSR_EXC_INVALID) = '1' and
              fpcr_reg(FPCR_EXC_EN_INVALID) = '1' then
             cir_exc_vector <= CIR_VEC_SNAN;
@@ -3764,7 +3774,7 @@ begin
               cir_state_reg <= CIR_RESTORE_FRAME;
             else
               -- Invalid format word: Pre-Instruction Exception.
-              cir_exc_vector <= "00" & x"0E";  -- Format error vector ($0E = 14)
+              cir_exc_vector <= CIR_VEC_FORMAT;  -- Format error vector ($0E = 14)
               cir_state_reg <= CIR_EXCEPT_PRE;
             end if;
           end if;

--- a/src/mc68881_top.vhd
+++ b/src/mc68881_top.vhd
@@ -712,11 +712,7 @@ architecture rtl of mc68881_top is
     -- For subnormals (biased exponent = 0), adjust bin_exp by counting
     -- leading mantissa zeros so the exp10 estimate is accurate.
     if unsigned(abs_val(FP_WIDTH-2 downto FP_MANT_WIDTH)) = 0 then
-      bin_exp := 1 - FP_EXP_BIAS;
-      for bit_idx in FP_MANT_WIDTH-1 downto 0 loop
-        exit when abs_val(bit_idx) = '1';
-        bin_exp := bin_exp - 1;
-      end loop;
+      bin_exp := 1 - FP_EXP_BIAS - clz(unsigned(abs_val(FP_MANT_WIDTH-1 downto 0)));
     end if;
     if bin_exp >= 0 then
       exp10 := (bin_exp * 77) / 256;
@@ -893,11 +889,7 @@ architecture rtl of mc68881_top is
     -- For subnormals (biased exponent = 0), adjust bin_exp by counting
     -- leading mantissa zeros so the exp10 estimate is accurate.
     if unsigned(abs_val(FP_WIDTH-2 downto FP_MANT_WIDTH)) = 0 then
-      bin_exp := 1 - FP_EXP_BIAS;
-      for bit_idx in FP_MANT_WIDTH-1 downto 0 loop
-        exit when abs_val(bit_idx) = '1';
-        bin_exp := bin_exp - 1;
-      end loop;
+      bin_exp := 1 - FP_EXP_BIAS - clz(unsigned(abs_val(FP_MANT_WIDTH-1 downto 0)));
     end if;
     if bin_exp >= 0 then
       exp10 := (bin_exp * 77) / 256;

--- a/src/mc68881_top.vhd
+++ b/src/mc68881_top.vhd
@@ -202,6 +202,7 @@ architecture rtl of mc68881_top is
   signal cir_operand_read_data : std_logic_vector(31 downto 0) := (others => '0');
   signal cir_regselect_word    : std_logic_vector(15 downto 0) := (others => '0');
   signal cir_operand_addr_reg  : std_logic_vector(31 downto 0) := (others => '0');
+  signal cir_instaddr_reg      : std_logic_vector(31 downto 0) := (others => '0');
 
   -- CIR ALU launch handshake signals.
   signal cir_launch_alu        : std_logic := '0';           -- One-cycle pulse from cir_dialog_proc
@@ -310,7 +311,12 @@ architecture rtl of mc68881_top is
   constant FPSR_EXC_DIVZERO  : natural := 3;
   constant FPSR_EXC_INVALID  : natural := 4;
   constant FPSR_EXC_BSUN     : natural := 7;
-  constant FPCR_EXC_EN_BSUN  : natural := 15;
+  constant FPCR_EXC_EN_INEXACT  : natural := 8;
+  constant FPCR_EXC_EN_UNDERFLOW: natural := 9;
+  constant FPCR_EXC_EN_OVERFLOW : natural := 10;
+  constant FPCR_EXC_EN_DIVZERO  : natural := 11;
+  constant FPCR_EXC_EN_INVALID  : natural := 12;
+  constant FPCR_EXC_EN_BSUN    : natural := 15;
 
   type access_class_t is (
     ACCESS_NONE,
@@ -2489,7 +2495,12 @@ begin
         result_ready_reg <= '0';
         result_ex_hi_reg <= (others => '0');
         aux_result_ex_hi_reg <= (others => '0');
-        fpiar_issue_snapshot_reg <= fpiar_reg;
+        -- Use instruction address from CIR protocol when available.
+        if cir_launch_alu = '1' then
+          fpiar_issue_snapshot_reg <= cir_instaddr_reg;
+        else
+          fpiar_issue_snapshot_reg <= fpiar_reg;
+        end if;
         micro_active_reg <= '1';
 
         -- Determine effective op and class for unified dispatch.
@@ -3335,6 +3346,7 @@ begin
       cir_operand_write_prev <= '0';
       cir_save_read_done <= '0';
       cir_save_read_prev <= '0';
+      cir_instaddr_reg <= (others => '0');
       cir_frame_data_reg <= (others => (others => '0'));
     elsif rising_edge(clk) then
       -- Clear one-shot flags
@@ -3431,9 +3443,8 @@ begin
             end if;
 
           when CIR_ADDR_INSTADDR =>
-            -- FPIAR capture from Instruction Address CIR
-            -- (fpiar_reg is written in existing process, so just note this)
-            null;
+            -- Capture CPU's instruction PC for FPIAR.
+            cir_instaddr_reg <= d_in;
 
           when CIR_ADDR_CONTROL =>
             cir_control_ack <= d_in(0);
@@ -3594,14 +3605,43 @@ begin
           null;  -- Reserved for multi-cycle format conversion
 
         when CIR_EXECUTE =>
-          -- Wait for ALU completion, then return to idle.
+          -- Wait for ALU completion. Go to CIR_EXECUTE_DONE so that
+          -- bus_frame_proc has time to update fpsr_reg with exception flags
+          -- (VHDL signal semantics: same-edge write not visible until next cycle).
           if valid = '1' then
-            cir_state_reg <= CIR_IDLE;
+            cir_state_reg <= CIR_EXECUTE_DONE;
           end if;
           -- cpSAVE preemption: allow FSAVE to suspend an in-progress computation.
           if cir_opword_written = '1' and cir_instr_type = CIR_TYPE_CPSAVE then
             cir_save_req <= '1';
             cir_state_reg <= CIR_SAVE_WAIT;
+          end if;
+
+        when CIR_EXECUTE_DONE =>
+          -- FPSR EXC byte is now stable. Check FPCR exception enables.
+          -- Priority (highest first): INVALID > OVERFLOW > UNDERFLOW > DIVZERO > INEXACT.
+          if fpsr_reg(FPSR_EXC_LSB + FPSR_EXC_INVALID) = '1' and
+             fpcr_reg(FPCR_EXC_EN_INVALID) = '1' then
+            cir_exc_vector <= CIR_VEC_SNAN;
+            cir_state_reg <= CIR_EXCEPT_POST;
+          elsif fpsr_reg(FPSR_EXC_LSB + FPSR_EXC_OVERFLOW) = '1' and
+                fpcr_reg(FPCR_EXC_EN_OVERFLOW) = '1' then
+            cir_exc_vector <= CIR_VEC_OVERFL;
+            cir_state_reg <= CIR_EXCEPT_POST;
+          elsif fpsr_reg(FPSR_EXC_LSB + FPSR_EXC_UNDERFLOW) = '1' and
+                fpcr_reg(FPCR_EXC_EN_UNDERFLOW) = '1' then
+            cir_exc_vector <= CIR_VEC_UNDERFL;
+            cir_state_reg <= CIR_EXCEPT_POST;
+          elsif fpsr_reg(FPSR_EXC_LSB + FPSR_EXC_DIVZERO) = '1' and
+                fpcr_reg(FPCR_EXC_EN_DIVZERO) = '1' then
+            cir_exc_vector <= CIR_VEC_DIVZERO;
+            cir_state_reg <= CIR_EXCEPT_POST;
+          elsif fpsr_reg(FPSR_EXC_LSB + FPSR_EXC_INEXACT) = '1' and
+                fpcr_reg(FPCR_EXC_EN_INEXACT) = '1' then
+            cir_exc_vector <= CIR_VEC_INEXACT;
+            cir_state_reg <= CIR_EXCEPT_POST;
+          else
+            cir_state_reg <= CIR_IDLE;
           end if;
 
         when CIR_XFER_DST =>
@@ -3622,12 +3662,27 @@ begin
 
         when CIR_COND_EVAL =>
           -- Launch condition evaluation through alu_control_proc.
-          -- PROG_CTRL ops complete combinationally within op_issue_pulse
-          -- (no ALU start), so go directly to CIR_IDLE rather than
-          -- CIR_EXECUTE (which waits for the ALU's valid signal).
-          -- Result is in cir_response_reg; host polls STATUS.valid.
+          -- PROG_CTRL ops complete combinationally within op_issue_pulse.
+          -- Go to CIR_COND_WAIT so cir_trap_pending_reg (set by alu_control_proc
+          -- on this same edge) is visible on the next cycle.
           cir_launch_alu <= '1';
-          cir_state_reg <= CIR_IDLE;
+          cir_state_reg <= CIR_COND_WAIT;
+
+        when CIR_COND_WAIT =>
+          -- alu_control_proc processes the launch on this cycle and sets
+          -- cir_trap_pending_reg. The new value isn't visible until next cycle.
+          cir_state_reg <= CIR_COND_CHECK;
+
+        when CIR_COND_CHECK =>
+          -- Now cir_trap_pending_reg from alu_control_proc is stable.
+          -- FTRAPcc traps are handled by the CPU in CIR mode — the FPU just
+          -- reports cond_true in the response word.
+          if cir_trap_pending_reg = '1' then
+            cir_exc_vector <= CIR_VEC_BSUN;
+            cir_state_reg <= CIR_EXCEPT_PRE;
+          else
+            cir_state_reg <= CIR_IDLE;
+          end if;
 
         when CIR_EXCEPT_PRE =>
           if cir_control_ack = '1' then
@@ -3747,6 +3802,8 @@ begin
         cir_response_prim <= CIR_PRIM_BUSY;
       when CIR_EXECUTE =>
         cir_response_prim <= CIR_PRIM_BUSY;
+      when CIR_EXECUTE_DONE =>
+        cir_response_prim <= CIR_PRIM_BUSY;
       when CIR_XFER_SRC =>
         -- Transfer Operand to-CP: [15:13]=011, [12]=1, [7:0]=byte count
         cir_response_prim <= "0111" & "0000" &
@@ -3760,6 +3817,10 @@ begin
       when CIR_XFER_DST_WAIT =>
         cir_response_prim <= CIR_PRIM_BUSY;
       when CIR_COND_EVAL =>
+        cir_response_prim <= CIR_PRIM_BUSY;
+      when CIR_COND_WAIT =>
+        cir_response_prim <= CIR_PRIM_BUSY;
+      when CIR_COND_CHECK =>
         cir_response_prim <= CIR_PRIM_BUSY;
       when CIR_EXCEPT_PRE =>
         cir_response_prim <= CIR_RESP_EXCEPT_PRE & "0" & "00" & cir_exc_vector;

--- a/src/mc68881_trig_unit.vhd
+++ b/src/mc68881_trig_unit.vhd
@@ -569,7 +569,6 @@ architecture rtl of mc68881_trig_unit is
   function fgetexp_unbiased_int(value : fp80_t) return integer is
     variable exp_bits : unsigned(FP_EXP_WIDTH-1 downto 0);
     variable unbiased_exp : integer := 0;
-    variable mantissa_norm : unsigned(FP_MANT_WIDTH-1 downto 0) := (others => '0');
   begin
     -- Log setup only needs finite/non-zero behavior; keep special classes inert.
     if fp80_is_zero(value) or fp80_is_nan(value) or fp80_is_inf(value) then
@@ -579,14 +578,8 @@ architecture rtl of mc68881_trig_unit is
     exp_bits := unsigned(value(FP_WIDTH-2 downto FP_WIDTH-1-FP_EXP_WIDTH));
 
     if exp_bits = 0 then
-      -- Match fgetexp_fp80 subnormal normalization semantics.
-      unbiased_exp := 1 - FP_EXP_BIAS;
-      mantissa_norm := unsigned(value(FP_MANT_WIDTH-1 downto 0));
-      for idx in 0 to FP_MANT_WIDTH-1 loop
-        exit when mantissa_norm(mantissa_norm'left) = '1';
-        mantissa_norm := shift_left(mantissa_norm, 1);
-        unbiased_exp := unbiased_exp - 1;
-      end loop;
+      -- Subnormal: unbiased exponent adjusted by leading zero count.
+      unbiased_exp := 1 - FP_EXP_BIAS - clz(unsigned(value(FP_MANT_WIDTH-1 downto 0)));
     else
       unbiased_exp := to_integer(exp_bits) - FP_EXP_BIAS;
     end if;

--- a/tb/tb_mc68881_cir_dialog.vhd
+++ b/tb/tb_mc68881_cir_dialog.vhd
@@ -54,6 +54,12 @@ architecture sim of tb_mc68881_cir_dialog is
   constant RESP_XFER_TO_CP_4   : std_logic_vector(15 downto 0) := x"7004";  -- 1 longword to-CP
   constant RESP_XFER_FROM_CP_4 : std_logic_vector(15 downto 0) := x"6004";  -- 1 longword from-CP
 
+  -- Exception response primitives: [15:13]=category, [12]=0, [11:10]=00, [9:0]=vector.
+  constant RESP_EXCEPT_PRE_BSUN : std_logic_vector(15 downto 0) :=
+    CIR_RESP_EXCEPT_PRE & "0" & "00" & CIR_VEC_BSUN;    -- $A030
+  constant RESP_EXCEPT_POST_DZ  : std_logic_vector(15 downto 0) :=
+    CIR_RESP_EXCEPT_POST & "0" & "00" & CIR_VEC_DIVZERO; -- $E032
+
   -- FP80 test constants.
   constant FP80_ONE_VAL   : fp80_t := x"3FFF8000000000000000";  -- 1.0
   constant FP80_TWO_VAL   : fp80_t := x"40008000000000000000";  -- 2.0
@@ -136,6 +142,19 @@ architecture sim of tb_mc68881_cir_dialog is
 
   -- FP80 QNaN for BSUN testing.
   constant FP80_QNAN : fp80_t := x"7FFFC000000000000001";
+
+  -- FP80 zero for divide-by-zero testing.
+  constant FP80_ZERO_VAL : fp80_t := x"00000000000000000000";
+
+  -- FP80 positive infinity (result of 1.0 / 0.0).
+  constant FP80_POS_INF : fp80_t := x"7FFF8000000000000000";
+
+  -- CIR Instruction Address register (for FPIAR capture tests).
+  constant CIR_INSTADDR : unsigned(4 downto 0) :=
+    unsigned(std_logic_vector(CIR_ADDR_INSTADDR));
+
+  -- Legacy FPIAR readback address.
+  constant ADDR_FPIAR_TB : unsigned(4 downto 0) := to_unsigned(24, 5);
 
   -- cpSAVE/cpRESTORE OpWord constants.
   constant CPSAVE_OPWORD : std_logic_vector(31 downto 0) :=
@@ -682,6 +701,7 @@ begin
     variable last_resp : std_logic_vector(15 downto 0) := (others => '0');
     variable cmd_word : std_logic_vector(31 downto 0) := (others => '0');
     variable cir_resp : std_logic_vector(31 downto 0) := (others => '0');
+    variable cir_resp_16 : std_logic_vector(15 downto 0) := (others => '0');
     variable fpsr_val : std_logic_vector(31 downto 0) := (others => '0');
     type frame_buf_t is array (0 to CIR_FRAME_BUSY_WORDS-1) of std_logic_vector(31 downto 0);
     variable save_buf : frame_buf_t := (others => (others => '0'));
@@ -2015,6 +2035,274 @@ begin
       wait until rising_edge(clk);
     end loop;
     report "TEST 39 PASSED" severity note;
+
+    -- ================================================================
+    -- TEST 40: BSUN trap delivery
+    --   Enable FPCR BSUN, evaluate signaling condition on NaN CC.
+    --   Verify CIR FSM enters EXCEPT_PRE with BSUN vector.
+    -- ================================================================
+    report "TEST 40: BSUN trap delivery via CIR" severity note;
+
+    -- Set up: load QNaN into FP2, 1.0 into FP3, then FCMP FP2,FP3 → sets CC NaN.
+    legacy_load_fp_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                       dsack0_n, dsack1_n, d_out, 2, FP80_QNAN);
+    legacy_load_fp_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                       dsack0_n, dsack1_n, d_out, 3, FP80_ONE_VAL);
+    cpgen_reg_to_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                     dsack0_n, dsack1_n, d_out,
+                     OPCODE_FCMP, 2, 3);
+
+    -- Enable BSUN exception in FPCR (bit 15).
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              ADDR_FPCR, x"00008000");
+
+    -- Evaluate signaling condition (GT) → triggers BSUN + trap because FPCR enabled.
+    cir_cond_eval(a_in, d_in, rw, cs_n, as_n, ds_n,
+                  dsack0_n, dsack1_n, d_out,
+                  CPBCC_W_OPWORD, FCC_GT, cir_resp);
+    report "TEST 40 cond_resp=" & to_hstring(cir_resp) severity note;
+    -- Verify BSUN and trap_requested bits in conditional response.
+    assert cir_resp(4) = '1'
+      report "FAIL TEST 40: BSUN bit should be 1"
+      severity failure;
+    assert cir_resp(5) = '1'
+      report "FAIL TEST 40: trap_requested should be 1"
+      severity failure;
+
+    -- Wait for FSM to settle into CIR_EXCEPT_PRE (1-2 clocks after response read).
+    for i in 0 to 3 loop
+      wait until rising_edge(clk);
+    end loop;
+
+    -- Read CIR Response again — should show EXCEPT_PRE with BSUN vector.
+    cir_read_response(a_in, rw, cs_n, as_n, ds_n,
+                      dsack0_n, dsack1_n, d_out, cir_resp_16);
+    report "TEST 40 exc_resp=" & to_hstring(cir_resp_16) severity note;
+    assert cir_resp_16 = RESP_EXCEPT_PRE_BSUN
+      report "FAIL TEST 40: expected EXCEPT_PRE/BSUN=" & to_hstring(RESP_EXCEPT_PRE_BSUN) &
+             " got=" & to_hstring(cir_resp_16)
+      severity failure;
+
+    -- Acknowledge exception via Control CIR.
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_CONTROL_ADDR, x"00000001");
+    for i in 0 to 3 loop
+      wait until rising_edge(clk);
+    end loop;
+
+    -- Verify FSM returned to IDLE (Response = Null).
+    cir_read_response(a_in, rw, cs_n, as_n, ds_n,
+                      dsack0_n, dsack1_n, d_out, cir_resp_16);
+    assert cir_resp_16 = RESP_NULL
+      report "FAIL TEST 40: after ack, expected Null response, got=" & to_hstring(cir_resp_16)
+      severity failure;
+
+    -- Clear FPCR for subsequent tests.
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              ADDR_FPCR, x"00000000");
+    report "TEST 40 PASSED" severity note;
+
+    -- ================================================================
+    -- TEST 41: Arithmetic post-instruction exception (FDIV by zero with DZ enable)
+    --   Enable FPCR DZ, execute FDIV(1.0, 0.0). Verify EXCEPT_POST with DZ vector.
+    -- ================================================================
+    report "TEST 41: Arithmetic FDIV/0 post-instruction exception" severity note;
+
+    -- Load 1.0 → FP0, 0.0 → FP1.
+    legacy_load_fp_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                       dsack0_n, dsack1_n, d_out, 0, FP80_ONE_VAL);
+    legacy_load_fp_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                       dsack0_n, dsack1_n, d_out, 1, FP80_ZERO_VAL);
+
+    -- Enable DZ exception in FPCR (bit 11).
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              ADDR_FPCR, x"00000800");
+
+    -- Execute FDIV FP1,FP0 (FP0 = FP0 / FP1 = 1.0 / 0.0).
+    -- Write OpWord (cpGEN).
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPWORD, CPGEN_OPWORD);
+    -- Write Command: reg-to-reg, src=1, dst=0, opcode=FDIV.
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_COMMAND, make_cpgen_reg_cmd(1, 0, OPCODE_FDIV));
+
+    -- Wait for ALU completion (STATUS.valid).
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n,
+                   dsack0_n, dsack1_n, d_out, fpsr_val);
+
+    -- Wait extra cycles for CIR_EXECUTE_DONE → CIR_EXCEPT_POST transition.
+    for i in 0 to 5 loop
+      wait until rising_edge(clk);
+    end loop;
+
+    -- Read CIR Response — should show EXCEPT_POST with DZ vector.
+    cir_read_response(a_in, rw, cs_n, as_n, ds_n,
+                      dsack0_n, dsack1_n, d_out, cir_resp_16);
+    report "TEST 41 exc_resp=" & to_hstring(cir_resp_16) severity note;
+    assert cir_resp_16 = RESP_EXCEPT_POST_DZ
+      report "FAIL TEST 41: expected EXCEPT_POST/DZ=" & to_hstring(RESP_EXCEPT_POST_DZ) &
+             " got=" & to_hstring(cir_resp_16)
+      severity failure;
+
+    -- Verify FPSR DZ flag is set.
+    bus_read(a_in, rw, cs_n, as_n, ds_n,
+             dsack0_n, dsack1_n, d_out, fpsr_val, ADDR_FPSR);
+    report "TEST 41 FPSR=" & to_hstring(fpsr_val) severity note;
+    assert fpsr_val(8 + 3) = '1'
+      report "FAIL TEST 41: FPSR EXC.DZ should be set"
+      severity failure;
+
+    -- Acknowledge exception via Control CIR.
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_CONTROL_ADDR, x"00000001");
+    for i in 0 to 3 loop
+      wait until rising_edge(clk);
+    end loop;
+
+    -- Verify FSM returned to IDLE.
+    cir_read_response(a_in, rw, cs_n, as_n, ds_n,
+                      dsack0_n, dsack1_n, d_out, cir_resp_16);
+    assert cir_resp_16 = RESP_NULL
+      report "FAIL TEST 41: after ack, expected Null, got=" & to_hstring(cir_resp_16)
+      severity failure;
+
+    -- Clear FPCR.
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              ADDR_FPCR, x"00000000");
+    report "TEST 41 PASSED" severity note;
+
+    -- ================================================================
+    -- TEST 42: Arithmetic exception with no FPCR enable
+    --   Execute FDIV(1.0, 0.0) without DZ enable. Verify no exception dialog.
+    -- ================================================================
+    report "TEST 42: FDIV/0 without FPCR DZ enable (no exception dialog)" severity note;
+
+    -- Reload operands (FP0=1.0, FP1=0.0).
+    legacy_load_fp_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                       dsack0_n, dsack1_n, d_out, 0, FP80_ONE_VAL);
+    legacy_load_fp_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                       dsack0_n, dsack1_n, d_out, 1, FP80_ZERO_VAL);
+
+    -- Ensure FPCR DZ enable is cleared.
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              ADDR_FPCR, x"00000000");
+
+    -- Execute FDIV FP1,FP0 via CIR.
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPWORD, CPGEN_OPWORD);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_COMMAND, make_cpgen_reg_cmd(1, 0, OPCODE_FDIV));
+
+    -- Wait for completion.
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n,
+                   dsack0_n, dsack1_n, d_out, fpsr_val);
+    for i in 0 to 5 loop
+      wait until rising_edge(clk);
+    end loop;
+
+    -- CIR Response should be Null (no exception dialog).
+    cir_read_response(a_in, rw, cs_n, as_n, ds_n,
+                      dsack0_n, dsack1_n, d_out, cir_resp_16);
+    report "TEST 42 resp=" & to_hstring(cir_resp_16) severity note;
+    assert cir_resp_16 = RESP_NULL
+      report "FAIL TEST 42: expected Null (no exception), got=" & to_hstring(cir_resp_16)
+      severity failure;
+
+    -- But FPSR DZ flag should still be set.
+    bus_read(a_in, rw, cs_n, as_n, ds_n,
+             dsack0_n, dsack1_n, d_out, fpsr_val, ADDR_FPSR);
+    report "TEST 42 FPSR=" & to_hstring(fpsr_val) severity note;
+    assert fpsr_val(8 + 3) = '1'
+      report "FAIL TEST 42: FPSR EXC.DZ should be set even without FPCR enable"
+      severity failure;
+    report "TEST 42 PASSED" severity note;
+
+    -- ================================================================
+    -- TEST 43: FPIAR capture from Instruction Address CIR
+    --   Write a known instruction address, execute an op that triggers
+    --   an exception, verify FPIAR matches.
+    -- ================================================================
+    report "TEST 43: FPIAR capture from CIR_ADDR_INSTADDR" severity note;
+
+    -- Clear FPIAR first.
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              ADDR_FPIAR_TB, x"00000000");
+
+    -- Write a known instruction address to CIR Instruction Address register.
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_INSTADDR, x"00CAFE00");
+
+    -- Load operands: QNaN → FP4, 1.0 → FP5.
+    legacy_load_fp_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                       dsack0_n, dsack1_n, d_out, 4, FP80_QNAN);
+    legacy_load_fp_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                       dsack0_n, dsack1_n, d_out, 5, FP80_ONE_VAL);
+
+    -- Execute FADD FP4,FP5 via CIR (SNAN input → INVALID exception → FPIAR capture).
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPWORD, CPGEN_OPWORD);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_COMMAND, make_cpgen_reg_cmd(4, 5, OPCODE_FADD));
+
+    -- Wait for completion.
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n,
+                   dsack0_n, dsack1_n, d_out, fpsr_val);
+    for i in 0 to 3 loop
+      wait until rising_edge(clk);
+    end loop;
+
+    -- Read FPIAR — should match the instruction address we wrote.
+    bus_read(a_in, rw, cs_n, as_n, ds_n,
+             dsack0_n, dsack1_n, d_out, fpsr_val, ADDR_FPIAR_TB);
+    report "TEST 43 FPIAR=" & to_hstring(fpsr_val) severity note;
+    assert fpsr_val = x"00CAFE00"
+      report "FAIL TEST 43: FPIAR expected=00CAFE00 got=" & to_hstring(fpsr_val)
+      severity failure;
+    report "TEST 43 PASSED" severity note;
+
+    -- ================================================================
+    -- TEST 44: BSUN without FPCR enable (no trap, but BSUN still in FPSR)
+    --   Same as Test 30 but verify FSM returns to IDLE (no exception dialog).
+    -- ================================================================
+    report "TEST 44: BSUN without FPCR enable (no trap)" severity note;
+
+    -- Ensure FPCR BSUN enable is off.
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              ADDR_FPCR, x"00000000");
+
+    -- Set up NaN CC: FCMP QNaN, 1.0.
+    legacy_load_fp_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                       dsack0_n, dsack1_n, d_out, 2, FP80_QNAN);
+    legacy_load_fp_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                       dsack0_n, dsack1_n, d_out, 3, FP80_ONE_VAL);
+    cpgen_reg_to_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                     dsack0_n, dsack1_n, d_out,
+                     OPCODE_FCMP, 2, 3);
+
+    -- Evaluate signaling condition (GT) — BSUN fires but no trap.
+    cir_cond_eval(a_in, d_in, rw, cs_n, as_n, ds_n,
+                  dsack0_n, dsack1_n, d_out,
+                  CPBCC_W_OPWORD, FCC_GT, cir_resp);
+    report "TEST 44 cond_resp=" & to_hstring(cir_resp) severity note;
+    -- BSUN set, but trap_requested=0 (no FPCR enable).
+    assert cir_resp(4) = '1'
+      report "FAIL TEST 44: BSUN bit should be 1"
+      severity failure;
+    assert cir_resp(5) = '0'
+      report "FAIL TEST 44: trap_requested should be 0 (no enable)"
+      severity failure;
+
+    -- Wait and verify FSM is IDLE (Null response, no exception dialog).
+    for i in 0 to 3 loop
+      wait until rising_edge(clk);
+    end loop;
+    cir_read_response(a_in, rw, cs_n, as_n, ds_n,
+                      dsack0_n, dsack1_n, d_out, cir_resp_16);
+    report "TEST 44 resp=" & to_hstring(cir_resp_16) severity note;
+    assert cir_resp_16 = RESP_NULL
+      report "FAIL TEST 44: expected Null (no trap), got=" & to_hstring(cir_resp_16)
+      severity failure;
+    report "TEST 44 PASSED" severity note;
 
     -- ================================================================
     report "All CIR dialog tests PASSED" severity note;

--- a/tb/tb_mc68881_cir_dialog.vhd
+++ b/tb/tb_mc68881_cir_dialog.vhd
@@ -59,6 +59,10 @@ architecture sim of tb_mc68881_cir_dialog is
     CIR_RESP_EXCEPT_PRE & "0" & "00" & CIR_VEC_BSUN;    -- $A030
   constant RESP_EXCEPT_POST_DZ  : std_logic_vector(15 downto 0) :=
     CIR_RESP_EXCEPT_POST & "0" & "00" & CIR_VEC_DIVZERO; -- $E032
+  constant RESP_EXCEPT_POST_OV  : std_logic_vector(15 downto 0) :=
+    CIR_RESP_EXCEPT_POST & "0" & "00" & CIR_VEC_OVERFL;  -- $E035
+  constant RESP_EXCEPT_POST_SNAN : std_logic_vector(15 downto 0) :=
+    CIR_RESP_EXCEPT_POST & "0" & "00" & CIR_VEC_SNAN;    -- $E036
 
   -- FP80 test constants.
   constant FP80_ONE_VAL   : fp80_t := x"3FFF8000000000000000";  -- 1.0
@@ -148,6 +152,9 @@ architecture sim of tb_mc68881_cir_dialog is
 
   -- FP80 positive infinity (result of 1.0 / 0.0).
   constant FP80_POS_INF : fp80_t := x"7FFF8000000000000000";
+
+  -- FP80 largest finite value (exponent $7FFE, max significand) for overflow tests.
+  constant FP80_LARGE : fp80_t := x"7FFEFFFFFFFFFFFFFFFF";
 
   -- CIR Instruction Address register (for FPIAR capture tests).
   constant CIR_INSTADDR : unsigned(4 downto 0) :=
@@ -2238,7 +2245,7 @@ begin
     legacy_load_fp_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
                        dsack0_n, dsack1_n, d_out, 5, FP80_ONE_VAL);
 
-    -- Execute FADD FP4,FP5 via CIR (SNAN input → INVALID exception → FPIAR capture).
+    -- Execute FADD FP4,FP5 via CIR (QNaN input → INVALID exception → FPIAR capture).
     bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
               CIR_OPWORD, CPGEN_OPWORD);
     bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
@@ -2303,6 +2310,142 @@ begin
       report "FAIL TEST 44: expected Null (no trap), got=" & to_hstring(cir_resp_16)
       severity failure;
     report "TEST 44 PASSED" severity note;
+
+    -- ================================================================
+    -- TEST 45: OVERFLOW post-instruction exception
+    --   FMUL(LARGE, LARGE) overflows to infinity. Enable FPCR OVERFLOW.
+    --   Verify EXCEPT_POST with OVERFLOW vector. Also verifies that OVERFLOW
+    --   wins over INEXACT (both are set, but OVERFLOW has higher priority).
+    -- ================================================================
+    report "TEST 45: OVERFLOW post-instruction exception" severity note;
+
+    -- Load largest finite value → FP6, FP7.
+    legacy_load_fp_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                       dsack0_n, dsack1_n, d_out, 6, FP80_LARGE);
+    legacy_load_fp_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                       dsack0_n, dsack1_n, d_out, 7, FP80_LARGE);
+
+    -- Enable OVERFLOW exception in FPCR (bit 10) and INEXACT (bit 8).
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              ADDR_FPCR, x"00000500");  -- bits 10 + 8
+
+    -- Execute FMUL FP7,FP6 (FP6 = FP6 * FP7 = LARGE * LARGE → overflow).
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPWORD, CPGEN_OPWORD);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_COMMAND, make_cpgen_reg_cmd(7, 6, OPCODE_FMUL));
+
+    -- Wait for ALU completion.
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n,
+                   dsack0_n, dsack1_n, d_out, fpsr_val);
+    for i in 0 to 5 loop
+      wait until rising_edge(clk);
+    end loop;
+
+    -- Read CIR Response — should show EXCEPT_POST with OVERFLOW vector.
+    cir_read_response(a_in, rw, cs_n, as_n, ds_n,
+                      dsack0_n, dsack1_n, d_out, cir_resp_16);
+    report "TEST 45 exc_resp=" & to_hstring(cir_resp_16) severity note;
+    assert cir_resp_16 = RESP_EXCEPT_POST_OV
+      report "FAIL TEST 45: expected EXCEPT_POST/OV=" & to_hstring(RESP_EXCEPT_POST_OV) &
+             " got=" & to_hstring(cir_resp_16)
+      severity failure;
+
+    -- Verify FPSR OVERFLOW and INEXACT flags both set.
+    bus_read(a_in, rw, cs_n, as_n, ds_n,
+             dsack0_n, dsack1_n, d_out, fpsr_val, ADDR_FPSR);
+    report "TEST 45 FPSR=" & to_hstring(fpsr_val) severity note;
+    assert fpsr_val(8 + 2) = '1'
+      report "FAIL TEST 45: FPSR EXC.OVERFLOW should be set"
+      severity failure;
+    assert fpsr_val(8 + 0) = '1'
+      report "FAIL TEST 45: FPSR EXC.INEXACT should also be set"
+      severity failure;
+
+    -- Acknowledge exception.
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_CONTROL_ADDR, x"00000001");
+    for i in 0 to 3 loop
+      wait until rising_edge(clk);
+    end loop;
+
+    -- Verify FSM returned to IDLE.
+    cir_read_response(a_in, rw, cs_n, as_n, ds_n,
+                      dsack0_n, dsack1_n, d_out, cir_resp_16);
+    assert cir_resp_16 = RESP_NULL
+      report "FAIL TEST 45: after ack, expected Null, got=" & to_hstring(cir_resp_16)
+      severity failure;
+
+    -- Clear FPCR for next test.
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              ADDR_FPCR, x"00000000");
+    report "TEST 45 PASSED" severity note;
+
+    -- ================================================================
+    -- TEST 46: Exception priority — INVALID wins over DIVZERO
+    --   FDIV(QNaN, 0.0) with both INVALID and DZ enabled. INVALID has
+    --   higher priority and should produce SNAN vector, not DZ vector.
+    -- ================================================================
+    report "TEST 46: Exception priority INVALID > DIVZERO" severity note;
+
+    -- Load QNaN → FP0, 0.0 → FP1.
+    legacy_load_fp_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                       dsack0_n, dsack1_n, d_out, 0, FP80_QNAN);
+    legacy_load_fp_reg(a_in, d_in, rw, cs_n, as_n, ds_n,
+                       dsack0_n, dsack1_n, d_out, 1, FP80_ZERO_VAL);
+
+    -- Enable both INVALID (bit 12) and DZ (bit 11) in FPCR.
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              ADDR_FPCR, x"00001800");  -- bits 12 + 11
+
+    -- Execute FDIV FP1,FP0 (FP0 = QNaN / 0.0 → NaN, INVALID set).
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_OPWORD, CPGEN_OPWORD);
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_COMMAND, make_cpgen_reg_cmd(1, 0, OPCODE_FDIV));
+
+    -- Wait for ALU completion.
+    wait_for_valid(a_in, rw, cs_n, as_n, ds_n,
+                   dsack0_n, dsack1_n, d_out, fpsr_val);
+    for i in 0 to 5 loop
+      wait until rising_edge(clk);
+    end loop;
+
+    -- Read CIR Response — should show EXCEPT_POST with SNAN vector (INVALID wins).
+    cir_read_response(a_in, rw, cs_n, as_n, ds_n,
+                      dsack0_n, dsack1_n, d_out, cir_resp_16);
+    report "TEST 46 exc_resp=" & to_hstring(cir_resp_16) severity note;
+    assert cir_resp_16 = RESP_EXCEPT_POST_SNAN
+      report "FAIL TEST 46: expected EXCEPT_POST/SNAN=" & to_hstring(RESP_EXCEPT_POST_SNAN) &
+             " got=" & to_hstring(cir_resp_16)
+      severity failure;
+
+    -- Verify FPSR INVALID is set.
+    bus_read(a_in, rw, cs_n, as_n, ds_n,
+             dsack0_n, dsack1_n, d_out, fpsr_val, ADDR_FPSR);
+    report "TEST 46 FPSR=" & to_hstring(fpsr_val) severity note;
+    assert fpsr_val(8 + 4) = '1'
+      report "FAIL TEST 46: FPSR EXC.INVALID should be set"
+      severity failure;
+
+    -- Acknowledge exception.
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              CIR_CONTROL_ADDR, x"00000001");
+    for i in 0 to 3 loop
+      wait until rising_edge(clk);
+    end loop;
+
+    -- Verify FSM returned to IDLE.
+    cir_read_response(a_in, rw, cs_n, as_n, ds_n,
+                      dsack0_n, dsack1_n, d_out, cir_resp_16);
+    assert cir_resp_16 = RESP_NULL
+      report "FAIL TEST 46: after ack, expected Null, got=" & to_hstring(cir_resp_16)
+      severity failure;
+
+    -- Clear FPCR.
+    bus_write(a_in, d_in, rw, cs_n, as_n, ds_n,
+              ADDR_FPCR, x"00000000");
+    report "TEST 46 PASSED" severity note;
 
     -- ================================================================
     report "All CIR dialog tests PASSED" severity note;


### PR DESCRIPTION
## Summary
- Wire BSUN trap delivery through CIR dialog FSM (`CIR_COND_EVAL` → `CIR_COND_WAIT` → `CIR_COND_CHECK` → `CIR_EXCEPT_PRE` with BSUN vector)
- Wire post-instruction arithmetic exceptions (`CIR_EXECUTE` → `CIR_EXECUTE_DONE` → `CIR_EXCEPT_POST`) consulting FPCR enable bits with priority-ordered vector selection (INVALID > OVERFLOW > UNDERFLOW > DIVZERO > INEXACT)
- Fix FPIAR capture: `CIR_ADDR_INSTADDR` now stores the CPU instruction address into `cir_instaddr_reg`, used as `fpiar_issue_snapshot_reg` for CIR-launched operations
- Add exception vector constants (`CIR_VEC_BSUN/SNAN/OVERFL/UNDERFL/DIVZERO/INEXACT/OPERR/FORMAT/TRAPCC`) and FPCR enable bit constants

## Test plan
- [x] Test 40: BSUN trap delivery — FPCR BSUN enabled, signaling condition on NaN CC → EXCEPT_PRE with BSUN vector, Control CIR ack → IDLE
- [x] Test 41: Arithmetic DZ exception — FPCR DZ enabled, FDIV(1.0, 0.0) → EXCEPT_POST with DZ vector, ack → IDLE
- [x] Test 42: No FPCR enable — FDIV(1.0, 0.0) without DZ enable → normal IDLE completion, FPSR DZ flag still set
- [x] Test 43: FPIAR capture — Write instruction address to CIR_ADDR_INSTADDR, execute FADD with NaN → FPIAR matches written address
- [x] Test 44: BSUN without FPCR enable — signaling condition on NaN CC → BSUN in FPSR but no trap, FSM returns to IDLE
- [x] All existing tests 1-39 pass (no regressions)
- [x] tb_mc68881_alu: no regressions
- [x] tb_mc68881_known_defects: no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)