### PR TITLE
Add Xilinx block design compatibility and Vitis test apps

### DIFF
--- a/src/vitis/mc68881_e2e_test.c
+++ b/src/vitis/mc68881_e2e_test.c
@@ -1,0 +1,280 @@
+/*
+ * mc68881_e2e_test.c
+ * Lightweight end-to-end test with vectors from the GHDL testbench.
+ * Tests arithmetic, trig, exponential, and logarithmic operations.
+ *
+ * Vitis standalone BSP application.
+ */
+
+#include <stdio.h>
+#include "platform.h"
+#include "xil_printf.h"
+#include "xil_io.h"
+
+#ifndef MC68881_BASE
+#define MC68881_BASE 0x80000000u
+#endif
+
+static inline void wr(u32 off, u32 v) { Xil_Out32(MC68881_BASE + off, v); }
+static inline u32  rd(u32 off)        { return Xil_In32(MC68881_BASE + off); }
+
+/* Register offsets (register index * 4) */
+#define OFF_OPSEL   (0  * 4)
+#define OFF_OPA_L   (1  * 4)
+#define OFF_OPA_H   (2  * 4)
+#define OFF_OPA_E   (3  * 4)
+#define OFF_OPB_L   (4  * 4)
+#define OFF_OPB_H   (5  * 4)
+#define OFF_OPB_E   (6  * 4)
+#define OFF_RES_L   (7  * 4)
+#define OFF_RES_H   (8  * 4)
+#define OFF_RES_E   (9  * 4)
+#define OFF_STATUS  (10 * 4)
+
+#define STATUS_VALID  0x01
+
+/* OPSEL: namespace[31:24] | opcode_id[7:0]   (CORE_V1 = 0x01) */
+#define OPSEL(id)  (0x01000000u | (u32)(id))
+
+#define OP_ADD    OPSEL(0x01)
+#define OP_SUB    OPSEL(0x02)
+#define OP_MUL    OPSEL(0x03)
+#define OP_DIV    OPSEL(0x04)
+#define OP_SQRT   OPSEL(0x11)
+#define OP_SIN    OPSEL(0x0D)
+#define OP_COS    OPSEL(0x0E)
+#define OP_TAN    OPSEL(0x0F)
+#define OP_ETOX   OPSEL(0x45)
+#define OP_LOGN   OPSEL(0x47)
+
+/* ------------------------------------------------------------------ */
+/* FP80 helper: {exp[15:0], sig_hi[31:0], sig_lo[31:0]}              */
+/* ------------------------------------------------------------------ */
+typedef struct { u32 e; u32 h; u32 l; } fp80_t;
+
+#define FP80(e,h,l) ((fp80_t){(e),(h),(l)})
+
+static void load_opa(fp80_t v) { wr(OFF_OPA_L,v.l); wr(OFF_OPA_H,v.h); wr(OFF_OPA_E,v.e); }
+static void load_opb(fp80_t v) { wr(OFF_OPB_L,v.l); wr(OFF_OPB_H,v.h); wr(OFF_OPB_E,v.e); }
+
+static fp80_t read_res(void)
+{
+    fp80_t r;
+    r.l = rd(OFF_RES_L);
+    r.h = rd(OFF_RES_H);
+    r.e = rd(OFF_RES_E) & 0xFFFFu;
+    return r;
+}
+
+static int wait_done(void)
+{
+    for (int i = 0; i < 200000; i++)
+        if (rd(OFF_STATUS) & STATUS_VALID) return 0;
+    return -1;
+}
+
+/* ------------------------------------------------------------------ */
+/* Simple FP80 comparison: exact match on exp+sign, then allow        */
+/* sig_hi:sig_lo to differ by up to 'tol' ULPs in the 64-bit         */
+/* significand.                                                       */
+/* ------------------------------------------------------------------ */
+static int fp80_close(fp80_t got, fp80_t exp, u32 ulp_tol)
+{
+    if (got.e != exp.e) return 0;
+
+    /* 64-bit significand compare via manual subtraction */
+    u32 dh, dl;
+    int borrow = 0;
+    if (got.h > exp.h || (got.h == exp.h && got.l >= exp.l)) {
+        dl = got.l - exp.l;
+        borrow = (got.l < exp.l) ? 1 : 0;
+        dh = got.h - exp.h - borrow;
+    } else {
+        dl = exp.l - got.l;
+        borrow = (exp.l < got.l) ? 1 : 0;
+        dh = exp.h - got.h - borrow;
+    }
+    if (dh != 0) return 0;       /* more than 4G ULPs apart */
+    return dl <= ulp_tol;
+}
+
+/* ------------------------------------------------------------------ */
+/* Test infrastructure                                                */
+/* ------------------------------------------------------------------ */
+static int pass_cnt = 0;
+static int fail_cnt = 0;
+
+static void print_fp80(const char *tag, fp80_t v)
+{
+    xil_printf("  %s %04lx %08lx %08lx\r\n", tag, v.e, v.h, v.l);
+}
+
+static void run_monadic(const char *name, u32 opsel, fp80_t arg, fp80_t expect, u32 ulp_tol)
+{
+    load_opa(arg);
+    wr(OFF_OPSEL, opsel);
+    if (wait_done() < 0) {
+        xil_printf("FAIL %s: TIMEOUT\r\n", name);
+        fail_cnt++;
+        return;
+    }
+    fp80_t got = read_res();
+    if (fp80_close(got, expect, ulp_tol)) {
+        xil_printf("PASS %s\r\n", name);
+        pass_cnt++;
+    } else {
+        xil_printf("FAIL %s\r\n", name);
+        print_fp80("got:   ", got);
+        print_fp80("expect:", expect);
+        fail_cnt++;
+    }
+}
+
+static void run_binary(const char *name, u32 opsel, fp80_t a, fp80_t b,
+                        fp80_t expect, u32 ulp_tol)
+{
+    load_opa(a);
+    load_opb(b);
+    wr(OFF_OPSEL, opsel);
+    if (wait_done() < 0) {
+        xil_printf("FAIL %s: TIMEOUT\r\n", name);
+        fail_cnt++;
+        return;
+    }
+    fp80_t got = read_res();
+    if (fp80_close(got, expect, ulp_tol)) {
+        xil_printf("PASS %s\r\n", name);
+        pass_cnt++;
+    } else {
+        xil_printf("FAIL %s\r\n", name);
+        print_fp80("got:   ", got);
+        print_fp80("expect:", expect);
+        fail_cnt++;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Test vectors from tb_mc68881_alu.vhd / mc68881_golden_vectors_pkg  */
+/* ULP tolerance: generous (0x10000) to cover last-bit rounding diffs */
+/* ------------------------------------------------------------------ */
+
+#define TOL  0x10000u    /* ~65K ULPs in 64-bit sig = ~3.5e-15 rel */
+
+int main()
+{
+    init_platform();
+    xil_printf("\r\nmc68881 e2e test (vectors from GHDL tb)\r\n");
+    xil_printf("========================================\r\n");
+
+    /* --- Arithmetic --- */
+
+    /* ADD: 3.7 + 2.4 = 6.1 */
+    run_binary("ADD 3.7+2.4",  OP_ADD,
+        FP80(0x4000, 0xECCCCCCC, 0xCCCCCCCD),   /* 3.7 */
+        FP80(0x4000, 0x99999999, 0x9999999A),   /* 2.4 */
+        FP80(0x4001, 0xC3333333, 0x33333333),   /* 6.1 */
+        TOL);
+
+    /* SUB: -2.3 - 0.6 = -2.9 */
+    run_binary("SUB -2.3-0.6", OP_SUB,
+        FP80(0xC000, 0x93333333, 0x33333333),   /* -2.3 */
+        FP80(0x3FFE, 0x99999999, 0x9999999A),   /* 0.6 */
+        FP80(0xC000, 0xB9999999, 0x9999999A),   /* -2.9 */
+        TOL);
+
+    /* MUL: 3.7 * 2.4 = 8.88 */
+    run_binary("MUL 3.7*2.4",  OP_MUL,
+        FP80(0x4000, 0xECCCCCCC, 0xCCCCCCCD),   /* 3.7 */
+        FP80(0x4000, 0x99999999, 0x9999999A),   /* 2.4 */
+        FP80(0x4002, 0x8E147AE1, 0x47AE147B),   /* 8.88 */
+        TOL);
+
+    /* DIV: 12.5 / -0.7 = -17.857142... */
+    run_binary("DIV 12.5/-0.7", OP_DIV,
+        FP80(0x4002, 0xC8000000, 0x00000000),   /* 12.5 */
+        FP80(0xBFFE, 0xB3333333, 0x33333333),   /* -0.7 */
+        FP80(0xC003, 0x8EDB6DB6, 0xDB6DB6DB),   /* -17.857.. */
+        TOL);
+
+    /* SQRT(9) = 3 */
+    run_monadic("SQRT(9)", OP_SQRT,
+        FP80(0x4002, 0x90000000, 0x00000000),   /* 9.0 */
+        FP80(0x4000, 0xC0000000, 0x00000000),   /* 3.0 */
+        0);  /* exact */
+
+    /* --- Trig --- */
+
+    /* SIN(1.0) - verified on hardware */
+    run_monadic("SIN(1.0)", OP_SIN,
+        FP80(0x3FFF, 0x80000000, 0x00000000),   /* 1.0 */
+        FP80(0x3FFE, 0xD76AA478, 0x48677020),   /* sin(1) */
+        TOL);
+
+    /* SIN(1.1) */
+    run_monadic("SIN(1.1)", OP_SIN,
+        FP80(0x3FFF, 0x8CCCCCCC, 0xCCCCCCCD),   /* 1.1 */
+        FP80(0x3FFE, 0xE4262A61, 0x6B19BA80),   /* sin(1.1) */
+        TOL);
+
+    /* SIN(-0.7) */
+    run_monadic("SIN(-0.7)", OP_SIN,
+        FP80(0xBFFE, 0xB3333333, 0x33333333),   /* -0.7 */
+        FP80(0xBFFE, 0xA4EB734A, 0x30CDC2A8),   /* sin(-0.7) */
+        TOL);
+
+    /* COS(-2.3) */
+    run_monadic("COS(-2.3)", OP_COS,
+        FP80(0xC000, 0x93333333, 0x33333333),   /* -2.3 */
+        FP80(0xBFFE, 0xAA9110B9, 0x817F0E68),   /* cos(-2.3) */
+        TOL);
+
+    /* COS(0.3) */
+    run_monadic("COS(0.3)", OP_COS,
+        FP80(0x3FFD, 0x99999999, 0x99999800),   /* 0.3 */
+        FP80(0x3FFE, 0xF490EEA1, 0x784DD000),   /* cos(0.3) */
+        TOL);
+
+    /* TAN(0.9) */
+    run_monadic("TAN(0.9)", OP_TAN,
+        FP80(0x3FFE, 0xE6666666, 0x66666800),   /* 0.9 */
+        FP80(0x3FFF, 0xA14CDD4E, 0x1509BE2A),   /* tan(0.9) */
+        TOL);
+
+    /* --- Exp / Log --- */
+
+    /* e^0.75 */
+    run_monadic("ETOX(0.75)", OP_ETOX,
+        FP80(0x3FFE, 0xC0000000, 0x00000000),   /* 0.75 */
+        FP80(0x4000, 0x877CEDA3, 0x3EE7BDEA),   /* e^0.75 */
+        TOL);
+
+    /* ln(1.25) */
+    run_monadic("LOGN(1.25)", OP_LOGN,
+        FP80(0x3FFF, 0xA0000000, 0x00000000),   /* 1.25 */
+        FP80(0x3FFC, 0xE47FBE3C, 0xD4D10D61),   /* ln(1.25) */
+        TOL);
+
+    /* --- Edge cases --- */
+
+    /* SIN(0) = 0 (exact) */
+    run_monadic("SIN(0)", OP_SIN,
+        FP80(0x0000, 0x00000000, 0x00000000),
+        FP80(0x0000, 0x00000000, 0x00000000),
+        0);
+
+    /* SQRT(1) = 1 (exact) */
+    run_monadic("SQRT(1)", OP_SQRT,
+        FP80(0x3FFF, 0x80000000, 0x00000000),
+        FP80(0x3FFF, 0x80000000, 0x00000000),
+        0);
+
+    /* --- Summary --- */
+    xil_printf("========================================\r\n");
+    xil_printf("%d passed, %d failed, %d total\r\n",
+               pass_cnt, fail_cnt, pass_cnt + fail_cnt);
+    if (fail_cnt == 0)
+        xil_printf("ALL TESTS PASSED\r\n");
+
+    cleanup_platform();
+    return fail_cnt ? 1 : 0;
+}

--- a/src/vitis/mc68881_e2e_test.c
+++ b/src/vitis/mc68881_e2e_test.c
@@ -66,9 +66,12 @@ static fp80_t read_res(void)
     return r;
 }
 
+/* ~200ms at 200MHz with AXI read latency ~500ns per poll */
+#define TIMEOUT_POLLS  200000
+
 static int wait_done(void)
 {
-    for (int i = 0; i < 200000; i++)
+    for (int i = 0; i < TIMEOUT_POLLS; i++)
         if (rd(OFF_STATUS) & STATUS_VALID) return 0;
     return -1;
 }
@@ -165,6 +168,14 @@ int main()
     init_platform();
     xil_printf("\r\nmc68881 e2e test (vectors from GHDL tb)\r\n");
     xil_printf("========================================\r\n");
+
+    u32 status = rd(OFF_STATUS);
+    if (status == 0xFFFFFFFFu) {
+        xil_printf("FATAL: No response at 0x%08lx -- check bitstream and address map\r\n",
+                   (u32)MC68881_BASE);
+        cleanup_platform();
+        return 1;
+    }
 
     /* --- Arithmetic --- */
 

--- a/src/vitis/mc68881_fsin_test.c
+++ b/src/vitis/mc68881_fsin_test.c
@@ -33,9 +33,7 @@ static inline u32  rd(u32 off)        { return Xil_In32(MC68881_BASE + off); }
 /* CORE_V1 namespace = 0x01, SIN opcode = 0x0D */
 #define OPSEL_SIN   0x0100000Du
 
-/* STATUS register bits */
 #define STATUS_VALID  0x01
-#define STATUS_BUSY   0x02
 
 static void load_fp80(u32 lo, u32 hi, u32 ex)
 {
@@ -44,9 +42,12 @@ static void load_fp80(u32 lo, u32 hi, u32 ex)
     wr(OFF_OPA_E, ex);
 }
 
+/* ~200ms at 200MHz with AXI read latency ~500ns per poll */
+#define TIMEOUT_POLLS  200000
+
 static int wait_done(void)
 {
-    for (int i = 0; i < 100000; i++) {
+    for (int i = 0; i < TIMEOUT_POLLS; i++) {
         u32 st = rd(OFF_STATUS);
         if (st & STATUS_VALID)
             return 0;
@@ -56,9 +57,19 @@ static int wait_done(void)
 
 int main()
 {
+    int errors = 0;
+
     init_platform();
 
     xil_printf("\r\nmc68881 FSIN test\r\n");
+
+    u32 status = rd(OFF_STATUS);
+    if (status == 0xFFFFFFFFu) {
+        xil_printf("FATAL: No response at 0x%08lx -- check bitstream and address map\r\n",
+                   (u32)MC68881_BASE);
+        cleanup_platform();
+        return 1;
+    }
 
     /* --- sin(1.0) --- */
     /* FP80 1.0 = 0x3FFF 80000000 00000000 */
@@ -67,8 +78,8 @@ int main()
     wr(OFF_OPSEL, OPSEL_SIN);
 
     if (wait_done() < 0) {
-        xil_printf("TIMEOUT waiting for result!\r\n");
-        xil_printf("STATUS = 0x%08lx\r\n", rd(OFF_STATUS));
+        xil_printf("FAIL sin(1.0): TIMEOUT, STATUS = 0x%08lx\r\n", rd(OFF_STATUS));
+        errors++;
     } else {
         u32 res_l = rd(OFF_RES_L);
         u32 res_h = rd(OFF_RES_H);
@@ -89,7 +100,8 @@ int main()
     wr(OFF_OPSEL, OPSEL_SIN);
 
     if (wait_done() < 0) {
-        xil_printf("TIMEOUT!\r\n");
+        xil_printf("FAIL sin(0.0): TIMEOUT, STATUS = 0x%08lx\r\n", rd(OFF_STATUS));
+        errors++;
     } else {
         u32 res_l = rd(OFF_RES_L);
         u32 res_h = rd(OFF_RES_H);
@@ -101,7 +113,7 @@ int main()
         xil_printf("  expect: 0000 00000000 00000000\r\n");
     }
 
-    xil_printf("done.\r\n");
+    xil_printf("%d errors\r\n", errors);
     cleanup_platform();
-    return 0;
+    return errors ? 1 : 0;
 }

--- a/src/vitis/mc68881_fsin_test.c
+++ b/src/vitis/mc68881_fsin_test.c
@@ -1,0 +1,107 @@
+/*
+ * mc68881_fsin_test.c
+ * Compute sin(1.0) and sin(0.0) on the mc68881 FPU via AXI-Lite.
+ * Loads FP80 operand, triggers FSIN, polls for completion, reads result.
+ *
+ * Vitis standalone BSP application.
+ */
+
+#include <stdio.h>
+#include "platform.h"
+#include "xil_printf.h"
+#include "xil_io.h"
+
+#ifndef MC68881_BASE
+#define MC68881_BASE 0x80000000u
+#endif
+
+static inline void wr(u32 off, u32 v) { Xil_Out32(MC68881_BASE + off, v); }
+static inline u32  rd(u32 off)        { return Xil_In32(MC68881_BASE + off); }
+
+/* Register offsets (register index * 4) */
+#define OFF_OPSEL   (0  * 4)
+#define OFF_OPA_L   (1  * 4)
+#define OFF_OPA_H   (2  * 4)
+#define OFF_OPA_E   (3  * 4)
+#define OFF_RES_L   (7  * 4)
+#define OFF_RES_H   (8  * 4)
+#define OFF_RES_E   (9  * 4)
+#define OFF_STATUS  (10 * 4)
+#define OFF_FPSR    (14 * 4)
+
+/* OPSEL encoding: namespace[31:24] | opcode_id[7:0] */
+/* CORE_V1 namespace = 0x01, SIN opcode = 0x0D */
+#define OPSEL_SIN   0x0100000Du
+
+/* STATUS register bits */
+#define STATUS_VALID  0x01
+#define STATUS_BUSY   0x02
+
+static void load_fp80(u32 lo, u32 hi, u32 ex)
+{
+    wr(OFF_OPA_L, lo);
+    wr(OFF_OPA_H, hi);
+    wr(OFF_OPA_E, ex);
+}
+
+static int wait_done(void)
+{
+    for (int i = 0; i < 100000; i++) {
+        u32 st = rd(OFF_STATUS);
+        if (st & STATUS_VALID)
+            return 0;
+    }
+    return -1;
+}
+
+int main()
+{
+    init_platform();
+
+    xil_printf("\r\nmc68881 FSIN test\r\n");
+
+    /* --- sin(1.0) --- */
+    /* FP80 1.0 = 0x3FFF 80000000 00000000 */
+    xil_printf("Computing sin(1.0)...\r\n");
+    load_fp80(0x00000000u, 0x80000000u, 0x3FFFu);
+    wr(OFF_OPSEL, OPSEL_SIN);
+
+    if (wait_done() < 0) {
+        xil_printf("TIMEOUT waiting for result!\r\n");
+        xil_printf("STATUS = 0x%08lx\r\n", rd(OFF_STATUS));
+    } else {
+        u32 res_l = rd(OFF_RES_L);
+        u32 res_h = rd(OFF_RES_H);
+        u32 res_e = rd(OFF_RES_E);
+        u32 fpsr  = rd(OFF_FPSR);
+
+        xil_printf("  RES_E = 0x%04lx (sign+exp)\r\n", res_e & 0xFFFF);
+        xil_printf("  RES_H = 0x%08lx (sig hi)\r\n", res_h);
+        xil_printf("  RES_L = 0x%08lx (sig lo)\r\n", res_l);
+        xil_printf("  FPSR  = 0x%08lx\r\n", fpsr);
+        xil_printf("  expect: 3FFE D76AA478 48677020\r\n");
+    }
+
+    /* --- sin(0.0) --- */
+    /* FP80 0.0 = 0x0000 00000000 00000000 */
+    xil_printf("Computing sin(0.0)...\r\n");
+    load_fp80(0x00000000u, 0x00000000u, 0x0000u);
+    wr(OFF_OPSEL, OPSEL_SIN);
+
+    if (wait_done() < 0) {
+        xil_printf("TIMEOUT!\r\n");
+    } else {
+        u32 res_l = rd(OFF_RES_L);
+        u32 res_h = rd(OFF_RES_H);
+        u32 res_e = rd(OFF_RES_E);
+
+        xil_printf("  RES_E = 0x%04lx\r\n", res_e & 0xFFFF);
+        xil_printf("  RES_H = 0x%08lx\r\n", res_h);
+        xil_printf("  RES_L = 0x%08lx\r\n", res_l);
+        xil_printf("  expect: 0000 00000000 00000000\r\n");
+    }
+
+    xil_printf("done.\r\n");
+    cleanup_platform();
+    return 0;
+}

--- a/src/vitis/mc68881_smoke_test.c
+++ b/src/vitis/mc68881_smoke_test.c
@@ -1,7 +1,8 @@
 /*
  * mc68881_smoke_test.c
  * Basic AXI-Lite register read/write test for mc68881 FPU.
- * Verifies bus connectivity by writing and reading back FPCR and FPIAR.
+ * Verifies bus connectivity by writing and reading back FPCR and FPIAR,
+ * and reading FPSR.
  *
  * Vitis standalone BSP application.
  */
@@ -25,32 +26,46 @@ static inline u32  rd(u32 off)        { return Xil_In32(MC68881_BASE + off); }
 
 int main()
 {
+    int errors = 0;
+
     init_platform();
 
     xil_printf("\r\nmc68881 AXI-Lite smoke test\r\n");
     xil_printf("BASE = 0x%08lx\r\n", (u32)MC68881_BASE);
 
     u32 status = rd(OFF_STATUS);
-    xil_printf("STATUS  = 0x%08lx (bus alive)\r\n", status);
+    if (status == 0xFFFFFFFFu) {
+        xil_printf("FATAL: No response at 0x%08lx -- check bitstream and address map\r\n",
+                   (u32)MC68881_BASE);
+        cleanup_platform();
+        return 1;
+    }
+    xil_printf("STATUS  = 0x%08lx\r\n", status);
 
     u32 fpcr_val = 0x00000010u;
     wr(OFF_FPCR, fpcr_val);
     u32 fpcr_rb = rd(OFF_FPCR);
-    xil_printf("FPCR    : wrote 0x%08lx, read 0x%08lx %s\r\n",
-               fpcr_val, fpcr_rb,
-               (fpcr_rb == fpcr_val) ? "OK" : "MISMATCH");
+    if (fpcr_rb != fpcr_val) {
+        xil_printf("FAIL FPCR : wrote 0x%08lx, read 0x%08lx\r\n", fpcr_val, fpcr_rb);
+        errors++;
+    } else {
+        xil_printf("PASS FPCR : wrote 0x%08lx, read 0x%08lx\r\n", fpcr_val, fpcr_rb);
+    }
 
     u32 fpiar_val = 0xDEADBEEFu;
     wr(OFF_FPIAR, fpiar_val);
     u32 fpiar_rb = rd(OFF_FPIAR);
-    xil_printf("FPIAR   : wrote 0x%08lx, read 0x%08lx %s\r\n",
-               fpiar_val, fpiar_rb,
-               (fpiar_rb == fpiar_val) ? "OK" : "MISMATCH");
+    if (fpiar_rb != fpiar_val) {
+        xil_printf("FAIL FPIAR: wrote 0x%08lx, read 0x%08lx\r\n", fpiar_val, fpiar_rb);
+        errors++;
+    } else {
+        xil_printf("PASS FPIAR: wrote 0x%08lx, read 0x%08lx\r\n", fpiar_val, fpiar_rb);
+    }
 
     u32 fpsr = rd(OFF_FPSR);
     xil_printf("FPSR    = 0x%08lx\r\n", fpsr);
 
-    xil_printf("done.\r\n");
+    xil_printf("%d errors\r\n", errors);
     cleanup_platform();
-    return 0;
+    return errors ? 1 : 0;
 }

--- a/src/vitis/mc68881_smoke_test.c
+++ b/src/vitis/mc68881_smoke_test.c
@@ -1,0 +1,56 @@
+/*
+ * mc68881_smoke_test.c
+ * Basic AXI-Lite register read/write test for mc68881 FPU.
+ * Verifies bus connectivity by writing and reading back FPCR and FPIAR.
+ *
+ * Vitis standalone BSP application.
+ */
+
+#include <stdio.h>
+#include "platform.h"
+#include "xil_printf.h"
+#include "xil_io.h"
+
+#ifndef MC68881_BASE
+#define MC68881_BASE 0x80000000u
+#endif
+
+static inline void wr(u32 off, u32 v) { Xil_Out32(MC68881_BASE + off, v); }
+static inline u32  rd(u32 off)        { return Xil_In32(MC68881_BASE + off); }
+
+#define OFF_FPCR    (11 * 4)
+#define OFF_FPSR    (14 * 4)
+#define OFF_FPIAR   (24 * 4)
+#define OFF_STATUS  (10 * 4)
+
+int main()
+{
+    init_platform();
+
+    xil_printf("\r\nmc68881 AXI-Lite smoke test\r\n");
+    xil_printf("BASE = 0x%08lx\r\n", (u32)MC68881_BASE);
+
+    u32 status = rd(OFF_STATUS);
+    xil_printf("STATUS  = 0x%08lx (bus alive)\r\n", status);
+
+    u32 fpcr_val = 0x00000010u;
+    wr(OFF_FPCR, fpcr_val);
+    u32 fpcr_rb = rd(OFF_FPCR);
+    xil_printf("FPCR    : wrote 0x%08lx, read 0x%08lx %s\r\n",
+               fpcr_val, fpcr_rb,
+               (fpcr_rb == fpcr_val) ? "OK" : "MISMATCH");
+
+    u32 fpiar_val = 0xDEADBEEFu;
+    wr(OFF_FPIAR, fpiar_val);
+    u32 fpiar_rb = rd(OFF_FPIAR);
+    xil_printf("FPIAR   : wrote 0x%08lx, read 0x%08lx %s\r\n",
+               fpiar_val, fpiar_rb,
+               (fpiar_rb == fpiar_val) ? "OK" : "MISMATCH");
+
+    u32 fpsr = rd(OFF_FPSR);
+    xil_printf("FPSR    = 0x%08lx\r\n", fpsr);
+
+    xil_printf("done.\r\n");
+    cleanup_platform();
+    return 0;
+}

--- a/wrappers/mc68881_axilite_wrapper.vhd
+++ b/wrappers/mc68881_axilite_wrapper.vhd
@@ -237,7 +237,11 @@ begin
             -- Prioritize bridge_done over issuing new request.
             -- Channel timeout is elsif so channel acceptance on the same cycle wins.
             if bridge_done = '1' then
-              resp_reg      <= "00" when bridge_error = '0' else "10";  -- OKAY or SLVERR
+              if bridge_error = '0' then
+                resp_reg      <= "00"; 
+               else 
+                resp_reg      <="10";  -- OKAY or SLVERR
+               end if;
               axi_state_reg <= AXI_WRITE_RESP;
             elsif aw_latched = '1' and w_latched = '1' and req_sent = '0' then
               bridge_addr  <= aw_addr_reg;
@@ -269,7 +273,11 @@ begin
             -- Prioritize bridge_done over issuing new request
             if bridge_done = '1' then
               rdata_reg     <= bridge_rdata;
-              resp_reg      <= "00" when bridge_error = '0' else "10";
+              if bridge_error = '0' then
+                resp_reg <= "00";
+               else 
+               resp_reg <= "10";
+              end if;
               axi_state_reg <= AXI_READ_RESP;
             elsif req_sent = '0' then
               bridge_addr <= ar_addr_reg;

--- a/wrappers/mc68881_axilite_wrapper.vhd
+++ b/wrappers/mc68881_axilite_wrapper.vhd
@@ -238,10 +238,10 @@ begin
             -- Channel timeout is elsif so channel acceptance on the same cycle wins.
             if bridge_done = '1' then
               if bridge_error = '0' then
-                resp_reg      <= "00"; 
-               else 
-                resp_reg      <="10";  -- OKAY or SLVERR
-               end if;
+                resp_reg <= "00";  -- OKAY
+              else
+                resp_reg <= "10";  -- SLVERR
+              end if;
               axi_state_reg <= AXI_WRITE_RESP;
             elsif aw_latched = '1' and w_latched = '1' and req_sent = '0' then
               bridge_addr  <= aw_addr_reg;
@@ -274,9 +274,9 @@ begin
             if bridge_done = '1' then
               rdata_reg     <= bridge_rdata;
               if bridge_error = '0' then
-                resp_reg <= "00";
-               else 
-               resp_reg <= "10";
+                resp_reg <= "00";  -- OKAY
+              else
+                resp_reg <= "10";  -- SLVERR
               end if;
               axi_state_reg <= AXI_READ_RESP;
             elsif req_sent = '0' then

--- a/wrappers/mc68881_ooc_timing.xdc
+++ b/wrappers/mc68881_ooc_timing.xdc
@@ -1,0 +1,114 @@
+# mc68881_ooc_timing.xdc
+# Multi-cycle path constraints for mc68881 inside the AXI-Lite wrapper.
+# Adapted from mc68881_top.xdc for the OOC (out-of-context) synthesis context
+# where the wrapper is the hierarchy root and record types are decomposed
+# into field-level registers.
+#
+# All patterns use */u_fpu/ prefix to scope within the wrapper hierarchy.
+# Uses -quiet on get_pins to avoid warnings for legitimately optimized-away registers.
+
+# ======================================================
+# Multi-Cycle Path Constraints
+# ======================================================
+
+# --- Operand staging -> operand_reg (4-cycle MCP) ---
+# Format conversion (fp80_from_int/single/double, packed96_to_fp80_fast) path.
+# RTL ensures 4-cycle separation via CIR_XFER_SRC_WAIT + CIR_XFER_SRC_WAIT2.
+set_multicycle_path -setup 4 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/cir_operand_staging_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/operand_reg_reg*/D}]
+set_multicycle_path -hold 3 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/cir_operand_staging_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/operand_reg_reg*/D}]
+
+# --- Trig a_reg -> log_exp_term / log_unbiased_exp / log_exp_term_zero (7-cycle MCP) ---
+set_multicycle_path -setup 7 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/alu_inst/trig_inst/a_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/alu_inst/trig_inst/log_exp_term_reg_reg*/D}]
+set_multicycle_path -hold 6 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/alu_inst/trig_inst/a_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/alu_inst/trig_inst/log_exp_term_reg_reg*/D}]
+set_multicycle_path -setup 7 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/alu_inst/trig_inst/a_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/alu_inst/trig_inst/log_unbiased_exp_reg_reg*/D}]
+set_multicycle_path -hold 6 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/alu_inst/trig_inst/a_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/alu_inst/trig_inst/log_unbiased_exp_reg_reg*/D}]
+set_multicycle_path -setup 7 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/alu_inst/trig_inst/a_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/alu_inst/trig_inst/log_exp_term_zero_reg_reg*/D}]
+set_multicycle_path -hold 6 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/alu_inst/trig_inst/a_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/alu_inst/trig_inst/log_exp_term_zero_reg_reg*/D}]
+
+# --- Trig a_reg -> x_reg (7-cycle) ---
+set_multicycle_path -setup 7 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/alu_inst/trig_inst/a_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/alu_inst/trig_inst/x_reg_reg*/D}]
+set_multicycle_path -hold 6 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/alu_inst/trig_inst/a_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/alu_inst/trig_inst/x_reg_reg*/D}]
+
+# --- Lightweight simple ALU ops -> result (2-cycle MCP) ---
+# Remaining lightweight ops (FINT, CMP, ABS, NEG, etc.) need 2-cycle MCP.
+set_multicycle_path -setup 2 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/alu_inst/simple_a_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/alu_inst/result_reg_reg*/D}]
+set_multicycle_path -hold 1 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/alu_inst/simple_a_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/alu_inst/result_reg_reg*/D}]
+set_multicycle_path -setup 2 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/alu_inst/simple_b_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/alu_inst/result_reg_reg*/D}]
+set_multicycle_path -hold 1 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/alu_inst/simple_b_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/alu_inst/result_reg_reg*/D}]
+set_multicycle_path -setup 2 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/alu_inst/simple_op_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/alu_inst/result_reg_reg*/D}]
+set_multicycle_path -hold 1 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/alu_inst/simple_op_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/alu_inst/result_reg_reg*/D}]
+
+# --- Packed decimal fp80_to_int_trunc (4-cycle MCP) ---
+# packed_unit_inst is inside generate block packed_engine_full_g in mc68881_top
+set_multicycle_path -setup 4 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/packed_engine_full_g.packed_unit_inst/arith_int_arg_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/packed_engine_full_g.packed_unit_inst/arith_int_res_reg_reg*/D}]
+set_multicycle_path -hold 3 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/packed_engine_full_g.packed_unit_inst/arith_int_arg_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/packed_engine_full_g.packed_unit_inst/arith_int_res_reg_reg*/D}]
+
+# --- operand_reg -> result (14-cycle MCP) ---
+set_multicycle_path -setup 14 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/operand_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/alu_inst/result_reg_reg*/D}]
+set_multicycle_path -hold 13 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/operand_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/alu_inst/result_reg_reg*/D}]
+
+# --- operand_reg -> MOVE handler destinations (2-cycle MCP) ---
+set_multicycle_path -setup 2 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/operand_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/fp_reg_file_reg_reg*/D}]
+set_multicycle_path -hold 1 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/operand_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/fp_reg_file_reg_reg*/D}]
+
+set_multicycle_path -setup 2 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/operand_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/exc_event_opa_reg_reg*/D}]
+set_multicycle_path -hold 1 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/operand_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/exc_event_opa_reg_reg*/D}]
+
+set_multicycle_path -setup 2 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/operand_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/exc_event_result_reg_reg*/D}]
+set_multicycle_path -hold 1 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/operand_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/exc_event_result_reg_reg*/D}]
+
+set_multicycle_path -setup 2 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/operand_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/result_ex_reg_reg*/D}]
+set_multicycle_path -hold 1 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/operand_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/result_ex_reg_reg*/D}]
+
+set_multicycle_path -setup 2 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/operand_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/result_lo_reg_reg*/D}]
+set_multicycle_path -hold 1 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/operand_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/result_lo_reg_reg*/D}]
+
+set_multicycle_path -setup 2 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/operand_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/result_hi_reg_reg*/D}]
+set_multicycle_path -hold 1 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/operand_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/result_hi_reg_reg*/D}]
+
+# --- fp_reg_file_reg -> MOVE REG_TO_MEM destinations (2-cycle MCP) ---
+set_multicycle_path -setup 2 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/fp_reg_file_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/exc_event_force_inexact_reg_reg/D}]
+set_multicycle_path -hold 1 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/fp_reg_file_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/exc_event_force_inexact_reg_reg/D}]
+
+set_multicycle_path -setup 2 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/fp_reg_file_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/exc_event_force_overflow_reg_reg/D}]
+set_multicycle_path -hold 1 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/fp_reg_file_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/exc_event_force_overflow_reg_reg/D}]
+
+set_multicycle_path -setup 2 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/fp_reg_file_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/exc_event_force_underflow_reg_reg/D}]
+set_multicycle_path -hold 1 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/fp_reg_file_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/exc_event_force_underflow_reg_reg/D}]
+
+set_multicycle_path -setup 2 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/fp_reg_file_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/exc_event_result_reg_reg*/D}]
+set_multicycle_path -hold 1 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/fp_reg_file_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/exc_event_result_reg_reg*/D}]
+
+set_multicycle_path -setup 2 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/fp_reg_file_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/exc_event_opa_reg_reg*/D}]
+set_multicycle_path -hold 1 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/fp_reg_file_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/exc_event_opa_reg_reg*/D}]
+
+# --- move_cfg_reg -> MOVE handler destinations (2-cycle MCP) ---
+# The VHDL signal move_cfg_decoded_reg (record type move_cfg_t) was optimized away
+# by synthesis; the decode logic was absorbed into combinational paths from
+# move_cfg_reg (std_logic_vector(31 downto 0)) which synthesizes as move_cfg_reg_reg[31:0].
+# The MCP rationale is the same: move_cfg_reg is written via bus write, and the MOVE
+# handler only reads it several bus cycles later when cir_launch_alu fires.
+set_multicycle_path -setup 2 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/move_cfg_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/fp_reg_file_reg_reg*/D}]
+set_multicycle_path -hold 1 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/move_cfg_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/fp_reg_file_reg_reg*/D}]
+
+set_multicycle_path -setup 2 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/move_cfg_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/exc_event_opa_reg_reg*/D}]
+set_multicycle_path -hold 1 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/move_cfg_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/exc_event_opa_reg_reg*/D}]
+
+set_multicycle_path -setup 2 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/move_cfg_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/exc_event_result_reg_reg*/D}]
+set_multicycle_path -hold 1 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/move_cfg_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/exc_event_result_reg_reg*/D}]
+
+set_multicycle_path -setup 2 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/move_cfg_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/result_ex_reg_reg*/D}]
+set_multicycle_path -hold 1 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/move_cfg_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/result_ex_reg_reg*/D}]
+
+set_multicycle_path -setup 2 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/move_cfg_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/result_lo_reg_reg*/D}]
+set_multicycle_path -hold 1 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/move_cfg_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/result_lo_reg_reg*/D}]
+
+set_multicycle_path -setup 2 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/move_cfg_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/result_hi_reg_reg*/D}]
+set_multicycle_path -hold 1 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/move_cfg_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/result_hi_reg_reg*/D}]
+
+# --- Trig log_unbiased_exp_reg -> mul_a_reg / log_exp_term_reg (2-cycle MCP) ---
+set_multicycle_path -setup 2 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/alu_inst/trig_inst/log_unbiased_exp_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/alu_inst/trig_inst/mul_a_reg_reg*/D}]
+set_multicycle_path -hold 1 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/alu_inst/trig_inst/log_unbiased_exp_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/alu_inst/trig_inst/mul_a_reg_reg*/D}]
+
+set_multicycle_path -setup 2 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/alu_inst/trig_inst/log_unbiased_exp_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/alu_inst/trig_inst/log_exp_term_reg_reg*/D}]
+set_multicycle_path -hold 1 -from [get_pins -quiet -hier -filter {REF_PIN_NAME == C && NAME =~ */u_fpu/alu_inst/trig_inst/log_unbiased_exp_reg_reg*/C}] -to [get_pins -quiet -hier -filter {REF_PIN_NAME == D && NAME =~ */u_fpu/alu_inst/trig_inst/log_exp_term_reg_reg*/D}]

--- a/wrappers/mc68881_wrapper.xdc
+++ b/wrappers/mc68881_wrapper.xdc
@@ -10,19 +10,19 @@ set_property ASYNC_REG true [get_cells -quiet -hier -filter {NAME =~ */u_bridge/
 set_property ASYNC_REG true [get_cells -quiet -hier -filter {NAME =~ */u_bridge/rst_ff*_reg}]
 
 # False paths on CDC toggle signals (bus_clk -> fpu_clk)
-set_false_path -from [get_cells -quiet -hier -filter {NAME =~ */u_bridge/req_toggle_reg*}] \
+set_false_path -from [get_cells -quiet -hier -filter {NAME =~ */u_bridge/req_toggle_reg* && IS_SEQUENTIAL}] \
                -to   [get_cells -quiet -hier -filter {NAME =~ */u_bridge/req_ff1_reg*}]
 
 # False paths on CDC toggle signals (fpu_clk -> bus_clk)
-set_false_path -from [get_cells -quiet -hier -filter {NAME =~ */u_bridge/ack_toggle_reg*}] \
+set_false_path -from [get_cells -quiet -hier -filter {NAME =~ */u_bridge/ack_toggle_reg* && IS_SEQUENTIAL}] \
                -to   [get_cells -quiet -hier -filter {NAME =~ */u_bridge/ack_ff1_reg*}]
 
 # False path on error flag CDC (fpu_clk -> bus_clk)
-set_false_path -from [get_cells -quiet -hier -filter {NAME =~ */u_bridge/fpu_error_reg*}] \
+set_false_path -from [get_cells -quiet -hier -filter {NAME =~ */u_bridge/fpu_error_reg* && IS_SEQUENTIAL}] \
                -to   [get_cells -quiet -hier -filter {NAME =~ */u_bridge/err_ff1_reg*}]
 
 # False path on status_valid CDC (fpu_clk -> bus_clk)
-set_false_path -from [get_cells -quiet -hier -filter {NAME =~ */u_fpu/status_valid_reg*}] \
+set_false_path -from [get_cells -quiet -hier -filter {NAME =~ */u_fpu/status_valid_reg* && IS_SEQUENTIAL}] \
                -to   [get_cells -quiet -hier -filter {NAME =~ */u_bridge/valid_ff1_reg*}]
 
 # False path on reset synchronizer (async input -> first sync FF)
@@ -30,15 +30,18 @@ set_false_path -to [get_cells -quiet -hier -filter {NAME =~ */u_bridge/rst_ff1_r
 
 # CDC data paths: request fields are stable before toggle crosses
 # (toggle handshake guarantees data is settled before the toggle propagates)
-set_false_path -from [get_cells -quiet -hier -filter {NAME =~ */u_bridge/req_addr_reg*}] \
-               -to   [get_cells -quiet -hier -filter {NAME =~ */u_bridge/fpu_addr_reg*}]
-set_false_path -from [get_cells -quiet -hier -filter {NAME =~ */u_bridge/req_wdata_reg*}] \
-               -to   [get_cells -quiet -hier -filter {NAME =~ */u_bridge/fpu_wdata_reg*}]
-set_false_path -from [get_cells -quiet -hier -filter {NAME =~ */u_bridge/req_rw_reg*}] \
-               -to   [get_cells -quiet -hier -filter {NAME =~ */u_bridge/fpu_rw_reg*}]
+set_false_path -from [get_cells -quiet -hier -filter {NAME =~ */u_bridge/req_addr_reg* && IS_SEQUENTIAL}] \
+               -to   [get_cells -quiet -hier -filter {NAME =~ */u_bridge/fpu_addr_reg* && IS_SEQUENTIAL}]
+set_false_path -from [get_cells -quiet -hier -filter {NAME =~ */u_bridge/req_wdata_reg* && IS_SEQUENTIAL}] \
+               -to   [get_cells -quiet -hier -filter {NAME =~ */u_bridge/fpu_wdata_reg* && IS_SEQUENTIAL}]
+set_false_path -from [get_cells -quiet -hier -filter {NAME =~ */u_bridge/req_rw_reg* && IS_SEQUENTIAL}] \
+               -to   [get_cells -quiet -hier -filter {NAME =~ */u_bridge/fpu_rw_reg* && IS_SEQUENTIAL}]
 
-# Read data path: rdata_fpu_reg is stable before ack toggle crosses back.
-# Target the actual destination registers in the wrapper FSM (bridge_rdata is
-# an output port, not a register; Vivado may merge it into the consumer).
-set_false_path -from [get_cells -quiet -hier -filter {NAME =~ */u_bridge/rdata_fpu_reg*}] \
-               -to   [get_cells -quiet -hier -filter {NAME =~ */rdata_reg*}]
+# Read data path: rdata_fpu_reg (fpu_clk) is stable before ack toggle crosses back.
+# bridge_rdata is registered in p_bus_clk, so the CDC crossing is
+# rdata_fpu_reg -> bridge_rdata_reg.  Also cover the downstream rdata_reg
+# in the wrapper (same bus_clk domain, but belt-and-suspenders).
+set_false_path -from [get_cells -quiet -hier -filter {NAME =~ */u_bridge/rdata_fpu_reg* && IS_SEQUENTIAL}] \
+               -to   [get_cells -quiet -hier -filter {NAME =~ */u_bridge/bridge_rdata_reg* && IS_SEQUENTIAL}]
+set_false_path -from [get_cells -quiet -hier -filter {NAME =~ */u_bridge/rdata_fpu_reg* && IS_SEQUENTIAL}] \
+               -to   [get_cells -quiet -hier -filter {NAME =~ */rdata_reg_reg* && IS_SEQUENTIAL}]


### PR DESCRIPTION
## Summary

- **AXI-Lite wrapper VHDL-2008 fix**: Replace conditional signal assignments (`when/else`) with `if/else` in `mc68881_axilite_wrapper.vhd` for Vivado block design OOC synthesis compatibility
- **OOC multicycle path constraints**: New `mc68881_ooc_timing.xdc` with ~50 multicycle path constraints adapted for wrapper hierarchy — fixes timing from -2.8ns WNS to +5.9ns on XCZU3EG
- **CDC constraint fixes**: Add `IS_SEQUENTIAL` filters to `mc68881_wrapper.xdc` false paths to prevent matching LUT cells; fix `rdata_reg` → `rdata_reg_reg` naming
- **Vitis test apps**: Smoke test (FPCR/FPIAR read/write), FSIN test (sin(1.0)/sin(0.0)), and e2e test with 15 vectors from GHDL testbench (ADD/SUB/MUL/DIV/SQRT/SIN/COS/TAN/ETOX/LOGN)

## Test plan

- [x] GHDL testbench passes (pre-push hook)
- [x] Vivado OOC synthesis: zero "No pins matched" warnings for MCP/CDC constraints
- [x] Vivado implementation: WNS +5.911ns on AXU3EG (xczu3eg-sfvc784-1-e)
- [x] Hardware verified: smoke test PASS, FSIN test PASS on AXU3EG board

🤖 Generated with [Claude Code](https://claude.com/claude-code)