### PR TITLE
Add fpu_lite_g generic for MC68040 hardware subset

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -24,6 +24,7 @@ echo "Running GHDL tests before push..."
   src/mc68881_top.vhd \
   tb/mc68881_golden_vectors_pkg.vhd \
   tb/tb_mc68881_alu.vhd \
+  tb/tb_mc68881_alu_lite.vhd \
   tb/tb_mc68881_known_defects.vhd \
   tb/tb_mc68881_top.vhd \
   tb/tb_mc68881_cir_dialog.vhd \
@@ -31,6 +32,9 @@ echo "Running GHDL tests before push..."
 
 "$GHDL_EXE" -e --std=08 tb_mc68881_alu
 "$GHDL_EXE" -r --std=08 tb_mc68881_alu --assert-level=error
+
+"$GHDL_EXE" -e --std=08 tb_mc68881_alu_lite
+"$GHDL_EXE" -r --std=08 tb_mc68881_alu_lite --assert-level=error
 
 "$GHDL_EXE" -e --std=08 tb_mc68881_top
 "$GHDL_EXE" -r --std=08 tb_mc68881_top --assert-level=error

--- a/.github/workflows/ghdl.yml
+++ b/.github/workflows/ghdl.yml
@@ -27,10 +27,13 @@ jobs:
             src/mc68881_top.vhd \
             tb/mc68881_golden_vectors_pkg.vhd \
             tb/tb_mc68881_alu.vhd \
+            tb/tb_mc68881_alu_lite.vhd \
             tb/tb_mc68881_known_defects.vhd \
             tb/tb_mc68881_top.vhd \
             tb/tb_mc68881_ea_cycles.vhd \
-            tb/tb_mc68881_cycle_counts.vhd
+            tb/tb_mc68881_cycle_counts.vhd \
+            tb/tb_mc68881_cir_dialog.vhd \
+            tb/tb_mc68881_torture.vhd
       - name: Run tb_mc68881_alu
         run: |
           ghdl -e --std=08 tb_mc68881_alu
@@ -47,3 +50,15 @@ jobs:
         run: |
           ghdl -e --std=08 tb_mc68881_cycle_counts
           ghdl -r --std=08 tb_mc68881_cycle_counts --assert-level=error
+      - name: Run tb_mc68881_alu_lite
+        run: |
+          ghdl -e --std=08 tb_mc68881_alu_lite
+          ghdl -r --std=08 tb_mc68881_alu_lite --assert-level=error
+      - name: Run tb_mc68881_cir_dialog
+        run: |
+          ghdl -e --std=08 tb_mc68881_cir_dialog
+          ghdl -r --std=08 tb_mc68881_cir_dialog --assert-level=error
+      - name: Run tb_mc68881_torture
+        run: |
+          ghdl -e --std=08 tb_mc68881_torture
+          ghdl -r --std=08 tb_mc68881_torture --assert-level=error

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ validation/hello_world/src/roms/bios.bin
 validation/hello_world/src/roms/bios.L68
 validation/hello_world/src/roms/bios.S68
 validation/hello_world/src/roms/listing.txt
+*.ghw
+*.vcd

--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ arithmetic, transcendental, exponential, and logarithmic operations.
 ## Features
 - **Full instruction set**: FADD, FSUB, FMUL, FDIV, FSQRT, FMOD, FREM, FSCALE,
   FSGLDIV, FSGLMUL, FABS, FNEG, FINT, FINTRZ, FGETEXP, FGETMAN, FTST, FCMP.
-- **Lite mode** (`fpu_lite_g => true`): MC68040 hardware subset -- keeps
-  ADD/SUB/MUL/DIV/SQRT/CMP/ABS/NEG/INT/INTRZ/TST plus control/move ops.
+- **Lite mode** (`fpu_lite_g => true`): MC68040 hardware subset -- keeps 11 ALU
+  ops (ADD/SUB/MUL/DIV/SQRT/CMP/ABS/NEG/INT/INTRZ/TST) plus control/move ops.
   Removes trig engine, sglops unit, and modrem post-processing via VHDL generate
-  blocks (~57-60% LUT savings). Unsupported ops return zero in 1 cycle.
+  blocks; stubs out GETEXP/GETMAN inline. Estimated ~57-60% LUT savings (pending
+  synthesis verification). Unsupported ops return zero in 1 cycle.
 - **Transcendental engine**: FSIN, FCOS, FTAN, FSINCOS, FASIN, FACOS, FATAN,
   FATANH, FSINH, FCOSH, FTANH, FETOX, FETOXM1, FTWOTOX, FTENTOX, FLOGN,
   FLOGNP1, FLOG2, FLOG10. BRAM coefficient ROM with degree-9 Horner polynomial
@@ -70,8 +71,8 @@ CIR coprocessor interface, and full exception dialog paths.*
 
 ### Target device compatibility
 The design fits on several FPGA families. With `fpu_lite_g => true` (MC68040
-hardware subset: 22 ALU ops, no trig/sglops/modrem/getexp/getman), the core
-drops to ~28K-30K LUTs:
+hardware subset: 11 ALU ops, no trig/sglops/modrem), the core is estimated at
+~28K-30K LUTs (pending synthesis verification):
 
 | Device | LUTs | DSPs | Full fit? | Lite fit? |
 |--------|------|------|-----------|-----------|
@@ -91,7 +92,7 @@ mc68881_top                     Bus interface, format converters, FMOVECR ROM
 ├── alu_inst (mc68881_alu)      Opcode dispatch, shared FP unit mux
 │   ├── trig_inst               Transcendental engine (generate: not fpu_lite)
 │   ├── divrem_inst             Radix-4 SRT division, FSQRT
-│   │   └── modrem_post         FMOD/FREM post-processing (generate: not fpu_lite)
+│   │   └── modrem_post         FMOD/FREM post-processing (generic: enable_modrem_post)
 │   ├── sglops_inst             FSCALE, FSGLDIV, FSGLMUL (generate: not fpu_lite)
 │   ├── alu_mul_inst            Shared 64×64 sequential multiplier (DSP48E1 cascade)
 │   └── alu_add_inst            Shared 67-bit sequential adder/subtractor

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ arithmetic, transcendental, exponential, and logarithmic operations.
 ## Features
 - **Full instruction set**: FADD, FSUB, FMUL, FDIV, FSQRT, FMOD, FREM, FSCALE,
   FSGLDIV, FSGLMUL, FABS, FNEG, FINT, FINTRZ, FGETEXP, FGETMAN, FTST, FCMP.
+- **Lite mode** (`fpu_lite_g => true`): MC68040 hardware subset -- keeps
+  ADD/SUB/MUL/DIV/SQRT/CMP/ABS/NEG/INT/INTRZ/TST plus control/move ops.
+  Removes trig engine, sglops unit, and modrem post-processing via VHDL generate
+  blocks (~57-60% LUT savings). Unsupported ops return zero in 1 cycle.
 - **Transcendental engine**: FSIN, FCOS, FTAN, FSINCOS, FASIN, FACOS, FATAN,
   FATANH, FSINH, FCOSH, FTANH, FETOX, FETOXM1, FTWOTOX, FTENTOX, FLOGN,
   FLOGNP1, FLOG2, FLOG10. BRAM coefficient ROM with degree-9 Horner polynomial
@@ -65,15 +69,16 @@ CIR coprocessor interface, and full exception dialog paths.*
 - Post-route WNS: **+0.405 ns** (timing met). WHS: **+0.022 ns** (no hold violations).
 
 ### Target device compatibility
-The design fits on several FPGA families. With CIR disabled (`ENABLE_CIR_g => false`),
-the core is ~56K LUTs:
+The design fits on several FPGA families. With `fpu_lite_g => true` (MC68040
+hardware subset: 22 ALU ops, no trig/sglops/modrem/getexp/getman), the core
+drops to ~28K-30K LUTs:
 
-| Device | LUTs | DSPs | Fit? |
-|--------|------|------|------|
-| Xilinx Artix-7 200T | 133,800 | 740 | Yes (47%) |
-| Xilinx Artix-7 100T | 63,400 | 240 | No (99%); Yes with CIR disabled (~88%) |
-| Xilinx Zynq UltraScale+ ZU3EG | ~71,000 | 360 | Yes (~88%) |
-| Intel Cyclone V 5CEBA7 | 150,720 ALMs | 156 | Yes |
+| Device | LUTs | DSPs | Full fit? | Lite fit? |
+|--------|------|------|-----------|-----------|
+| Xilinx Artix-7 200T | 133,800 | 740 | Yes (47%) | Yes (~21%) |
+| Xilinx Artix-7 100T | 63,400 | 240 | Tight (99%) | Yes (~45%) |
+| Xilinx Zynq UltraScale+ ZU3EG | ~71,000 | 360 | Yes (~88%) | Yes (~42%) |
+| Intel Cyclone V 5CEBA7 | 150,720 ALMs | 156 | Yes | Yes |
 
 All RTL is vendor-portable (inferred DSP/BRAM, no Xilinx IP cores). Porting to
 Intel/Quartus requires XDC-to-SDC constraint conversion and minor DSP inference
@@ -84,10 +89,10 @@ adjustments.
 ```
 mc68881_top                     Bus interface, format converters, FMOVECR ROM
 ├── alu_inst (mc68881_alu)      Opcode dispatch, shared FP unit mux
-│   ├── trig_inst               Transcendental engine (own mul/add/div — runs concurrently)
-│   ├── divrem_inst             Radix-4 SRT division, FSQRT, FMOD/FREM
-│   │   └── modrem_post         Post-processing (uses shared mul/add)
-│   ├── sglops_inst             FSCALE, FSGLDIV, FSGLMUL
+│   ├── trig_inst               Transcendental engine (generate: not fpu_lite)
+│   ├── divrem_inst             Radix-4 SRT division, FSQRT
+│   │   └── modrem_post         FMOD/FREM post-processing (generate: not fpu_lite)
+│   ├── sglops_inst             FSCALE, FSGLDIV, FSGLMUL (generate: not fpu_lite)
 │   ├── alu_mul_inst            Shared 64×64 sequential multiplier (DSP48E1 cascade)
 │   └── alu_add_inst            Shared 67-bit sequential adder/subtractor
 └── packed_unit_inst            Packed-decimal BCD encode/decode (uses shared mul/add)
@@ -125,7 +130,7 @@ instances per consumer.
 - `src/vitis/roms/` — 68000 BIOS ROM source (assembler, disassembler, monitor with FPU support)
 - `tb/` — VHDL-2008 self-checking testbenches (14 files, ~8.5K lines)
 - `docs/` — Implementation plan, timing notes, reference documentation
-- `verilog/` — Auto-generated Verilog conversion (see [verilog/README.md](verilog/README.md))
+- `verilog/` — Auto-generated Verilog conversion; `verilog/fpu_lite/` has the lite-mode variant (see [verilog/README.md](verilog/README.md))
 - `scripts/` — Test runner, golden vector generator, implementation TCL
 - `.github/workflows/ghdl.yml` — CI: GHDL analysis + 4 testbench runs
 - `.githooks/pre-push` — Pre-push GHDL regression gate
@@ -144,6 +149,7 @@ The script uses `GHDL_EXE` if set, otherwise defaults to
 ### CI testbenches
 The GitHub Actions workflow runs these testbenches on every push:
 - `tb_mc68881_alu` — Arithmetic, NaN/infinity, transcendental, special values
+- `tb_mc68881_alu_lite` — Lite-mode (`fpu_lite => true`): kept ops + removed ops return zero
 - `tb_mc68881_top` — Bus interface, format conversions, FPSR/exception checks
 - `tb_mc68881_ea_cycles` — Effective address cycle count tables
 - `tb_mc68881_cycle_counts` — Instruction cycle timing verification
@@ -210,7 +216,8 @@ automatically. To convert manually:
 powershell -ExecutionPolicy Bypass -File scripts/convert_to_verilog.ps1
 ```
 
-Output goes to [`verilog/`](verilog/). **These files are supplied as-is for
+Output goes to [`verilog/`](verilog/). A lite-mode variant (`fpu_lite_g => true`)
+is also generated into `verilog/fpu_lite/`. **These files are supplied as-is for
 information only — no guarantee of correctness is made and no tests are run on
 the converted code.** The VHDL sources remain the authoritative implementation.
 

--- a/docs/fpu-progress-checklist.md
+++ b/docs/fpu-progress-checklist.md
@@ -626,7 +626,8 @@ Keep this list short, actionable, and updated whenever a defect is fixed or newl
   - LUT reductions offset CIR additions: net +565 LUTs vs pre-CIR baseline (66,007).
   - Timing dramatically improved: WNS from +0.404 ns to +11.404 ns (+11 ns gain)
     due to carry-propagation serialization breaking worst combinational paths.
-  - CIR feature is gatable (`ENABLE_CIR_g => false`) for smaller FPGAs.
+  - CIR was initially gatable (`ENABLE_CIR_g`); later replaced by a runtime
+    register (address 13 bit 0) and the generic was removed.
 - Run data (non-incremental synthesis + implementation):
   - Utilization (post-place): `Slice LUTs = 66572 / 133800 (49.75%)`
   - DSPs: 33 / 740 (4.46%)

--- a/scripts/convert_to_verilog.ps1
+++ b/scripts/convert_to_verilog.ps1
@@ -94,6 +94,17 @@ try {
     if ($LASTEXITCODE -ne 0) { throw "GHDL synth failed: $entity" }
     $convertCount++
 
+    # --- Lite-mode top-level (fpu_lite_g => true) ---
+    $LiteDir = Join-Path $OutDir "fpu_lite"
+    if (-not (Test-Path $LiteDir)) {
+        New-Item -ItemType Directory -Path $LiteDir | Out-Null
+    }
+    $out = Join-Path $LiteDir "$entity.v"
+    Write-Host "  Converting: $TopFile -> $out (fpu_lite_g=true)"
+    & $GhdlPath synth --std=08 -fsynopsys -fexplicit --latches --out=verilog "-gfpu_lite_g=true" $entity | Out-File -Encoding ascii -FilePath $out
+    if ($LASTEXITCODE -ne 0) { throw "GHDL synth failed: $entity (lite)" }
+    $convertCount++
+
     Write-Host ""
 
     # ============================================================

--- a/scripts/convert_to_verilog.sh
+++ b/scripts/convert_to_verilog.sh
@@ -97,6 +97,15 @@ ghdl synth --std=08 -fsynopsys -fexplicit --latches \
     --out=verilog "$entity" > "$out"
 convert_count=$((convert_count + 1))
 
+# Lite-mode top-level (fpu_lite_g => true)
+LITE_DIR="$OUT_DIR/fpu_lite"
+mkdir -p "$LITE_DIR"
+out="$LITE_DIR/${entity}.v"
+echo "  Converting: $TOP_FILE -> $out (fpu_lite_g=true)"
+ghdl synth --std=08 -fsynopsys -fexplicit --latches \
+    --out=verilog -gfpu_lite_g=true "$entity" > "$out"
+convert_count=$((convert_count + 1))
+
 echo ""
 
 # ============================================================

--- a/src/mc68881_alu.vhd
+++ b/src/mc68881_alu.vhd
@@ -595,18 +595,8 @@ begin
                 when FPU_OP_ABS    => result_reg <= abs_fp80(simple_a_reg);
                 when FPU_OP_NEG    => result_reg <= neg_fp80(simple_a_reg);
                 when FPU_OP_INTRZ  => result_reg <= fintrz_fp80(simple_a_reg);
-                when FPU_OP_GETEXP =>
-                  if not fpu_lite then
-                    result_reg <= fgetexp_fp80(simple_a_reg);
-                  else
-                    result_reg <= (others => '0');
-                  end if;
-                when FPU_OP_GETMAN =>
-                  if not fpu_lite then
-                    result_reg <= fgetman_fp80(simple_a_reg);
-                  else
-                    result_reg <= (others => '0');
-                  end if;
+                when FPU_OP_GETEXP => result_reg <= fgetexp_fp80(simple_a_reg);
+                when FPU_OP_GETMAN => result_reg <= fgetman_fp80(simple_a_reg);
                 when FPU_OP_TST    => result_reg <= ftst_fp80(simple_a_reg);
                 when others        => result_reg <= (others => '0');
               end case;
@@ -646,7 +636,7 @@ begin
           else
             latency_count_reg <= op_alu_latency(op_sel) - 2;
           end if;
-        elsif is_simple_op(op_sel) then
+        elsif is_simple_op(op_sel) and (not fpu_lite or (op_sel /= FPU_OP_GETEXP and op_sel /= FPU_OP_GETMAN)) then
           if op_sel = FPU_OP_ADD or op_sel = FPU_OP_SUB or op_sel = FPU_OP_MUL then
             -- Sequential FP path: register operands, launch unit
             simple_a_reg <= a_in;
@@ -665,7 +655,7 @@ begin
             busy_reg <= '1';
             latency_count_reg <= op_alu_latency(op_sel) - 1;
           else
-            -- Lightweight combinational path (CMP/ABS/NEG/INT/INTRZ/GETEXP/GETMAN/TST)
+            -- Lightweight combinational path (CMP/ABS/NEG/INT/INTRZ/TST; GETEXP/GETMAN in full mode)
             simple_a_reg <= a_in;
             simple_b_reg <= b_in;
             simple_op_reg <= op_sel;

--- a/src/mc68881_alu.vhd
+++ b/src/mc68881_alu.vhd
@@ -5,6 +5,9 @@ use ieee.numeric_std.all;
 use work.mc68881_pkg.all;
 
 entity mc68881_alu is
+  generic (
+    fpu_lite : boolean := false
+  );
   port (
     clk     : in  std_logic;
     reset_n : in  std_logic;
@@ -216,34 +219,50 @@ architecture rtl of mc68881_alu is
   signal shared_add_rp    : fp_round_prec_t;
 
 begin
-  trig_inst : entity work.mc68881_trig_unit
-    generic map (
-      table_impl => TABLE_IMPL_BRAM
-    )
-    port map (
-      clk        => clk,
-      reset_n    => reset_n,
-      start      => trig_start_reg,
-      op_sel     => op_pending_reg,
-      a_in       => a_in,
-      round_mode => round_mode,
-      round_prec => round_prec,
-      busy       => trig_busy,
-      done       => trig_done,
-      result     => trig_result,
-      aux_valid  => trig_aux_valid,
-      aux_result => trig_aux_result,
-      flag_divzero => trig_flag_divzero,
-      save_req       => save_req,
-      save_data      => trig_save_data,
-      save_addr      => trig_save_addr,
-      restore_req    => restore_req,
-      restore_data   => restore_data,
-      restore_addr   => trig_restore_addr,
-      restore_wr     => trig_restore_wr
-    );
+  gen_trig_full : if not fpu_lite generate
+    trig_inst : entity work.mc68881_trig_unit
+      generic map (
+        table_impl => TABLE_IMPL_BRAM
+      )
+      port map (
+        clk        => clk,
+        reset_n    => reset_n,
+        start      => trig_start_reg,
+        op_sel     => op_pending_reg,
+        a_in       => a_in,
+        round_mode => round_mode,
+        round_prec => round_prec,
+        busy       => trig_busy,
+        done       => trig_done,
+        result     => trig_result,
+        aux_valid  => trig_aux_valid,
+        aux_result => trig_aux_result,
+        flag_divzero => trig_flag_divzero,
+        save_req       => save_req,
+        save_data      => trig_save_data,
+        save_addr      => trig_save_addr,
+        restore_req    => restore_req,
+        restore_data   => restore_data,
+        restore_addr   => trig_restore_addr,
+        restore_wr     => trig_restore_wr
+      );
+  end generate;
+
+  gen_trig_lite : if fpu_lite generate
+  begin
+    trig_busy <= '0';
+    trig_done <= '0';
+    trig_result <= (others => '0');
+    trig_aux_result <= (others => '0');
+    trig_aux_valid <= '0';
+    trig_flag_divzero <= '0';
+    trig_save_data <= (others => '0');
+  end generate;
 
   divrem_inst : entity work.mc68881_divrem_unit
+    generic map (
+      enable_modrem_post => not fpu_lite
+    )
     port map (
       clk     => clk,
       reset_n => reset_n,
@@ -285,19 +304,28 @@ begin
       restore_wr     => divrem_restore_wr
     );
 
-  sglops_inst : entity work.mc68881_sgl_ops_unit
-    port map (
-      clk        => clk,
-      reset_n    => reset_n,
-      start      => sglops_start_reg,
-      op_sel     => sglops_op_reg,
-      a_in       => sglops_a_reg,
-      b_in       => sglops_b_reg,
-      round_mode => sglops_rm_reg,
-      busy       => sglops_busy,
-      done       => sglops_done,
-      result     => sglops_result
-    );
+  gen_sglops_full : if not fpu_lite generate
+    sglops_inst : entity work.mc68881_sgl_ops_unit
+      port map (
+        clk        => clk,
+        reset_n    => reset_n,
+        start      => sglops_start_reg,
+        op_sel     => sglops_op_reg,
+        a_in       => sglops_a_reg,
+        b_in       => sglops_b_reg,
+        round_mode => sglops_rm_reg,
+        busy       => sglops_busy,
+        done       => sglops_done,
+        result     => sglops_result
+      );
+  end generate;
+
+  gen_sglops_lite : if fpu_lite generate
+  begin
+    sglops_busy <= '0';
+    sglops_done <= '0';
+    sglops_result <= (others => '0');
+  end generate;
 
   -- Shared FP multiply operand mux (mutually exclusive: ALU own vs modrem vs packed)
   -- pragma translate_off
@@ -567,8 +595,18 @@ begin
                 when FPU_OP_ABS    => result_reg <= abs_fp80(simple_a_reg);
                 when FPU_OP_NEG    => result_reg <= neg_fp80(simple_a_reg);
                 when FPU_OP_INTRZ  => result_reg <= fintrz_fp80(simple_a_reg);
-                when FPU_OP_GETEXP => result_reg <= fgetexp_fp80(simple_a_reg);
-                when FPU_OP_GETMAN => result_reg <= fgetman_fp80(simple_a_reg);
+                when FPU_OP_GETEXP =>
+                  if not fpu_lite then
+                    result_reg <= fgetexp_fp80(simple_a_reg);
+                  else
+                    result_reg <= (others => '0');
+                  end if;
+                when FPU_OP_GETMAN =>
+                  if not fpu_lite then
+                    result_reg <= fgetman_fp80(simple_a_reg);
+                  else
+                    result_reg <= (others => '0');
+                  end if;
                 when FPU_OP_TST    => result_reg <= ftst_fp80(simple_a_reg);
                 when others        => result_reg <= (others => '0');
               end case;
@@ -599,7 +637,7 @@ begin
         sglops_done_seen_reg <= '0';
         simple_compute_pending_reg <= '0';
         op_pending_reg <= op_sel;
-        if is_trig_op(op_sel) then
+        if is_trig_op(op_sel) and not fpu_lite then
           trig_start_reg <= '1';
           busy_reg <= '1';
           trig_done_seen_reg <= '0';
@@ -642,7 +680,7 @@ begin
               latency_count_reg <= op_alu_latency(op_sel) - 1;
             end if;
           end if;
-        elsif is_divrem_op(op_sel) then
+        elsif is_divrem_op(op_sel) and (not fpu_lite or (op_sel = FPU_OP_DIV or op_sel = FPU_OP_SQRT)) then
           divrem_op_reg <= op_sel;
           divrem_a_reg <= a_in;
           divrem_b_reg <= b_in;
@@ -655,7 +693,7 @@ begin
           else
             latency_count_reg <= op_alu_latency(op_sel) - 2;
           end if;
-        elsif is_sglops_op(op_sel) then
+        elsif is_sglops_op(op_sel) and not fpu_lite then
           sglops_op_reg <= op_sel;
           sglops_a_reg <= a_in;
           sglops_b_reg <= b_in;
@@ -668,11 +706,18 @@ begin
             latency_count_reg <= op_alu_latency(op_sel) - 2;
           end if;
         else
+          -- Unsupported or NOP: return zero immediately
           result_reg <= (others => '0');
           if op_alu_latency(op_sel) = 0 then
             valid <= '1';
             busy_reg <= '0';
             op_pending_reg <= FPU_OP_NOP;
+            latency_count_reg <= 0;
+          elsif fpu_lite then
+            -- Unsupported op in lite mode: complete after 1 cycle
+            -- Force op_pending to NOP so the simple-ops completion path handles it
+            op_pending_reg <= FPU_OP_NOP;
+            busy_reg <= '1';
             latency_count_reg <= 0;
           else
             busy_reg <= '1';

--- a/src/mc68881_top.vhd
+++ b/src/mc68881_top.vhd
@@ -13,7 +13,10 @@ entity mc68881_top is
   generic (
     -- `true`: full packed-decimal conversion path.
     -- `false`: synthesis-safe packed-decimal fallback for debug/triage builds.
-    packed_decimal_full_g : boolean := true
+    packed_decimal_full_g : boolean := true;
+    -- `true`: MC68040 hardware subset (22 ALU ops, no trig/sglops/modrem/getexp/getman).
+    -- `false`: full MC68881 (48 ops).
+    fpu_lite_g : boolean := false
   );
   port (
     -- Bus interface
@@ -1779,6 +1782,9 @@ begin
   ) else '0';
 
   alu_inst : entity work.mc68881_alu
+    generic map (
+      fpu_lite => fpu_lite_g
+    )
     port map (
       clk    => clk,
       reset_n => reset_n,

--- a/src/mc68881_top.vhd
+++ b/src/mc68881_top.vhd
@@ -14,8 +14,8 @@ entity mc68881_top is
     -- `true`: full packed-decimal conversion path.
     -- `false`: synthesis-safe packed-decimal fallback for debug/triage builds.
     packed_decimal_full_g : boolean := true;
-    -- `true`: MC68040 hardware subset (22 ALU ops, no trig/sglops/modrem/getexp/getman).
-    -- `false`: full MC68881 (48 ops).
+    -- `true`: MC68040 hardware subset (11 ALU ops, no trig/sglops/modrem/getexp/getman).
+    -- `false`: full MC68881 (37 ALU ops + 10 control/move).
     fpu_lite_g : boolean := false
   );
   port (

--- a/tb/tb_mc68881_alu_lite.vhd
+++ b/tb/tb_mc68881_alu_lite.vhd
@@ -1,0 +1,524 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use std.env.all;
+
+use work.mc68881_pkg.all;
+
+-- Lite-mode ALU testbench: verifies kept ops work and removed ops return zero.
+entity tb_mc68881_alu_lite is
+end entity tb_mc68881_alu_lite;
+
+architecture sim of tb_mc68881_alu_lite is
+  signal clk    : std_logic := '0';
+  signal reset_n: std_logic := '0';
+  signal start  : std_logic := '0';
+  signal op_sel : fpu_op_t := FPU_OP_NOP;
+  signal round_mode : fp_round_mode_t := FP_RND_NEAREST;
+  signal round_prec : fp_round_prec_t := FP_PREC_EXTENDED;
+  signal a_in   : fp80_t := (others => '0');
+  signal b_in   : fp80_t := (others => '0');
+  signal result : fp80_t;
+  signal aux_result : fp80_t;
+  signal valid  : std_logic;
+  signal aux_valid : std_logic;
+  signal quotient_valid : std_logic;
+  signal quotient_byte : std_logic_vector(7 downto 0);
+  signal flag_divzero : std_logic;
+  signal busy   : std_logic;
+
+  constant CLK_PERIOD : time := 10 ns;
+
+  -- Helper: split fp80 for assertions
+  procedure split_fp80(
+    constant value : fp80_t;
+    variable sign  : out std_logic;
+    variable exp   : out unsigned(FP_EXP_WIDTH-1 downto 0);
+    variable mant  : out unsigned(FP_MANT_WIDTH-1 downto 0)
+  ) is
+  begin
+    sign := value(FP_WIDTH-1);
+    exp  := unsigned(value(FP_WIDTH-2 downto FP_WIDTH-1-FP_EXP_WIDTH));
+    mant := unsigned(value(FP_MANT_WIDTH-1 downto 0));
+  end procedure;
+
+  procedure check_result_exact(
+    signal   res       : in fp80_t;
+    constant expected  : fp80_t;
+    constant test_name : string
+  ) is
+    variable got_sign  : std_logic := '0';
+    variable exp_sign  : std_logic := '0';
+    variable got_exp   : unsigned(FP_EXP_WIDTH-1 downto 0) := (others => '0');
+    variable exp_exp   : unsigned(FP_EXP_WIDTH-1 downto 0) := (others => '0');
+    variable got_mant  : unsigned(FP_MANT_WIDTH-1 downto 0) := (others => '0');
+    variable exp_mant  : unsigned(FP_MANT_WIDTH-1 downto 0) := (others => '0');
+  begin
+    split_fp80(res, got_sign, got_exp, got_mant);
+    split_fp80(expected, exp_sign, exp_exp, exp_mant);
+    assert got_sign = exp_sign and got_exp = exp_exp and got_mant = exp_mant
+      report "FAIL: " & test_name &
+             " expected=" & to_hstring(expected) &
+             " got=" & to_hstring(res)
+      severity failure;
+  end procedure;
+
+  procedure check_result_zero(
+    signal   res       : in fp80_t;
+    constant test_name : string
+  ) is
+    constant ZERO80 : fp80_t := (others => '0');
+  begin
+    assert res = ZERO80
+      report "FAIL: " & test_name &
+             " expected zero got=" & to_hstring(res)
+      severity failure;
+  end procedure;
+
+begin
+  clk <= not clk after CLK_PERIOD / 2;
+
+  dut : entity work.mc68881_alu
+    generic map (
+      fpu_lite => true
+    )
+    port map (
+      clk    => clk,
+      reset_n => reset_n,
+      start  => start,
+      op_sel => op_sel,
+      round_mode => round_mode,
+      round_prec => round_prec,
+      a_in   => a_in,
+      b_in   => b_in,
+      result => result,
+      valid  => valid,
+      busy   => busy,
+      quotient_byte => quotient_byte,
+      quotient_valid => quotient_valid,
+      aux_result => aux_result,
+      aux_valid => aux_valid,
+      flag_divzero => flag_divzero,
+      packed_fp_mul_start  => '0',
+      packed_fp_mul_a      => (others => '0'),
+      packed_fp_mul_b      => (others => '0'),
+      packed_fp_mul_done   => open,
+      packed_fp_mul_result => open,
+      packed_fp_add_start  => '0',
+      packed_fp_add_a      => (others => '0'),
+      packed_fp_add_b      => (others => '0'),
+      packed_fp_add_sub    => false,
+      packed_fp_add_done   => open,
+      packed_fp_add_result => open,
+      save_req       => '0',
+      save_data      => open,
+      save_addr      => 0,
+      restore_req    => '0',
+      restore_data   => (others => '0'),
+      restore_addr   => 0,
+      restore_wr     => '0'
+    );
+
+  process
+    -- FP80 constants: 1.0, 2.0, 3.0, -1.5
+    constant FP80_ONE : fp80_t := x"3FFF" & x"8000000000000000";
+    constant FP80_TWO : fp80_t := x"4000" & x"8000000000000000";
+    constant FP80_THREE : fp80_t := x"4000" & x"C000000000000000";
+    constant FP80_NEG_ONE : fp80_t := x"BFFF" & x"8000000000000000";
+    constant FP80_HALF : fp80_t := x"3FFE" & x"8000000000000000";  -- 0.5
+    constant ZERO80 : fp80_t := (others => '0');
+  begin
+    -- Reset
+    reset_n <= '0';
+    wait for CLK_PERIOD * 3;
+    reset_n <= '1';
+    wait for CLK_PERIOD * 2;
+
+    -- ================================================================
+    -- Test 1: FADD (kept op) -- 1.0 + 2.0 = 3.0
+    -- ================================================================
+    report "LITE: Testing FADD 1.0 + 2.0";
+    a_in <= FP80_ONE;
+    b_in <= FP80_TWO;
+    op_sel <= FPU_OP_ADD;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait until valid = '1';
+    wait for 0 ns;
+    check_result_exact(result, FP80_THREE, "FADD 1.0+2.0=3.0");
+    report "LITE: FADD passed";
+
+    wait for CLK_PERIOD * 2;
+
+    -- ================================================================
+    -- Test 2: FSUB (kept op) -- 2.0 - 1.0 = 1.0
+    -- ================================================================
+    report "LITE: Testing FSUB 2.0 - 1.0";
+    a_in <= FP80_TWO;
+    b_in <= FP80_ONE;
+    op_sel <= FPU_OP_SUB;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait until valid = '1';
+    wait for 0 ns;
+    check_result_exact(result, FP80_ONE, "FSUB 2.0-1.0=1.0");
+    report "LITE: FSUB passed";
+
+    wait for CLK_PERIOD * 2;
+
+    -- ================================================================
+    -- Test 3: FMUL (kept op) -- 1.0 * 2.0 = 2.0
+    -- ================================================================
+    report "LITE: Testing FMUL 1.0 * 2.0";
+    a_in <= FP80_ONE;
+    b_in <= FP80_TWO;
+    op_sel <= FPU_OP_MUL;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait until valid = '1';
+    wait for 0 ns;
+    check_result_exact(result, FP80_TWO, "FMUL 1.0*2.0=2.0");
+    report "LITE: FMUL passed";
+
+    wait for CLK_PERIOD * 2;
+
+    -- ================================================================
+    -- Test 4: FDIV (kept op) -- 2.0 / 2.0 = 1.0
+    -- ================================================================
+    report "LITE: Testing FDIV 2.0 / 2.0";
+    a_in <= FP80_TWO;
+    b_in <= FP80_TWO;
+    op_sel <= FPU_OP_DIV;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait until valid = '1';
+    wait for 0 ns;
+    check_result_exact(result, FP80_ONE, "FDIV 2.0/2.0=1.0");
+    report "LITE: FDIV passed";
+
+    wait for CLK_PERIOD * 2;
+
+    -- ================================================================
+    -- Test 5: FABS (kept op) -- ABS(-1.0) = 1.0
+    -- ================================================================
+    report "LITE: Testing FABS -1.0";
+    a_in <= FP80_NEG_ONE;
+    b_in <= ZERO80;
+    op_sel <= FPU_OP_ABS;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait until valid = '1';
+    wait for 0 ns;
+    check_result_exact(result, FP80_ONE, "FABS(-1.0)=1.0");
+    report "LITE: FABS passed";
+
+    wait for CLK_PERIOD * 2;
+
+    -- ================================================================
+    -- Test 6: FNEG (kept op) -- NEG(1.0) = -1.0
+    -- ================================================================
+    report "LITE: Testing FNEG 1.0";
+    a_in <= FP80_ONE;
+    b_in <= ZERO80;
+    op_sel <= FPU_OP_NEG;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait until valid = '1';
+    wait for 0 ns;
+    check_result_exact(result, FP80_NEG_ONE, "FNEG(1.0)=-1.0");
+    report "LITE: FNEG passed";
+
+    wait for CLK_PERIOD * 2;
+
+    -- ================================================================
+    -- Test 7: FINTRZ (kept op) -- INTRZ(2.0) = 2.0
+    -- ================================================================
+    report "LITE: Testing FINTRZ 2.0";
+    a_in <= FP80_TWO;
+    b_in <= ZERO80;
+    op_sel <= FPU_OP_INTRZ;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait until valid = '1';
+    wait for 0 ns;
+    check_result_exact(result, FP80_TWO, "FINTRZ(2.0)=2.0");
+    report "LITE: FINTRZ passed";
+
+    wait for CLK_PERIOD * 2;
+
+    -- ================================================================
+    -- Test 8: FSQRT (kept op) -- SQRT(1.0) = 1.0
+    -- ================================================================
+    report "LITE: Testing FSQRT 1.0";
+    a_in <= FP80_ONE;
+    b_in <= ZERO80;
+    op_sel <= FPU_OP_SQRT;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait until valid = '1';
+    wait for 0 ns;
+    check_result_exact(result, FP80_ONE, "FSQRT(1.0)=1.0");
+    report "LITE: FSQRT passed";
+
+    wait for CLK_PERIOD * 2;
+
+    -- ================================================================
+    -- Test 9: FCMP (kept op) -- CMP(2.0, 1.0) => positive (fp80_from_int(1) = 1.0)
+    -- ================================================================
+    report "LITE: Testing FCMP 2.0 vs 1.0";
+    a_in <= FP80_TWO;
+    b_in <= FP80_ONE;
+    op_sel <= FPU_OP_CMP;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait until valid = '1';
+    wait for 0 ns;
+    check_result_exact(result, FP80_ONE, "FCMP(2.0,1.0)=+1");
+    report "LITE: FCMP passed";
+
+    wait for CLK_PERIOD * 2;
+
+    -- ================================================================
+    -- Test 10: FINT (kept op) -- INT(2.0, nearest) = 2.0
+    -- ================================================================
+    report "LITE: Testing FINT 2.0";
+    a_in <= FP80_TWO;
+    b_in <= ZERO80;
+    op_sel <= FPU_OP_INT;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait until valid = '1';
+    wait for 0 ns;
+    check_result_exact(result, FP80_TWO, "FINT(2.0)=2.0");
+    report "LITE: FINT passed";
+
+    wait for CLK_PERIOD * 2;
+
+    -- ================================================================
+    -- Test 11: FTST (kept op) -- TST(1.0) passthrough = 1.0
+    -- ================================================================
+    report "LITE: Testing FTST 1.0";
+    a_in <= FP80_ONE;
+    b_in <= ZERO80;
+    op_sel <= FPU_OP_TST;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait until valid = '1';
+    wait for 0 ns;
+    check_result_exact(result, FP80_ONE, "FTST(1.0)=1.0");
+    report "LITE: FTST passed";
+
+    wait for CLK_PERIOD * 2;
+
+    -- ================================================================
+    -- Removed ops: verify they return zero and don't hang
+    -- ================================================================
+
+    -- FSIN (trig -- removed)
+    report "LITE: Testing FSIN (removed op, expect zero)";
+    a_in <= FP80_ONE;
+    b_in <= ZERO80;
+    op_sel <= FPU_OP_SIN;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait until valid = '1';
+    wait for 0 ns;
+    check_result_zero(result, "FSIN (removed) returns zero");
+    report "LITE: FSIN (removed) passed -- returned zero";
+
+    wait for CLK_PERIOD * 2;
+
+    -- FCOS (trig -- removed)
+    report "LITE: Testing FCOS (removed op, expect zero)";
+    a_in <= FP80_ONE;
+    b_in <= ZERO80;
+    op_sel <= FPU_OP_COS;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait until valid = '1';
+    wait for 0 ns;
+    check_result_zero(result, "FCOS (removed) returns zero");
+    report "LITE: FCOS (removed) passed -- returned zero";
+
+    wait for CLK_PERIOD * 2;
+
+    -- FETOX (trig -- removed)
+    report "LITE: Testing FETOX (removed op, expect zero)";
+    a_in <= FP80_ONE;
+    b_in <= ZERO80;
+    op_sel <= FPU_OP_ETOX;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait until valid = '1';
+    wait for 0 ns;
+    check_result_zero(result, "FETOX (removed) returns zero");
+    report "LITE: FETOX (removed) passed -- returned zero";
+
+    wait for CLK_PERIOD * 2;
+
+    -- FSCALE (sglops -- removed)
+    report "LITE: Testing FSCALE (removed op, expect zero)";
+    a_in <= FP80_ONE;
+    b_in <= FP80_TWO;
+    op_sel <= FPU_OP_SCALE;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait until valid = '1';
+    wait for 0 ns;
+    check_result_zero(result, "FSCALE (removed) returns zero");
+    report "LITE: FSCALE (removed) passed -- returned zero";
+
+    wait for CLK_PERIOD * 2;
+
+    -- FSGLDIV (sglops -- removed)
+    report "LITE: Testing FSGLDIV (removed op, expect zero)";
+    a_in <= FP80_TWO;
+    b_in <= FP80_ONE;
+    op_sel <= FPU_OP_SGLDIV;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait until valid = '1';
+    wait for 0 ns;
+    check_result_zero(result, "FSGLDIV (removed) returns zero");
+    report "LITE: FSGLDIV (removed) passed -- returned zero";
+
+    wait for CLK_PERIOD * 2;
+
+    -- FMOD (modrem -- removed)
+    report "LITE: Testing FMOD (removed op, expect zero)";
+    a_in <= FP80_THREE;
+    b_in <= FP80_TWO;
+    op_sel <= FPU_OP_MOD;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait until valid = '1';
+    wait for 0 ns;
+    check_result_zero(result, "FMOD (removed) returns zero");
+    report "LITE: FMOD (removed) passed -- returned zero";
+
+    wait for CLK_PERIOD * 2;
+
+    -- FREM (modrem -- removed)
+    report "LITE: Testing FREM (removed op, expect zero)";
+    a_in <= FP80_THREE;
+    b_in <= FP80_TWO;
+    op_sel <= FPU_OP_REM;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait until valid = '1';
+    wait for 0 ns;
+    check_result_zero(result, "FREM (removed) returns zero");
+    report "LITE: FREM (removed) passed -- returned zero";
+
+    wait for CLK_PERIOD * 2;
+
+    -- FGETEXP (removed in lite)
+    report "LITE: Testing FGETEXP (removed op, expect zero)";
+    a_in <= FP80_TWO;
+    b_in <= ZERO80;
+    op_sel <= FPU_OP_GETEXP;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait until valid = '1';
+    wait for 0 ns;
+    check_result_zero(result, "FGETEXP (removed) returns zero");
+    report "LITE: FGETEXP (removed) passed -- returned zero";
+
+    wait for CLK_PERIOD * 2;
+
+    -- FGETMAN (removed in lite)
+    report "LITE: Testing FGETMAN (removed op, expect zero)";
+    a_in <= FP80_TWO;
+    b_in <= ZERO80;
+    op_sel <= FPU_OP_GETMAN;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait until valid = '1';
+    wait for 0 ns;
+    check_result_zero(result, "FGETMAN (removed) returns zero");
+    report "LITE: FGETMAN (removed) passed -- returned zero";
+
+    wait for CLK_PERIOD * 2;
+
+    -- ================================================================
+    -- Test: FADD after removed ops (verify pipeline not corrupted)
+    -- ================================================================
+    report "LITE: Testing FADD after removed ops (pipeline integrity)";
+    a_in <= FP80_ONE;
+    b_in <= FP80_ONE;
+    op_sel <= FPU_OP_ADD;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait until valid = '1';
+    wait for 0 ns;
+    check_result_exact(result, FP80_TWO, "FADD 1.0+1.0=2.0 after removed ops");
+    report "LITE: Post-removed-ops FADD passed";
+
+    report "LITE: All lite-mode tests passed";
+    std.env.stop;
+    wait;
+  end process;
+end architecture sim;

--- a/tb/tb_mc68881_alu_lite.vhd
+++ b/tb/tb_mc68881_alu_lite.vhd
@@ -28,6 +28,7 @@ architecture sim of tb_mc68881_alu_lite is
   signal busy   : std_logic;
 
   constant CLK_PERIOD : time := 10 ns;
+  constant TIMEOUT    : time := 1 us;
 
   -- Helper: split fp80 for assertions
   procedure split_fp80(
@@ -75,6 +76,17 @@ architecture sim of tb_mc68881_alu_lite is
       severity failure;
   end procedure;
 
+  -- Wait for valid with timeout protection
+  procedure wait_valid(constant test_name : string) is
+  begin
+    wait until valid = '1' for TIMEOUT;
+    assert valid = '1'
+      report "TIMEOUT: " & test_name & " did not complete within " &
+             time'image(TIMEOUT)
+      severity failure;
+    wait for 0 ns;
+  end procedure;
+
 begin
   clk <= not clk after CLK_PERIOD / 2;
 
@@ -120,7 +132,7 @@ begin
     );
 
   process
-    -- FP80 constants: 1.0, 2.0, 3.0, -1.5
+    -- FP80 constants
     constant FP80_ONE : fp80_t := x"3FFF" & x"8000000000000000";
     constant FP80_TWO : fp80_t := x"4000" & x"8000000000000000";
     constant FP80_THREE : fp80_t := x"4000" & x"C000000000000000";
@@ -135,8 +147,10 @@ begin
     wait for CLK_PERIOD * 2;
 
     -- ================================================================
-    -- Test 1: FADD (kept op) -- 1.0 + 2.0 = 3.0
+    -- Kept ops (11 ALU operations)
     -- ================================================================
+
+    -- Test 1: FADD 1.0 + 2.0 = 3.0
     report "LITE: Testing FADD 1.0 + 2.0";
     a_in <= FP80_ONE;
     b_in <= FP80_TWO;
@@ -146,16 +160,13 @@ begin
     wait until rising_edge(clk);
     start <= '0';
     wait for 0 ns;
-    wait until valid = '1';
-    wait for 0 ns;
+    wait_valid("FADD");
     check_result_exact(result, FP80_THREE, "FADD 1.0+2.0=3.0");
     report "LITE: FADD passed";
 
     wait for CLK_PERIOD * 2;
 
-    -- ================================================================
-    -- Test 2: FSUB (kept op) -- 2.0 - 1.0 = 1.0
-    -- ================================================================
+    -- Test 2: FSUB 2.0 - 1.0 = 1.0
     report "LITE: Testing FSUB 2.0 - 1.0";
     a_in <= FP80_TWO;
     b_in <= FP80_ONE;
@@ -165,16 +176,13 @@ begin
     wait until rising_edge(clk);
     start <= '0';
     wait for 0 ns;
-    wait until valid = '1';
-    wait for 0 ns;
+    wait_valid("FSUB");
     check_result_exact(result, FP80_ONE, "FSUB 2.0-1.0=1.0");
     report "LITE: FSUB passed";
 
     wait for CLK_PERIOD * 2;
 
-    -- ================================================================
-    -- Test 3: FMUL (kept op) -- 1.0 * 2.0 = 2.0
-    -- ================================================================
+    -- Test 3: FMUL 1.0 * 2.0 = 2.0
     report "LITE: Testing FMUL 1.0 * 2.0";
     a_in <= FP80_ONE;
     b_in <= FP80_TWO;
@@ -184,16 +192,13 @@ begin
     wait until rising_edge(clk);
     start <= '0';
     wait for 0 ns;
-    wait until valid = '1';
-    wait for 0 ns;
+    wait_valid("FMUL");
     check_result_exact(result, FP80_TWO, "FMUL 1.0*2.0=2.0");
     report "LITE: FMUL passed";
 
     wait for CLK_PERIOD * 2;
 
-    -- ================================================================
-    -- Test 4: FDIV (kept op) -- 2.0 / 2.0 = 1.0
-    -- ================================================================
+    -- Test 4: FDIV 2.0 / 2.0 = 1.0
     report "LITE: Testing FDIV 2.0 / 2.0";
     a_in <= FP80_TWO;
     b_in <= FP80_TWO;
@@ -203,16 +208,13 @@ begin
     wait until rising_edge(clk);
     start <= '0';
     wait for 0 ns;
-    wait until valid = '1';
-    wait for 0 ns;
+    wait_valid("FDIV");
     check_result_exact(result, FP80_ONE, "FDIV 2.0/2.0=1.0");
     report "LITE: FDIV passed";
 
     wait for CLK_PERIOD * 2;
 
-    -- ================================================================
-    -- Test 5: FABS (kept op) -- ABS(-1.0) = 1.0
-    -- ================================================================
+    -- Test 5: FABS(-1.0) = 1.0
     report "LITE: Testing FABS -1.0";
     a_in <= FP80_NEG_ONE;
     b_in <= ZERO80;
@@ -222,16 +224,13 @@ begin
     wait until rising_edge(clk);
     start <= '0';
     wait for 0 ns;
-    wait until valid = '1';
-    wait for 0 ns;
+    wait_valid("FABS");
     check_result_exact(result, FP80_ONE, "FABS(-1.0)=1.0");
     report "LITE: FABS passed";
 
     wait for CLK_PERIOD * 2;
 
-    -- ================================================================
-    -- Test 6: FNEG (kept op) -- NEG(1.0) = -1.0
-    -- ================================================================
+    -- Test 6: FNEG(1.0) = -1.0
     report "LITE: Testing FNEG 1.0";
     a_in <= FP80_ONE;
     b_in <= ZERO80;
@@ -241,16 +240,13 @@ begin
     wait until rising_edge(clk);
     start <= '0';
     wait for 0 ns;
-    wait until valid = '1';
-    wait for 0 ns;
+    wait_valid("FNEG");
     check_result_exact(result, FP80_NEG_ONE, "FNEG(1.0)=-1.0");
     report "LITE: FNEG passed";
 
     wait for CLK_PERIOD * 2;
 
-    -- ================================================================
-    -- Test 7: FINTRZ (kept op) -- INTRZ(2.0) = 2.0
-    -- ================================================================
+    -- Test 7: FINTRZ(2.0) = 2.0
     report "LITE: Testing FINTRZ 2.0";
     a_in <= FP80_TWO;
     b_in <= ZERO80;
@@ -260,16 +256,13 @@ begin
     wait until rising_edge(clk);
     start <= '0';
     wait for 0 ns;
-    wait until valid = '1';
-    wait for 0 ns;
+    wait_valid("FINTRZ");
     check_result_exact(result, FP80_TWO, "FINTRZ(2.0)=2.0");
     report "LITE: FINTRZ passed";
 
     wait for CLK_PERIOD * 2;
 
-    -- ================================================================
-    -- Test 8: FSQRT (kept op) -- SQRT(1.0) = 1.0
-    -- ================================================================
+    -- Test 8: FSQRT(1.0) = 1.0
     report "LITE: Testing FSQRT 1.0";
     a_in <= FP80_ONE;
     b_in <= ZERO80;
@@ -279,16 +272,13 @@ begin
     wait until rising_edge(clk);
     start <= '0';
     wait for 0 ns;
-    wait until valid = '1';
-    wait for 0 ns;
+    wait_valid("FSQRT");
     check_result_exact(result, FP80_ONE, "FSQRT(1.0)=1.0");
     report "LITE: FSQRT passed";
 
     wait for CLK_PERIOD * 2;
 
-    -- ================================================================
-    -- Test 9: FCMP (kept op) -- CMP(2.0, 1.0) => positive (fp80_from_int(1) = 1.0)
-    -- ================================================================
+    -- Test 9: FCMP(2.0, 1.0) => positive
     report "LITE: Testing FCMP 2.0 vs 1.0";
     a_in <= FP80_TWO;
     b_in <= FP80_ONE;
@@ -298,16 +288,13 @@ begin
     wait until rising_edge(clk);
     start <= '0';
     wait for 0 ns;
-    wait until valid = '1';
-    wait for 0 ns;
+    wait_valid("FCMP");
     check_result_exact(result, FP80_ONE, "FCMP(2.0,1.0)=+1");
     report "LITE: FCMP passed";
 
     wait for CLK_PERIOD * 2;
 
-    -- ================================================================
-    -- Test 10: FINT (kept op) -- INT(2.0, nearest) = 2.0
-    -- ================================================================
+    -- Test 10: FINT(2.0, nearest) = 2.0
     report "LITE: Testing FINT 2.0";
     a_in <= FP80_TWO;
     b_in <= ZERO80;
@@ -317,16 +304,13 @@ begin
     wait until rising_edge(clk);
     start <= '0';
     wait for 0 ns;
-    wait until valid = '1';
-    wait for 0 ns;
+    wait_valid("FINT");
     check_result_exact(result, FP80_TWO, "FINT(2.0)=2.0");
     report "LITE: FINT passed";
 
     wait for CLK_PERIOD * 2;
 
-    -- ================================================================
-    -- Test 11: FTST (kept op) -- TST(1.0) passthrough = 1.0
-    -- ================================================================
+    -- Test 11: FTST(1.0) passthrough = 1.0
     report "LITE: Testing FTST 1.0";
     a_in <= FP80_ONE;
     b_in <= ZERO80;
@@ -336,8 +320,7 @@ begin
     wait until rising_edge(clk);
     start <= '0';
     wait for 0 ns;
-    wait until valid = '1';
-    wait for 0 ns;
+    wait_valid("FTST");
     check_result_exact(result, FP80_ONE, "FTST(1.0)=1.0");
     report "LITE: FTST passed";
 
@@ -357,10 +340,9 @@ begin
     wait until rising_edge(clk);
     start <= '0';
     wait for 0 ns;
-    wait until valid = '1';
-    wait for 0 ns;
+    wait_valid("FSIN removed");
     check_result_zero(result, "FSIN (removed) returns zero");
-    report "LITE: FSIN (removed) passed -- returned zero";
+    report "LITE: FSIN (removed) passed";
 
     wait for CLK_PERIOD * 2;
 
@@ -374,10 +356,9 @@ begin
     wait until rising_edge(clk);
     start <= '0';
     wait for 0 ns;
-    wait until valid = '1';
-    wait for 0 ns;
+    wait_valid("FCOS removed");
     check_result_zero(result, "FCOS (removed) returns zero");
-    report "LITE: FCOS (removed) passed -- returned zero";
+    report "LITE: FCOS (removed) passed";
 
     wait for CLK_PERIOD * 2;
 
@@ -391,10 +372,41 @@ begin
     wait until rising_edge(clk);
     start <= '0';
     wait for 0 ns;
-    wait until valid = '1';
-    wait for 0 ns;
+    wait_valid("FETOX removed");
     check_result_zero(result, "FETOX (removed) returns zero");
-    report "LITE: FETOX (removed) passed -- returned zero";
+    report "LITE: FETOX (removed) passed";
+
+    wait for CLK_PERIOD * 2;
+
+    -- FATAN (inverse trig -- removed)
+    report "LITE: Testing FATAN (removed op, expect zero)";
+    a_in <= FP80_ONE;
+    b_in <= ZERO80;
+    op_sel <= FPU_OP_ATAN;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait_valid("FATAN removed");
+    check_result_zero(result, "FATAN (removed) returns zero");
+    report "LITE: FATAN (removed) passed";
+
+    wait for CLK_PERIOD * 2;
+
+    -- FLOGN (logarithmic -- removed)
+    report "LITE: Testing FLOGN (removed op, expect zero)";
+    a_in <= FP80_ONE;
+    b_in <= ZERO80;
+    op_sel <= FPU_OP_LOGN;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait_valid("FLOGN removed");
+    check_result_zero(result, "FLOGN (removed) returns zero");
+    report "LITE: FLOGN (removed) passed";
 
     wait for CLK_PERIOD * 2;
 
@@ -408,10 +420,9 @@ begin
     wait until rising_edge(clk);
     start <= '0';
     wait for 0 ns;
-    wait until valid = '1';
-    wait for 0 ns;
+    wait_valid("FSCALE removed");
     check_result_zero(result, "FSCALE (removed) returns zero");
-    report "LITE: FSCALE (removed) passed -- returned zero";
+    report "LITE: FSCALE (removed) passed";
 
     wait for CLK_PERIOD * 2;
 
@@ -425,10 +436,25 @@ begin
     wait until rising_edge(clk);
     start <= '0';
     wait for 0 ns;
-    wait until valid = '1';
-    wait for 0 ns;
+    wait_valid("FSGLDIV removed");
     check_result_zero(result, "FSGLDIV (removed) returns zero");
-    report "LITE: FSGLDIV (removed) passed -- returned zero";
+    report "LITE: FSGLDIV (removed) passed";
+
+    wait for CLK_PERIOD * 2;
+
+    -- FSGLMUL (sglops -- removed)
+    report "LITE: Testing FSGLMUL (removed op, expect zero)";
+    a_in <= FP80_TWO;
+    b_in <= FP80_THREE;
+    op_sel <= FPU_OP_SGLMUL;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait_valid("FSGLMUL removed");
+    check_result_zero(result, "FSGLMUL (removed) returns zero");
+    report "LITE: FSGLMUL (removed) passed";
 
     wait for CLK_PERIOD * 2;
 
@@ -442,10 +468,9 @@ begin
     wait until rising_edge(clk);
     start <= '0';
     wait for 0 ns;
-    wait until valid = '1';
-    wait for 0 ns;
+    wait_valid("FMOD removed");
     check_result_zero(result, "FMOD (removed) returns zero");
-    report "LITE: FMOD (removed) passed -- returned zero";
+    report "LITE: FMOD (removed) passed";
 
     wait for CLK_PERIOD * 2;
 
@@ -459,10 +484,9 @@ begin
     wait until rising_edge(clk);
     start <= '0';
     wait for 0 ns;
-    wait until valid = '1';
-    wait for 0 ns;
+    wait_valid("FREM removed");
     check_result_zero(result, "FREM (removed) returns zero");
-    report "LITE: FREM (removed) passed -- returned zero";
+    report "LITE: FREM (removed) passed";
 
     wait for CLK_PERIOD * 2;
 
@@ -476,10 +500,9 @@ begin
     wait until rising_edge(clk);
     start <= '0';
     wait for 0 ns;
-    wait until valid = '1';
-    wait for 0 ns;
+    wait_valid("FGETEXP removed");
     check_result_zero(result, "FGETEXP (removed) returns zero");
-    report "LITE: FGETEXP (removed) passed -- returned zero";
+    report "LITE: FGETEXP (removed) passed";
 
     wait for CLK_PERIOD * 2;
 
@@ -493,15 +516,14 @@ begin
     wait until rising_edge(clk);
     start <= '0';
     wait for 0 ns;
-    wait until valid = '1';
-    wait for 0 ns;
+    wait_valid("FGETMAN removed");
     check_result_zero(result, "FGETMAN (removed) returns zero");
-    report "LITE: FGETMAN (removed) passed -- returned zero";
+    report "LITE: FGETMAN (removed) passed";
 
     wait for CLK_PERIOD * 2;
 
     -- ================================================================
-    -- Test: FADD after removed ops (verify pipeline not corrupted)
+    -- Pipeline integrity: FADD after removed ops
     -- ================================================================
     report "LITE: Testing FADD after removed ops (pipeline integrity)";
     a_in <= FP80_ONE;
@@ -512,10 +534,67 @@ begin
     wait until rising_edge(clk);
     start <= '0';
     wait for 0 ns;
-    wait until valid = '1';
-    wait for 0 ns;
+    wait_valid("FADD after removed ops");
     check_result_exact(result, FP80_TWO, "FADD 1.0+1.0=2.0 after removed ops");
     report "LITE: Post-removed-ops FADD passed";
+
+    wait for CLK_PERIOD * 2;
+
+    -- ================================================================
+    -- Back-to-back: removed op then kept op with no gap
+    -- Verifies busy/valid handshake works without idle cycles
+    -- ================================================================
+    report "LITE: Testing back-to-back: FSIN(removed) then FADD(kept), no gap";
+    -- Issue FSIN (removed)
+    a_in <= FP80_ONE;
+    b_in <= ZERO80;
+    op_sel <= FPU_OP_SIN;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait_valid("FSIN back-to-back");
+    check_result_zero(result, "FSIN back-to-back returns zero");
+    -- Immediately issue FADD with no gap (start on next clock)
+    a_in <= FP80_ONE;
+    b_in <= FP80_TWO;
+    op_sel <= FPU_OP_ADD;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait_valid("FADD back-to-back after FSIN");
+    check_result_exact(result, FP80_THREE, "FADD 1+2=3 back-to-back after removed op");
+    report "LITE: Back-to-back (removed then kept) passed";
+
+    wait for CLK_PERIOD * 2;
+
+    -- Back-to-back: kept op then removed op
+    report "LITE: Testing back-to-back: FNEG(kept) then FSCALE(removed), no gap";
+    a_in <= FP80_ONE;
+    b_in <= ZERO80;
+    op_sel <= FPU_OP_NEG;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait_valid("FNEG back-to-back");
+    check_result_exact(result, FP80_NEG_ONE, "FNEG(1.0) back-to-back");
+    -- Immediately issue FSCALE (removed)
+    a_in <= FP80_ONE;
+    b_in <= FP80_TWO;
+    op_sel <= FPU_OP_SCALE;
+    wait until rising_edge(clk);
+    start <= '1';
+    wait until rising_edge(clk);
+    start <= '0';
+    wait for 0 ns;
+    wait_valid("FSCALE back-to-back after FNEG");
+    check_result_zero(result, "FSCALE back-to-back returns zero");
+    report "LITE: Back-to-back (kept then removed) passed";
 
     report "LITE: All lite-mode tests passed";
     std.env.stop;


### PR DESCRIPTION
## Summary
- Adds `fpu_lite_g` generic to `mc68881_top` (and `fpu_lite` to `mc68881_alu`) that conditionally removes the trig engine, sglops unit, and modrem post-processing via VHDL generate blocks
- In lite mode, 22 ALU ops are kept (ADD/SUB/MUL/DIV/SQRT/CMP/ABS/NEG/INT/INTRZ/TST + control/move); unsupported ops return zero in 1 cycle
- Estimated savings: ~40K-43K LUTs (57-60%), dropping from ~63K to ~28K-30K LUTs
- Follows existing `enable_modrem_post` generate pattern from `mc68881_divrem_unit`

### Files changed
- `src/mc68881_top.vhd` — new `fpu_lite_g` generic, passed to ALU
- `src/mc68881_alu.vhd` — generate blocks for trig/sglops, `enable_modrem_post => not fpu_lite`, gated dispatch for removed ops
- `tb/tb_mc68881_alu_lite.vhd` — new testbench: 11 kept-op tests + 9 removed-op tests + pipeline integrity
- `.githooks/pre-push` — runs lite testbench alongside existing tests
- `scripts/convert_to_verilog.{ps1,sh}` — generates lite Verilog into `verilog/fpu_lite/`
- `README.md` — lite mode feature, updated device table, architecture diagram, removed obsolete `ENABLE_CIR_g` references
- `docs/fpu-progress-checklist.md` — updated historical `ENABLE_CIR_g` note

## Test plan
- [x] Full-mode regression: `tb_mc68881_alu` passes (349 vectors, no changes to default behaviour)
- [x] Lite-mode: `tb_mc68881_alu_lite` passes (11 kept ops + 9 removed ops + pipeline integrity)
- [x] Pre-push hook runs both testbenches plus top/CIR/torture (all pass)
- [ ] Vivado non-incremental synthesis of both configurations to compare utilization

🤖 Generated with [Claude Code](https://claude.com/claude-code)