### PR TITLE
Make RTL VHDL-93 compatible for Quartus 17 (MiSTer)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ validation/hello_world/src/roms/bios.S68
 validation/hello_world/src/roms/listing.txt
 *.ghw
 *.vcd
+validation/hello_world/src/roms/savage.bin

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ hardware subset: 11 ALU ops, no trig/sglops/modrem), the core uses 37,380 LUTs
 | Intel Cyclone V SE 5CSEBA6 (MiSTer DE10-Nano) | 41,910 ALMs | 112 | No (~75%) | Yes (~45%) |
 
 All RTL is VHDL-93 compatible and vendor-portable (inferred DSP/BRAM, no Xilinx
-IP cores). The source synthesizes directly in Quartus 17+ (as used by MiSTer)
-without requiring VHDL-2008 support. Verify with `scripts/check_vhdl93.sh`.
+IP cores). The source is VHDL-93 compatible (verified via `ghdl --std=93`) and
+should synthesize directly in Quartus 17+ (as used by MiSTer). Verify with `scripts/check_vhdl93.sh`.
 Porting requires XDC-to-SDC constraint conversion and minor DSP inference
 adjustments.
 

--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ arithmetic, transcendental, exponential, and logarithmic operations.
 
 ## Utilization (Xilinx Artix-7 200T, post-place)
 
-| Resource | Used | Available | Util% |
-|----------|------|-----------|-------|
-| Slice LUTs | 62,784 | 133,800 | 46.92% |
-| Registers | 13,629 | 267,600 | 5.09% |
-| Block RAM | 8 tiles | 365 | 2.19% |
-| DSP48E1 | 34 | 740 | 4.59% |
+| Resource | Full | Lite (`fpu_lite_g`) | Available | Full % | Lite % |
+|----------|------|---------------------|-----------|--------|--------|
+| Slice LUTs | 62,281 | 37,380 | 133,800 | 46.55% | 27.94% |
+| Registers | 13,655 | 7,030 | 267,600 | 5.10% | 2.63% |
+| Block RAM | 8 tiles | 0 | 365 | 2.19% | 0% |
+| DSP48E1 | 34 | 18 | 740 | 4.59% | 2.43% |
 
-*Non-incremental synthesis + implementation, Vivado 2025.2, `xc7a200tfbg676-1`. Date: 2026-03-08.
+*Non-incremental synthesis + implementation, Vivado 2025.2, `xc7a200tfbg676-1`. Date: 2026-03-15.
 33 MHz target clock. Includes transcendental accuracy improvements (BRAM coefficient ROM,
 table-assisted ATAN/LOG, Cody-Waite trig/EXP), GHDL synth-compatible RTL,
 CIR coprocessor interface, and full exception dialog paths.*
@@ -67,20 +67,20 @@ CIR coprocessor interface, and full exception dialog paths.*
   FP register file to exception destinations).
 - Packed decimal encode pipeline: 3-stage split (exponent extraction → DSP multiply
   → scale computation) with pipelined DSP48E1 input.
-- Post-route WNS: **+0.405 ns** (timing met). WHS: **+0.022 ns** (no hold violations).
+- Post-route WNS: **+0.129 ns** full / **+0.160 ns** lite (timing met). No hold violations.
 
 ### Target device compatibility
 The design fits on several FPGA families. With `fpu_lite_g => true` (MC68040
-hardware subset: 11 ALU ops, no trig/sglops/modrem), the core is estimated at
-~28K-30K LUTs (pending synthesis verification):
+hardware subset: 11 ALU ops, no trig/sglops/modrem), the core uses 37,380 LUTs
+/ 18 DSPs / 0 BRAM:
 
 | Device | LUTs | DSPs | Full fit? | Lite fit? |
 |--------|------|------|-----------|-----------|
-| Xilinx Artix-7 200T | 133,800 | 740 | Yes (47%) | Yes (~21%) |
-| Xilinx Artix-7 100T | 63,400 | 240 | Tight (99%) | Yes (~45%) |
-| Xilinx Zynq UltraScale+ ZU3EG | ~71,000 | 360 | Yes (~88%) | Yes (~42%) |
+| Xilinx Artix-7 200T | 133,800 | 740 | Yes (47%) | Yes (28%) |
+| Xilinx Artix-7 100T | 63,400 | 240 | Tight (98%) | Yes (59%) |
+| Xilinx Zynq UltraScale+ ZU3EG | ~71,000 | 360 | Yes (~88%) | Yes (~53%) |
 | Intel Cyclone V 5CEBA7 | 150,720 ALMs | 156 | Yes | Yes |
-| Intel Cyclone V SE 5CSEBA6 (MiSTer DE10-Nano) | 41,910 ALMs | 112 | No (~75%) | Likely (~35%) |
+| Intel Cyclone V SE 5CSEBA6 (MiSTer DE10-Nano) | 41,910 ALMs | 112 | No (~75%) | Yes (~45%) |
 
 All RTL is VHDL-93 compatible and vendor-portable (inferred DSP/BRAM, no Xilinx
 IP cores). The source synthesizes directly in Quartus 17+ (as used by MiSTer)
@@ -88,9 +88,9 @@ without requiring VHDL-2008 support. Porting requires XDC-to-SDC constraint
 conversion and minor DSP inference adjustments.
 
 **MiSTer note:** The DE10-Nano's Cyclone V SE has 41,910 ALMs (each ALM roughly
-maps to 2 Xilinx LUTs, giving ~84K LUT-equivalent). The full FPU (~63K LUTs /
+maps to 2 Xilinx LUTs, giving ~84K LUT-equivalent). The full FPU (62K LUTs /
 34 DSPs) exceeds ALM capacity but fits within the 112 DSP budget. Lite mode
-(~28K-30K LUTs, ~14K-15K ALMs, ~17 DSPs) should fit comfortably. These are rough
+(37K LUTs ≈ ~19K ALMs, 18 DSPs, 0 BRAM) should fit comfortably. These are rough
 estimates; actual Quartus ALM counts may differ from Xilinx LUT counts due to
 architectural differences.
 

--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ hardware subset: 11 ALU ops, no trig/sglops/modrem), the core uses 37,380 LUTs
 
 All RTL is VHDL-93 compatible and vendor-portable (inferred DSP/BRAM, no Xilinx
 IP cores). The source synthesizes directly in Quartus 17+ (as used by MiSTer)
-without requiring VHDL-2008 support. Porting requires XDC-to-SDC constraint
-conversion and minor DSP inference adjustments.
+without requiring VHDL-2008 support. Verify with `scripts/check_vhdl93.sh`.
+Porting requires XDC-to-SDC constraint conversion and minor DSP inference
+adjustments.
 
 **MiSTer note:** The DE10-Nano's Cyclone V SE has 41,910 ALMs (each ALM roughly
 maps to 2 Xilinx LUTs, giving ~84K LUT-equivalent). The full FPU (62K LUTs /

--- a/README.md
+++ b/README.md
@@ -82,9 +82,10 @@ hardware subset: 11 ALU ops, no trig/sglops/modrem), the core is estimated at
 | Intel Cyclone V 5CEBA7 | 150,720 ALMs | 156 | Yes | Yes |
 | Intel Cyclone V SE 5CSEBA6 (MiSTer DE10-Nano) | 41,910 ALMs | 112 | No (~75%) | Likely (~35%) |
 
-All RTL is vendor-portable (inferred DSP/BRAM, no Xilinx IP cores). Porting to
-Intel/Quartus requires XDC-to-SDC constraint conversion and minor DSP inference
-adjustments.
+All RTL is VHDL-93 compatible and vendor-portable (inferred DSP/BRAM, no Xilinx
+IP cores). The source synthesizes directly in Quartus 17+ (as used by MiSTer)
+without requiring VHDL-2008 support. Porting requires XDC-to-SDC constraint
+conversion and minor DSP inference adjustments.
 
 **MiSTer note:** The DE10-Nano's Cyclone V SE has 41,910 ALMs (each ALM roughly
 maps to 2 Xilinx LUTs, giving ~84K LUT-equivalent). The full FPU (~63K LUTs /

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MC68881 FPGA Core
 
 ## Overview
-A VHDL-2008 implementation of a Motorola MC68881-compatible floating-point
+A VHDL implementation of a Motorola MC68881-compatible floating-point
 coprocessor targeting Xilinx 7-series and UltraScale+ FPGAs. The design implements
 the full MC68881 instruction set including all arithmetic, transcendental,
 program-control, system-control, and packed-decimal operations. It uses

--- a/agents.md
+++ b/agents.md
@@ -1,7 +1,7 @@
 # agents.md
 
 ## Repository overview
-- MC68881-compatible FPU core targeting VHDL-2008 and Xilinx Artix-7.
+- MC68881-compatible FPU core in VHDL-93 targeting Xilinx Artix-7 and Intel Cyclone V (MiSTer).
 - Sources live in `src/` with testbenches under `tb/`.
 
 ## Development notes
@@ -30,7 +30,8 @@
   cross-reference (`target/m68k/fpu_helper.c`, `fpu_rom[128]`) and keep
   `docs/fmovecr_qemu_summary.md` in sync when constants or expectations change.
 - Add or extend testbench coverage in `tb/` for any new RTL behavior.
-- Maintain VHDL-2008 compatibility and avoid vendor-specific primitives.
+- Maintain VHDL-93 compatibility in RTL (for Quartus 17/MiSTer portability) and avoid vendor-specific primitives.
+  Testbenches may use VHDL-2008.
 - Follow Vivado/VRFC parameter mode rules in VHDL subprograms: never read an `out`
   parameter and never write to an `in` parameter (use local variables or `buffer`/`inout`
   only when semantically required).

--- a/scripts/check_vhdl93.sh
+++ b/scripts/check_vhdl93.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Verify all RTL sources compile under strict VHDL-93.
+# Testbenches are excluded — they may use VHDL-2008.
+# Usage: bash scripts/check_vhdl93.sh
+
+GHDL_EXE="${GHDL_EXE:-ghdl}"
+
+echo "Checking RTL VHDL-93 compatibility..."
+"$GHDL_EXE" -a --std=93 -fsynopsys -fexplicit -C \
+  src/mc68881_pkg.vhd \
+  src/mc68881_fp80_mul_unit.vhd \
+  src/mc68881_fp80_addsub_unit.vhd \
+  src/mc68881_modrem_post_unit.vhd \
+  src/mc68881_divrem_unit.vhd \
+  src/mc68881_trig_unit.vhd \
+  src/mc68881_sgl_ops_unit.vhd \
+  src/mc68881_alu.vhd \
+  src/mc68881_packed_decimal_unit.vhd \
+  src/mc68881_top.vhd
+
+if [ $? -eq 0 ]; then
+  echo "PASS: All RTL sources are VHDL-93 compatible."
+else
+  echo "FAIL: VHDL-93 errors found."
+  exit 1
+fi

--- a/scripts/check_vhdl93.sh
+++ b/scripts/check_vhdl93.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Verify all RTL sources compile under strict VHDL-93.
+# Verify all RTL sources compile under VHDL-93 (-fsynopsys -fexplicit).
 # Testbenches are excluded — they may use VHDL-2008.
 # Usage: bash scripts/check_vhdl93.sh
 

--- a/scripts/run_impl_lite.tcl
+++ b/scripts/run_impl_lite.tcl
@@ -1,0 +1,84 @@
+# Non-incremental synthesis + implementation for MC68881 FPGA (lite mode)
+# Run via: vivado -mode batch -source scripts/run_impl_lite.tcl
+
+set project_path "C:/code/68881-fpga/project/fpga68881/fpga68881.xpr"
+set report_dir "C:/code/68881-fpga/reports/lite"
+file mkdir $report_dir
+
+# Use more threads for synthesis/implementation
+set_param general.maxThreads 8
+
+puts "=== Opening project ==="
+open_project $project_path
+
+# Set fpu_lite_g generic to true
+puts "=== Setting fpu_lite_g => true ==="
+set_property generic {fpu_lite_g=true} [current_fileset]
+
+# Force non-incremental synthesis
+puts "=== Configuring non-incremental synthesis ==="
+set_property AUTO_INCREMENTAL_CHECKPOINT 0 [get_runs synth_1]
+set_property INCREMENTAL_CHECKPOINT "" [get_runs synth_1]
+
+# Configure implementation for timing closure on near-miss routed runs.
+puts "=== Configuring implementation run settings ==="
+set impl_run [get_runs impl_1]
+set_property STEPS.ROUTE_DESIGN.ARGS.DIRECTIVE AggressiveExplore $impl_run
+set_property STEPS.POST_ROUTE_PHYS_OPT_DESIGN.IS_ENABLED 1 $impl_run
+set_property STEPS.POST_ROUTE_PHYS_OPT_DESIGN.ARGS.DIRECTIVE AggressiveExplore $impl_run
+
+# Reset both runs
+puts "=== Resetting runs ==="
+reset_run synth_1
+reset_run impl_1
+
+# Launch synthesis
+puts "=== Launching synthesis (lite mode) ==="
+launch_runs synth_1
+wait_on_run synth_1
+set synth_status [get_property STATUS [get_runs synth_1]]
+puts "Synthesis status: $synth_status"
+if {[string match "*ERROR*" $synth_status]} {
+    puts "ERROR: Synthesis failed"
+    exit 1
+}
+
+# Generate post-synth utilization report
+open_run synth_1
+report_utilization -file "$report_dir/post_synth_util.rpt"
+report_utilization -hierarchical -hierarchical_depth 10 -file "$report_dir/post_synth_util_hier.rpt"
+close_design
+
+# Launch implementation
+puts "=== Launching implementation ==="
+launch_runs impl_1
+wait_on_run impl_1
+set impl_status [get_property STATUS [get_runs impl_1]]
+puts "Implementation status: $impl_status"
+if {[string match "*ERROR*" $impl_status]} {
+    puts "ERROR: Implementation failed"
+    exit 1
+}
+
+# Generate post-impl reports
+puts "=== Generating reports ==="
+open_run impl_1
+report_utilization -file "$report_dir/post_impl_util.rpt"
+report_utilization -hierarchical -hierarchical_depth 10 -file "$report_dir/post_impl_util_hier.rpt"
+report_timing_summary -max_paths 10 -file "$report_dir/timing_summary.rpt"
+report_timing -max_paths 20 -sort_by slack -file "$report_dir/timing_paths.rpt"
+report_exceptions -coverage -file "$report_dir/exceptions_coverage.rpt"
+report_power -file "$report_dir/power.rpt"
+report_drc -file "$report_dir/drc.rpt"
+report_methodology -file "$report_dir/methodology.rpt"
+report_clock_utilization -file "$report_dir/clock_util.rpt"
+report_route_status -file "$report_dir/route_status.rpt"
+close_design
+
+# Restore generic to default (full mode) so project isn't left in lite state
+puts "=== Restoring fpu_lite_g => false ==="
+set_property generic {fpu_lite_g=false} [current_fileset]
+
+puts "=== Done (lite mode) ==="
+puts "Reports written to: $report_dir/"
+exit 0

--- a/src/mc68881_alu.vhd
+++ b/src/mc68881_alu.vhd
@@ -747,7 +747,11 @@ begin
                         & alu_fp_seq_pending_reg
                         & alu_fp_is_mul_reg
                         & (x"00000" & '0');  -- 21-bit padding (alu_fp_subtract is boolean, encode as bit)
-        shadow_regs(1)(20) <= '1' when alu_fp_subtract_reg else '0';
+        if alu_fp_subtract_reg then
+          shadow_regs(1)(20) <= '1';
+        else
+          shadow_regs(1)(20) <= '0';
+        end if;
         -- Word 2: simple_op (16b) | simple_rm (8b) | simple_rp (8b)
         shadow_regs(2) <= std_logic_vector(to_unsigned(fpu_op_t'pos(simple_op_reg), 16))
                         & std_logic_vector(to_unsigned(fp_round_mode_t'pos(simple_rm_reg), 8))

--- a/src/mc68881_divrem_unit.vhd
+++ b/src/mc68881_divrem_unit.vhd
@@ -824,7 +824,7 @@ begin
             if lead_idx > FP_MANT_EXT_WIDTH then
               -- OR-prefix scan: single dynamic mux instead of N comparators
               quot_or_prefix(0) := quot_reg(0);
-              for i in 1 to quot_reg'length-1 loop
+              for i in 1 to quot_reg'high loop
                 quot_or_prefix(i) := quot_or_prefix(i-1) or quot_reg(i);
               end loop;
               if quot_or_prefix(lead_idx - FP_MANT_EXT_WIDTH - 1) = '1' then

--- a/src/mc68881_pkg.vhd
+++ b/src/mc68881_pkg.vhd
@@ -1591,7 +1591,7 @@ package body mc68881_pkg is
     -- OR-prefix scan: or_prefix(i) = value(0) | ... | value(i)
     -- Then sticky = or_prefix(shift-1) via single dynamic mux
     or_prefix(0) := value(0);
-    for i in 1 to value'length-1 loop
+    for i in 1 to value'high loop
       or_prefix(i) := or_prefix(i-1) or value(i);
     end loop;
     sticky := or_prefix(shift - 1);
@@ -1613,7 +1613,7 @@ package body mc68881_pkg is
     variable exp_var : unsigned(exp_in'range) := exp_in;
   begin
     -- Bound the iteration count for synthesis convergence.
-    for i in 0 to value'length-1 loop
+    for i in 0 to value'high loop
       exit when not (result(result'left) = '0' and exp_var /= 0 and result /= 0);
       result := result(result'left-1 downto 0) & '0';
       exp_var := exp_var - 1;
@@ -2217,7 +2217,7 @@ package body mc68881_pkg is
     variable a_abs : fp80_t := abs_fp80(a);
     variable b_abs : fp80_t := abs_fp80(b);
   begin
-    if a_abs = (a_abs'range => '0') and b_abs = (b_abs'range => '0') then
+    if a_abs = FP80_ZERO and b_abs = FP80_ZERO then
       return 0;
     end if;
 

--- a/src/mc68881_top.vhd
+++ b/src/mc68881_top.vhd
@@ -95,35 +95,35 @@ architecture rtl of mc68881_top is
   signal addr      : unsigned(4 downto 0);
 
   -- Memory-mapped register offsets used by host-side command/data protocol.
-  constant ADDR_OPSEL  : unsigned(4 downto 0) := to_unsigned(0, 5);
-  constant ADDR_OPA_L  : unsigned(4 downto 0) := to_unsigned(1, 5);
-  constant ADDR_OPA_H  : unsigned(4 downto 0) := to_unsigned(2, 5);
-  constant ADDR_OPA_E  : unsigned(4 downto 0) := to_unsigned(3, 5);
-  constant ADDR_OPB_L  : unsigned(4 downto 0) := to_unsigned(4, 5);
-  constant ADDR_OPB_H  : unsigned(4 downto 0) := to_unsigned(5, 5);
-  constant ADDR_OPB_E  : unsigned(4 downto 0) := to_unsigned(6, 5);
-  constant ADDR_RES_L  : unsigned(4 downto 0) := to_unsigned(7, 5);
-  constant ADDR_RES_H  : unsigned(4 downto 0) := to_unsigned(8, 5);
-  constant ADDR_RES_E  : unsigned(4 downto 0) := to_unsigned(9, 5);
-  constant ADDR_STATUS : unsigned(4 downto 0) := to_unsigned(10, 5);
-  constant ADDR_FPCR   : unsigned(4 downto 0) := to_unsigned(11, 5);
-  constant ADDR_CIR_SAVE    : unsigned(4 downto 0) := to_unsigned(12, 5);
-  constant ADDR_CIR_RESPONSE: unsigned(4 downto 0) := to_unsigned(13, 5);
-  constant ADDR_FPSR   : unsigned(4 downto 0) := to_unsigned(14, 5);
-  constant ADDR_CYCLE_CFG0 : unsigned(4 downto 0) := to_unsigned(15, 5);
-  constant ADDR_CYCLE_CFG1 : unsigned(4 downto 0) := to_unsigned(16, 5);
-  constant ADDR_FRAME_CMD  : unsigned(4 downto 0) := to_unsigned(17, 5);
-  constant ADDR_FRAME_W0   : unsigned(4 downto 0) := to_unsigned(18, 5);
-  constant ADDR_FRAME_W1   : unsigned(4 downto 0) := to_unsigned(19, 5);
-  constant ADDR_FRAME_W2   : unsigned(4 downto 0) := to_unsigned(20, 5);
-  constant ADDR_FRAME_W3   : unsigned(4 downto 0) := to_unsigned(21, 5);
-  constant ADDR_CYCLE_TOTAL: unsigned(4 downto 0) := to_unsigned(22, 5);
-  constant ADDR_MOVE_CFG   : unsigned(4 downto 0) := to_unsigned(23, 5);
-  constant ADDR_FPIAR      : unsigned(4 downto 0) := to_unsigned(24, 5);
-  constant ADDR_AUX_RES_L  : unsigned(4 downto 0) := to_unsigned(25, 5);
-  constant ADDR_AUX_RES_H  : unsigned(4 downto 0) := to_unsigned(26, 5);
-  constant ADDR_AUX_RES_E  : unsigned(4 downto 0) := to_unsigned(27, 5);
-  constant ADDR_CIR_RESTORE : unsigned(4 downto 0) := to_unsigned(28, 5);
+  constant ADDR_OPSEL  : unsigned(4 downto 0) := "00000";  -- 0
+  constant ADDR_OPA_L  : unsigned(4 downto 0) := "00001";  -- 1
+  constant ADDR_OPA_H  : unsigned(4 downto 0) := "00010";  -- 2
+  constant ADDR_OPA_E  : unsigned(4 downto 0) := "00011";  -- 3
+  constant ADDR_OPB_L  : unsigned(4 downto 0) := "00100";  -- 4
+  constant ADDR_OPB_H  : unsigned(4 downto 0) := "00101";  -- 5
+  constant ADDR_OPB_E  : unsigned(4 downto 0) := "00110";  -- 6
+  constant ADDR_RES_L  : unsigned(4 downto 0) := "00111";  -- 7
+  constant ADDR_RES_H  : unsigned(4 downto 0) := "01000";  -- 8
+  constant ADDR_RES_E  : unsigned(4 downto 0) := "01001";  -- 9
+  constant ADDR_STATUS : unsigned(4 downto 0) := "01010";  -- 10
+  constant ADDR_FPCR   : unsigned(4 downto 0) := "01011";  -- 11
+  constant ADDR_CIR_SAVE    : unsigned(4 downto 0) := "01100";  -- 12
+  constant ADDR_CIR_RESPONSE: unsigned(4 downto 0) := "01101";  -- 13
+  constant ADDR_FPSR   : unsigned(4 downto 0) := "01110";  -- 14
+  constant ADDR_CYCLE_CFG0 : unsigned(4 downto 0) := "01111";  -- 15
+  constant ADDR_CYCLE_CFG1 : unsigned(4 downto 0) := "10000";  -- 16
+  constant ADDR_FRAME_CMD  : unsigned(4 downto 0) := "10001";  -- 17
+  constant ADDR_FRAME_W0   : unsigned(4 downto 0) := "10010";  -- 18
+  constant ADDR_FRAME_W1   : unsigned(4 downto 0) := "10011";  -- 19
+  constant ADDR_FRAME_W2   : unsigned(4 downto 0) := "10100";  -- 20
+  constant ADDR_FRAME_W3   : unsigned(4 downto 0) := "10101";  -- 21
+  constant ADDR_CYCLE_TOTAL: unsigned(4 downto 0) := "10110";  -- 22
+  constant ADDR_MOVE_CFG   : unsigned(4 downto 0) := "10111";  -- 23
+  constant ADDR_FPIAR      : unsigned(4 downto 0) := "11000";  -- 24
+  constant ADDR_AUX_RES_L  : unsigned(4 downto 0) := "11001";  -- 25
+  constant ADDR_AUX_RES_H  : unsigned(4 downto 0) := "11010";  -- 26
+  constant ADDR_AUX_RES_E  : unsigned(4 downto 0) := "11011";  -- 27
+  constant ADDR_CIR_RESTORE : unsigned(4 downto 0) := "11100";  -- 28
 
   type dsack_state_t is (DSACK_IDLE, DSACK_WAIT_ASSERT, DSACK_ASSERTED);
   signal dsack_state  : dsack_state_t := DSACK_IDLE;

--- a/src/mc68881_trig_unit.vhd
+++ b/src/mc68881_trig_unit.vhd
@@ -901,7 +901,7 @@ architecture rtl of mc68881_trig_unit is
   begin
     res(FP_WIDTH-2 downto FP_WIDTH-1-FP_EXP_WIDTH) := (others => '1');
     res(FP_MANT_WIDTH-1) := '1';
-    if res(FP_MANT_WIDTH-2 downto 0) = (res(FP_MANT_WIDTH-2 downto 0)'range => '0') then
+    if unsigned(res(FP_MANT_WIDTH-2 downto 0)) = 0 then
       -- FPCP-created NaN: all mantissa bits set per datasheet.
       res(FP_MANT_WIDTH-2 downto 0) := (others => '1');
     end if;


### PR DESCRIPTION
## Summary
- Make all RTL source files VHDL-93 compatible for direct synthesis in Quartus 17+ (MiSTer DE10-Nano)
- Verified with `ghdl --std=93` across all 10 source files — zero errors
- Vivado non-incremental synthesis + implementation confirms no regressions

### VHDL-93 fixes across 5 source files:
- `mc68881_pkg.vhd`: `(a_abs'range => '0')` → `FP80_ZERO`; `value'length-1` → `value'high` (×2)
- `mc68881_divrem_unit.vhd`: `quot_reg'length-1` → `quot_reg'high`
- `mc68881_alu.vhd`: conditional signal assignment in process → `if/else`
- `mc68881_trig_unit.vhd`: `'range` aggregate → `unsigned() = 0`
- `mc68881_top.vhd`: 29 `ADDR_*` constants from `to_unsigned()` → binary literals (locally-static case choices)

### Synthesis results (Vivado 2025.2, xc7a200t, 33 MHz)

| Metric | Full | Lite |
|--------|------|------|
| Placed LUTs | 62,281 | 37,380 |
| Registers | 13,655 | 7,030 |
| BRAM | 8 | 0 |
| DSPs | 34 | 18 |
| WNS | +0.129ns | +0.160ns |

### Other changes
- README updated with verified full/lite resource tables and timing
- `agents.md` updated: VHDL-2008 → VHDL-93 policy
- Added `scripts/run_impl_lite.tcl` for lite-mode synthesis

## Test plan
- [x] GHDL `--std=93` compilation of all RTL sources
- [x] Full test suite (349 tests) — no regressions
- [x] Vivado non-incremental synth+impl — full mode (timing met)
- [x] Vivado non-incremental synth+impl — lite mode (timing met)
- [ ] Optional: Quartus 17 synthesis on Cyclone V

🤖 Generated with [Claude Code](https://claude.com/claude-code)